### PR TITLE
Relaxes the redirect URI rules for native clients.

### DIFF
--- a/lib/helpers/client_schema.js
+++ b/lib/helpers/client_schema.js
@@ -426,14 +426,6 @@ module.exports = function getSchema(provider) {
             if (!validUrl.isUri(redirectUri)) {
               throw new errors.InvalidClientMetadata('redirect_uris must only contain valid uris');
             }
-            if (redirectUri.startsWith('https:')) {
-              throw new errors.InvalidClientMetadata(
-                'redirect_uris for native clients must not be using https URI scheme');
-            }
-            if (url.parse(redirectUri).hostname !== 'localhost') {
-              throw new errors.InvalidClientMetadata(
-                'redirect_uris for native clients must be using localhost as hostname');
-            }
             break;
         }
       });


### PR DESCRIPTION
- Native apps may use custom URI schemes like com.example.app:/
- Native apps may use loopback IP URI schemes http://127.0.0.1 in addition to localhost.
- Native apps may even use HTTP schemes these days due to Univeral Links (iOS) and AppLinks (Android).

Removing these rules will enable support for all redirect URI schemes documented in the OAuth 2.0 for Native Apps BCP: https://tools.ietf.org/html/draft-ietf-oauth-native-apps