### PR TITLE
acr claim behavior fix

### DIFF
--- a/example/my_adapter.js
+++ b/example/my_adapter.js
@@ -57,7 +57,6 @@ class MyAdapter {
      * - account {string} the session account identifier
      * - authorizations {object} object with session authorized clients and their session identifiers
      * - loginTs {number} timestamp of user's authentication
-     * - acrValue {string} the ACR value of user's authentication
      *
      */
   }

--- a/lib/actions/authorization/interactions.js
+++ b/lib/actions/authorization/interactions.js
@@ -77,8 +77,8 @@ module.exports = (provider) => {
       // are met
       () => {
         const request = _.get(ctx.claims, 'id_token.acr', {});
-        if (request.essential && request.values) {
-          if (request.values.indexOf(ctx.session.acr()) === -1) {
+        if (request && request.essential && request.values) {
+          if (request.values.indexOf(ctx.acr) === -1) {
             return {
               error: 'login_required',
               error_description: 'none of the requested ACRs could not be obtained',
@@ -93,8 +93,8 @@ module.exports = (provider) => {
       // single requested authentication context class reference is not met
       () => {
         const request = _.get(ctx.claims, 'id_token.acr', {});
-        if (request.essential && request.value) {
-          if (request.value !== ctx.session.acr()) {
+        if (request && request.essential && request.value) {
+          if (request.value !== ctx.acr) {
             return {
               error: 'login_required',
               error_description: 'requested ACR could not be obtained',

--- a/lib/actions/authorization/process_response_types.js
+++ b/lib/actions/authorization/process_response_types.js
@@ -29,7 +29,7 @@ module.exports = (provider) => {
   function* codeHandler() {
     const ac = new AuthorizationCode({
       accountId: this.oidc.session.accountId(),
-      acr: this.oidc.session.acr(this.oidc.uuid),
+      acr: this.oidc.acr,
       authTime: this.oidc.session.authTime(),
       claims: this.oidc.claims,
       clientId: this.oidc.client.clientId,
@@ -51,7 +51,7 @@ module.exports = (provider) => {
   function idTokenHandler() {
     const token = new IdToken(
       Object.assign({}, this.oidc.account.claims(), {
-        acr: this.oidc.session.acr(this.oidc.uuid),
+        acr: this.oidc.acr,
         auth_time: this.oidc.session.authTime(),
       }), this.oidc.client.sectorIdentifier);
 

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -185,12 +185,10 @@ module.exports = {
   /*
    * ttl
    *
-   * description: expirations (in seconds) for all token types and Authentication Context Class
-   *   Reference
-   * affects: tokens and ID Token acr values
+   * description: expirations (in seconds) for all token types
+   * affects: tokens
    */
   ttl: {
-    acr: 5 * 60, // 5 minutes in seconds
     AccessToken: 2 * 60 * 60, // 2 hours in seconds
     AuthorizationCode: 10 * 60, // 10 minutes in seconds
     ClientCredentials: 10 * 60, // 10 minutes in seconds

--- a/lib/helpers/oidc_context.js
+++ b/lib/helpers/oidc_context.js
@@ -5,9 +5,11 @@ const url = require('url');
 const uuid = require('uuid');
 
 const errors = require('./errors');
+const providerInstance = require('../helpers/weak_cache');
 
 module.exports = function getContext(provider) {
   const map = new WeakMap();
+  const acrValues = providerInstance(provider).configuration('acrValues');
 
   function instance(ctx) {
     if (!map.has(ctx)) map.set(ctx, { claims: {} });
@@ -38,6 +40,10 @@ module.exports = function getContext(provider) {
 
       const should = _.difference(this.prompts, _.keys(this.result));
       return should.indexOf(name) !== -1;
+    }
+
+    get acr() {
+      return _.get(this, 'result.login.acr', acrValues[0]);
     }
 
     set params(value) { Object.defineProperty(this, 'params', { enumerable: true, value }); }

--- a/lib/models/session.js
+++ b/lib/models/session.js
@@ -27,15 +27,6 @@ module.exports = function getSession(provider) {
       return this.loginTs;
     }
 
-    acr() {
-      const conf = instance(provider).configuration();
-      if (epochTime() - this.authTime() < conf.ttl.acr) {
-        return _.get(this, 'acrValue', conf.acrValues[0]);
-      }
-
-      return conf.acrValues[0];
-    }
-
     past(age) {
       const maxAge = +age;
 

--- a/lib/shared/resume.js
+++ b/lib/shared/resume.js
@@ -35,7 +35,6 @@ module.exports = function getResumeAction(provider) {
         delete this.oidc.session.authorizations;
       }
 
-      this.oidc.session.acrValue = result.login.acr;
       this.oidc.session.account = result.login.account;
       this.oidc.session.loginTs = result.login.ts;
     }


### PR DESCRIPTION
- only the authentication request ACR was negotiated for should have
  higher than the fallback value
- requesting acr claim via null value no longer throws server_error