### PR TITLE
Support for passing client_secret in the request-body.

### DIFF
--- a/lib/middlewares/find_client_id.js
+++ b/lib/middlewares/find_client_id.js
@@ -27,6 +27,10 @@ module.exports = function * findClientId(next) {
     this.oidc.authorization.clientSecret = basic.slice(i + 1);
   } else if (this.oidc.params.client_id && !this.oidc.params.client_assertion) {
     this.oidc.authorization.clientId = this.oidc.params.client_id;
+
+    if(this.oidc.params.client_secret) {
+      this.oidc.authorization.clientSecret = this.oidc.params.client_secret;
+    }
   } else if (this.oidc.params.client_assertion) {
     let assertionSub;
 


### PR DESCRIPTION
 Pages 15 & 16: https://tools.ietf.org/html/rfc6749

Alternatively, the authorization server MAY support including the
   client credentials in the request-body using the following
   parameters:

   client_id
         REQUIRED.  The client identifier issued to the client during
         the registration process described by Section 2.2.

   client_secret
         REQUIRED.  The client secret.  The client MAY omit the
         parameter if the client secret is an empty string.

 Including the client credentials in the request-body using the two
   parameters is NOT RECOMMENDED and SHOULD be limited to clients unable
   to directly utilize the HTTP Basic authentication scheme (or other
   password-based HTTP authentication schemes).  The parameters can only
   be transmitted in the request-body and MUST NOT be included in the
   request URI.

   For example, a request to refresh an access token (Section 6) using
   the body parameters (with extra line breaks for display purposes
   only):

     POST /token HTTP/1.1
     Host: server.example.com
     Content-Type: application/x-www-form-urlencoded

     grant_type=refresh_token&refresh_token=tGzv3JOkF0XG5Qx2TlKWIA
     &client_id=s6BhdRkqt3&client_secret=7Fjfp0ZBr1KtDRbnfVdmIw