### PR TITLE
Whitelist extra parameters for authentication

### DIFF
--- a/lib/actions/authorization.js
+++ b/lib/actions/authorization.js
@@ -6,14 +6,21 @@ const bodyParser = require('../shared/conditional_body');
 const rejectDupes = require('../shared/check_dupes');
 const paramsMiddleware = require('../shared/get_params');
 
+const instance = require('../helpers/weak_cache');
+
 const PARAM_LIST = require('../consts').PARAM_LIST;
 
 const stack = require('./authorization/');
 
 const parseBody = bodyParser('application/x-www-form-urlencoded');
-const getParams = paramsMiddleware(PARAM_LIST);
 
 module.exports = function authorizationAction(provider) {
+  const whitelist = new Set(PARAM_LIST);
+  const extras = instance(provider).configuration('extraParams');
+  extras.forEach(whitelist.add.bind(whitelist));
+
+  const getParams = paramsMiddleware(whitelist);
+
   return compose([
     parseBody,
     getParams,

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -70,6 +70,17 @@ module.exports = {
 
 
   /*
+   * extraParams
+   *
+   * description: pass an iterable object (i.e. array or set) to extend the parameters recognized
+   *  by the authorization endpoint. These parameters are then available in ctx.oidc.params as well
+   *  as passed via the _grant cookie to interaction
+   * affects: authorization, interaction
+   */
+  extraParams: [],
+
+
+  /*
    * features
    *
    * description: enable/disable feature 'packs', see configuration.md for more details


### PR DESCRIPTION
Using new configuration option an extra set of parameters will get
recognized by the authentication endpoint, these parameters will be
included in ctx.oidc.params as well as in the _grant cookie that is
passed interaction. Resolves #37