### PR TITLE
OAuth 2.0 for Native Apps BCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The following drafts/experimental specifications are implemented by oidc-provide
 - [OpenID Connect Session Management 1.0 - draft 27][feature-session-management]
 - [OpenID Connect Back-Channel Logout 1.0 - draft 03][feature-backchannel-logout]
 - [RFC7592 - OAuth 2.0 Dynamic Client Registration Management Protocol (Update and Delete)][feature-registration-management]
-- [OAuth 2.0 for Native Apps - draft 06][feature-oauth-native-apps]
+- [OAuth 2.0 for Native Apps BCP - draft 06][feature-oauth-native-apps]
 
 Updates to drafts and experimental specification versions are released as MINOR library versions.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ your own unique-looking and functioning user flows.
 
 ## Implemented specs & features
 
-The following specifications are implemented by oidc-provider.
+The following specifications are implemented by oidc-provider. Note that not all features are
+enabled by default, check the configuration section on how to enable them.
 
 - [OpenID Connect Core 1.0 incorporating errata set 1][feature-core]
   - Authorization (Authorization Code Flow, Implicit Flow, Hybrid Flow)
@@ -49,6 +50,7 @@ The following drafts/experimental specifications are implemented by oidc-provide
 - [OpenID Connect Session Management 1.0 - draft 27][feature-session-management]
 - [OpenID Connect Back-Channel Logout 1.0 - draft 03][feature-backchannel-logout]
 - [RFC7592 - OAuth 2.0 Dynamic Client Registration Management Protocol (Update and Delete)][feature-registration-management]
+- [OAuth 2.0 for Native Apps - draft 06][feature-oauth-native-apps]
 
 Updates to drafts and experimental specification versions are released as MINOR library versions.
 
@@ -136,3 +138,4 @@ OP Config and OP Dynamic profiles of the OpenID Connect™ protocol.
 [openid-client]: https://github.com/panva/node-openid-client
 [feature-backchannel-logout]: http://openid.net/specs/openid-connect-backchannel-1_0-03.html
 [feature-registration-management]: https://tools.ietf.org/html/rfc7592
+[feature-oauth-native-apps]: https://tools.ietf.org/html/draft-ietf-oauth-native-apps-06

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ point to get an idea of what you should provide.
   - [Configuring available scopes](#configuring-available-scopes)
   - [Persistance](#persistance)
   - [Interaction](#interaction)
-  - [Enable/Disable optional OIDC features](#enabledisable-optional-oidc-features)
+  - [Enable/Disable optional oidc-provider features](#enabledisable-optional-oidc-provider-features)
   - [Custom Grant Types](#custom-grant-types)
   - [Extending Authorization with Custom Parameters](#extending-authorization-with-custom-parameters)
   - [Extending Discovery with Custom Properties](#extending-discovery-with-custom-properties)
@@ -198,7 +198,7 @@ endpoint, affixed by the uuid of the original request and the interaction result
 the provider instance that ties things together for you.
 
 
-## Enable/Disable optional OIDC features
+## Enable/Disable optional oidc-provider features
 
 There are many features defined in OIDC which are optional and can be omitted to keep your
 deployment compact. The feature flags with their default values are
@@ -218,6 +218,7 @@ deployment compact. The feature flags with their default values are
 | request | no |
 | requestUri | no |
 | revocation | no |
+| oauthNativeApps | no |
 | sessionManagement | no |
 
 **Development quick-start interactions**
@@ -323,6 +324,14 @@ is not sent. The use of this endpoint is covered by the same authz mechanism as 
 endpoint.
 ```js
 const configuration = { features: { revocation: Boolean[false] } };
+```
+
+
+**OAuth 2.0 Native Apps Best Current Practice**
+Changes `redirect_uris` validations for clients with application_type `native` to those described by
+[OAuth 2.0 for Native Apps][feature-oauth-native-apps].
+```js
+const configuration = { features: { oauthNativeApps: Boolean[false] } };
 ```
 
 
@@ -499,6 +508,7 @@ Supply an array of string values to acrValues configuration option to overwrite 
 [feature-registration-management]: https://tools.ietf.org/html/rfc7592
 [feature-registration]: http://openid.net/specs/openid-connect-registration-1_0.html
 [feature-revocation]: https://tools.ietf.org/html/rfc7009
+[feature-oauth-native-apps]: https://tools.ietf.org/html/draft-ietf-oauth-native-apps-06
 [feature-session-management]: http://openid.net/specs/openid-connect-session-1_0-27.html
 [got-library]: https://github.com/sindresorhus/got
 [password-grant]: https://tools.ietf.org/html/rfc6749#section-4.3

--- a/lib/helpers/client_schema.js
+++ b/lib/helpers/client_schema.js
@@ -426,13 +426,33 @@ module.exports = function getSchema(provider) {
             if (!validUrl.isUri(redirectUri)) {
               throw new errors.InvalidClientMetadata('redirect_uris must only contain valid uris');
             }
-            if (redirectUri.startsWith('https:')) {
-              throw new errors.InvalidClientMetadata(
-                'redirect_uris for native clients must not be using https URI scheme');
-            }
-            if (url.parse(redirectUri).hostname !== 'localhost') {
-              throw new errors.InvalidClientMetadata(
-                'redirect_uris for native clients must be using localhost as hostname');
+
+            if (instance(provider).configuration('features.oauthNativeApps')) {
+              const uri = url.parse(redirectUri);
+
+              switch (uri.protocol) {
+                case 'http:': // Loopback URI Redirection
+                  // TODO: hostname IN ['localhost', '127.0.0.1' or '[::1]'];
+                  break;
+                case 'https:': // App-claimed HTTPS URI Redirection
+                  // TODO: hostname NOT IN ['localhost', '127.0.0.1' or '[::1]'];
+                  break;
+                default: // App-declared Custom URI Scheme Redirection
+                  if (uri.hostname !== 'localhost') {
+                    throw new errors.InvalidClientMetadata(
+                      'redirect_uris for native clients using custom URI scheme must be using localhost as hostname');
+                  }
+              }
+            } else {
+              if (redirectUri.startsWith('https:')) {
+                throw new errors.InvalidClientMetadata(
+                  'redirect_uris for native clients must not be using https URI scheme');
+              }
+
+              if (url.parse(redirectUri).hostname !== 'localhost') {
+                throw new errors.InvalidClientMetadata(
+                  'redirect_uris for native clients must be using localhost as hostname');
+              }
             }
             break;
         }

--- a/lib/helpers/client_schema.js
+++ b/lib/helpers/client_schema.js
@@ -7,6 +7,10 @@ const errors = require('./errors');
 
 const instance = require('./weak_cache');
 
+function invalidate(message) {
+  throw new errors.InvalidClientMetadata(message);
+}
+
 const RECOGNIZED_METADATA = [
   'application_type',
   'backchannel_logout_uri',
@@ -143,6 +147,8 @@ const LENGTH = [
   'response_types',
 ];
 
+const LOOPBACKS = ['localhost', '127.0.0.1', '::1'];
+
 module.exports = function getSchema(provider) {
   const ENUM = {
     application_type: ['native', 'web'],
@@ -199,11 +205,12 @@ module.exports = function getSchema(provider) {
       this.booleans();
       this.webUris();
       this.redirectUris();
+      this.normalizeNativeAppUris();
 
         // MAX AGE FORMAT
       if (this.default_max_age !== undefined) {
         if (!Number.isInteger(this.default_max_age) || this.default_max_age <= 0) {
-          throw new errors.InvalidClientMetadata('default_max_age must be a positive integer');
+          invalidate('default_max_age must be a positive integer');
         }
       }
 
@@ -215,20 +222,17 @@ module.exports = function getSchema(provider) {
 
       if (this.token_endpoint_auth_method === 'none') {
         if (_.includes(this.grant_types, 'authorization_code')) {
-          throw new errors.InvalidClientMetadata(
-            'grant_types must not use token endpoint when token_endpoint_auth_method is none');
+          invalidate('grant_types must not use token endpoint when token_endpoint_auth_method is none');
         }
       }
 
       if (_.includes(rts, 'code') && !_.includes(this.grant_types, 'authorization_code')) {
-        throw new errors.InvalidClientMetadata(
-          'grant_types must contain authorization_code when code is amongst response_types');
+        invalidate('grant_types must contain authorization_code when code is amongst response_types');
       }
 
       if (_.includes(rts, 'token') || _.includes(rts, 'id_token')) {
         if (!_.includes(this.grant_types, 'implicit')) {
-          throw new errors.InvalidClientMetadata(
-            'grant_types must contain implicit when id_token or token are amongst response_types');
+          invalidate('grant_types must contain implicit when id_token or token are amongst response_types');
         }
       }
 
@@ -247,12 +251,12 @@ module.exports = function getSchema(provider) {
         ['private_key_jwt', 'none'].indexOf(this.token_endpoint_auth_method) === -1;
 
       if (validateSecretPresence && !this.client_secret) {
-        throw new errors.InvalidClientMetadata('client_secret is mandatory property');
+        invalidate('client_secret is mandatory property');
       }
 
       if (validateSecretLength) {
         if (this.client_secret.length < validateSecretLength) {
-          throw new errors.InvalidClientMetadata('insufficient client_secret length');
+          invalidate('insufficient client_secret length');
         }
       }
 
@@ -266,24 +270,22 @@ module.exports = function getSchema(provider) {
         if (hosts.length === 1) {
           this.sector_identifier = hosts[0];
         } else {
-          throw new errors.InvalidClientMetadata(
-            'sector_identifier_uri is required when using multiple hosts in your redirect_uris');
+          invalidate('sector_identifier_uri is required when using multiple hosts in your redirect_uris');
         }
       } else if (this.sector_identifier_uri) {
         this.sector_identifier = url.parse(this.sector_identifier_uri).host;
       }
 
       if (this.jwks !== undefined && this.jwks_uri !== undefined) {
-        throw new errors.InvalidClientMetadata(
-          'jwks and jwks_uri must not be used at the same time');
+        invalidate('jwks and jwks_uri must not be used at the same time');
       }
 
       if (this.jwks !== undefined) {
         if (!Array.isArray(this.jwks.keys)) {
-          throw new errors.InvalidClientMetadata('jwks must be a JWK Set');
+          invalidate('jwks must be a JWK Set');
         }
         if (!this.jwks.keys.length) {
-          throw new errors.InvalidClientMetadata('jwks.keys must not be empty');
+          invalidate('jwks.keys must not be empty');
         }
       }
     }
@@ -291,7 +293,7 @@ module.exports = function getSchema(provider) {
     required() {
       REQUIRED.forEach((prop) => {
         if (!this[prop]) {
-          throw new errors.InvalidClientMetadata(`${prop} is mandatory property`);
+          invalidate(`${prop} is mandatory property`);
         }
       });
 
@@ -301,7 +303,7 @@ module.exports = function getSchema(provider) {
         (String(this.userinfo_encrypted_response_alg).match(/^(RSA|ECDH)/));
 
       if (requireJwks && !this.jwks && !this.jwks_uri) {
-        throw new errors.InvalidClientMetadata('jwks or jwks_uri is mandatory for this client');
+        invalidate('jwks or jwks_uri is mandatory for this client');
       }
     }
 
@@ -311,9 +313,9 @@ module.exports = function getSchema(provider) {
           const isAry = ARYS.indexOf(prop) !== -1;
           (isAry ? this[prop] : [this[prop]]).forEach((val) => {
             if (typeof val !== 'string' || !val.length) {
-              throw new errors.InvalidClientMetadata(
-                isAry ? `${prop} must only contain strings` :
-                  `${prop} must be a non-empty string if provided`);
+              invalidate(isAry ?
+                `${prop} must only contain strings` :
+                `${prop} must be a non-empty string if provided`);
             }
           });
         }
@@ -328,8 +330,9 @@ module.exports = function getSchema(provider) {
             const method = HTTPS_URI.indexOf(prop) === -1 ? 'isWebUri' : 'isHttpsUri';
             const type = method === 'isWebUri' ? 'web' : 'https';
             if (!validUrl[method](val)) {
-              throw new errors.InvalidClientMetadata(
-                isAry ? `${prop} must only contain ${type} uris` : `${prop} must be a ${type} uri`);
+              invalidate(isAry ?
+                `${prop} must only contain ${type} uris` :
+                `${prop} must be a ${type} uri`);
             }
           });
         }
@@ -340,7 +343,7 @@ module.exports = function getSchema(provider) {
       ARYS.forEach((prop) => {
         if (this[prop] !== undefined) {
           if (!Array.isArray(this[prop])) {
-            throw new errors.InvalidClientMetadata(`${prop} must be an array`);
+            invalidate(`${prop} must be an array`);
           }
           this[prop] = _.uniq(this[prop]);
         }
@@ -353,7 +356,7 @@ module.exports = function getSchema(provider) {
       }
       LENGTH.forEach((prop) => {
         if (this[prop] !== undefined && !this[prop].length) {
-          throw new errors.InvalidClientMetadata(`${prop} must contain members`);
+          invalidate(`${prop} must contain members`);
         }
       });
     }
@@ -362,7 +365,7 @@ module.exports = function getSchema(provider) {
       BOOL.forEach((prop) => {
         if (this[prop] !== undefined) {
           if (typeof this[prop] !== 'boolean') {
-            throw new errors.InvalidClientMetadata(`${prop} must be a boolean`);
+            invalidate(`${prop} must be a boolean`);
           }
         }
       });
@@ -371,7 +374,7 @@ module.exports = function getSchema(provider) {
     whens() {
       _.forEach(WHEN, (then, when) => {
         if (this[when] !== undefined && this[then[0]] === undefined) {
-          throw new errors.InvalidClientMetadata(`${then[0]} is mandatory property`);
+          invalidate(`${then[0]} is mandatory property`);
         } else if (this[when] === undefined && this[then[0]] !== undefined) {
           this[when] = then[1];
         }
@@ -392,39 +395,53 @@ module.exports = function getSchema(provider) {
             }
             return only.indexOf(val) === -1;
           })) {
-            throw new errors.InvalidClientMetadata(`${prop} can only contain members [${only}]`);
+            invalidate(`${prop} can only contain members [${only}]`);
           } else if (!isAry && only.indexOf(this[prop]) === -1) {
-            throw new errors.InvalidClientMetadata(`${prop} must be one of [${only}]`);
+            invalidate(`${prop} must be one of [${only}]`);
           }
         }
+      });
+    }
+
+    normalizeNativeAppUris() {
+      if (this.application_type === 'web') return;
+      if (!instance(provider).configuration('features.oauthNativeApps')) return;
+
+      this.redirect_uris = _.map(this.redirect_uris, (redirectUri) => {
+        if (redirectUri.startsWith('http:')) { // this removes the port component, making dynamic ports allowed
+          return url.format(Object.assign(url.parse(redirectUri), {
+            host: null,
+            port: null,
+          }));
+        }
+
+        return redirectUri;
       });
     }
 
     redirectUris() {
       this.redirect_uris.forEach((redirectUri) => {
         if (redirectUri.indexOf('#') !== -1) {
-          throw new errors.InvalidClientMetadata('redirect_uris must not contain fragments');
+          invalidate('redirect_uris must not contain fragments');
         }
 
         switch (this.application_type) { // eslint-disable-line default-case
           case 'web':
             if (!validUrl.isWebUri(redirectUri)) {
-              throw new errors.InvalidClientMetadata('redirect_uris must only contain valid web uris');
+              invalidate('redirect_uris must only contain valid web uris');
             }
 
             if (this.grant_types.indexOf('implicit') !== -1 && redirectUri.startsWith('http:')) {
-              throw new errors.InvalidClientMetadata(
-                'redirect_uris for web clients using implicit flow MUST only register URLs using the https scheme');
+              invalidate('redirect_uris for web clients using implicit flow MUST only register URLs using the https scheme');
             }
 
             if (url.parse(redirectUri).hostname === 'localhost') {
-              throw new errors.InvalidClientMetadata(
-                'redirect_uris for web clients must not be using localhost');
+              invalidate('redirect_uris for web clients must not be using localhost');
             }
             break;
           case 'native':
             if (!validUrl.isUri(redirectUri)) {
-              throw new errors.InvalidClientMetadata('redirect_uris must only contain valid uris');
+              invalidate('redirect_uris must only contain valid uris');
             }
 
             if (instance(provider).configuration('features.oauthNativeApps')) {
@@ -432,26 +449,27 @@ module.exports = function getSchema(provider) {
 
               switch (uri.protocol) {
                 case 'http:': // Loopback URI Redirection
-                  // TODO: hostname IN ['localhost', '127.0.0.1' or '[::1]'];
+                  if (LOOPBACKS.indexOf(uri.hostname) === -1) {
+                    invalidate('redirect_uris for native clients using http as a protocol can only use loopback addresses as hostnames');
+                  }
                   break;
                 case 'https:': // App-claimed HTTPS URI Redirection
-                  // TODO: hostname NOT IN ['localhost', '127.0.0.1' or '[::1]'];
+                  if (LOOPBACKS.indexOf(uri.hostname) !== -1) {
+                    invalidate(`redirect_uris for native clients using claimed HTTPS URIs must not be using ${uri.hostname} as hostname`);
+                  }
                   break;
                 default: // App-declared Custom URI Scheme Redirection
                   if (uri.hostname !== 'localhost') {
-                    throw new errors.InvalidClientMetadata(
-                      'redirect_uris for native clients using custom URI scheme must be using localhost as hostname');
+                    invalidate('redirect_uris for native clients using custom URI scheme must be using localhost as hostname');
                   }
               }
             } else {
               if (redirectUri.startsWith('https:')) {
-                throw new errors.InvalidClientMetadata(
-                  'redirect_uris for native clients must not be using https URI scheme');
+                invalidate('redirect_uris for native clients must not be using https URI scheme');
               }
 
               if (url.parse(redirectUri).hostname !== 'localhost') {
-                throw new errors.InvalidClientMetadata(
-                  'redirect_uris for native clients must be using localhost as hostname');
+                invalidate('redirect_uris for native clients must be using localhost as hostname');
               }
             }
             break;

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -100,6 +100,7 @@ module.exports = {
     request: false,
     requestUri: false,
     revocation: false,
+    oauthNativeApps: false,
     sessionManagement: false,
   },
 

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -222,15 +222,23 @@ module.exports = function getClient(provider) {
       return this.grantTypes.indexOf(type) !== -1;
     }
 
-    redirectUriAllowed(uri) {
-      if (this.applicationType === 'native' &&
-        uri.startsWith('http:') &&
-        instance(provider).configuration('features.oauthNativeApps')
-      ) {
-        // TODO: ALLOW DYNAMIC PORTS
-      }
+    redirectUriAllowed(redirectUri) {
+      const checkedUri = (() => {
+        if (this.applicationType === 'native' &&
+          redirectUri.startsWith('http:') &&
+          instance(provider).configuration('features.oauthNativeApps')
+        ) {
+          return url.format(Object.assign(url.parse(redirectUri), {
+            host: null,
+            port: null,
+          }));
+        }
 
-      return this.redirectUris.indexOf(uri) !== -1;
+        return redirectUri;
+      })();
+
+
+      return this.redirectUris.indexOf(checkedUri) !== -1;
     }
 
     requestUriAllowed(uri) {

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -223,6 +223,13 @@ module.exports = function getClient(provider) {
     }
 
     redirectUriAllowed(uri) {
+      if (this.applicationType === 'native' &&
+        uri.startsWith('http:') &&
+        instance(provider).configuration('features.oauthNativeApps')
+      ) {
+        // TODO: ALLOW DYNAMIC PORTS
+      }
+
       return this.redirectUris.indexOf(uri) !== -1;
     }
 

--- a/test/oauth_native_apps/oauth_native_apps.config.js
+++ b/test/oauth_native_apps/oauth_native_apps.config.js
@@ -1,0 +1,10 @@
+'use strict';
+
+const _ = require('lodash');
+const config = _.clone(require('../default.config'));
+
+config.features = { oauthNativeApps: true };
+
+module.exports = {
+  config,
+};

--- a/test/oauth_native_apps/oauth_native_apps.test.js
+++ b/test/oauth_native_apps/oauth_native_apps.test.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const bootstrap = require('../test_helper');
+
+
+describe('OAuth 2.0 for Native Apps Best Current Practice features', function () {
+  before(bootstrap(__dirname)); // provider
+
+  describe('changed native client validations', function () {
+    describe('App-declared Custom URI Scheme Redirection', function () {
+      it('allows custom uri scheme uris with localhost');
+      it('rejects custom uri scheme uris if not using localhost');
+    });
+
+    describe('App-claimed HTTPS URI Redirection', function () {
+      it('allows claimed https uris');
+      it('rejects https if using loopback uris');
+    });
+
+    describe('Loopback URI Redirection', function () {
+      it('allows http protocol localhost loopback uris');
+      it('allows http protocol IPv4 loopback uris');
+      it('allows http protocol IPv6 loopback uris');
+      it('rejects http protocol uris not using loopback uris');
+    });
+  });
+
+  describe('authentication request validations', function () {
+    it('allows Loopback URI Redirection to provide a random port value');
+  });
+});

--- a/test/oauth_native_apps/oauth_native_apps.test.js
+++ b/test/oauth_native_apps/oauth_native_apps.test.js
@@ -1,31 +1,138 @@
 'use strict';
 
 const bootstrap = require('../test_helper');
+const { expect } = require('chai');
 
+const fail = () => {
+  throw new Error('expected promise to be rejected');
+};
 
 describe('OAuth 2.0 for Native Apps Best Current Practice features', function () {
   before(bootstrap(__dirname)); // provider
 
   describe('changed native client validations', function () {
     describe('App-declared Custom URI Scheme Redirection', function () {
-      it('allows custom uri scheme uris with localhost');
-      it('rejects custom uri scheme uris if not using localhost');
+      it('allows custom uri scheme uris with localhost', function () {
+        return i(this.provider).clientAdd({
+          application_type: 'native',
+          client_id: 'native-custom',
+          grant_types: ['implicit'],
+          response_types: ['id_token'],
+          token_endpoint_auth_method: 'none',
+          redirect_uris: ['com.example.app://localhost/op/callback', 'myapp://localhost/op/callback'],
+        });
+      });
+
+      it('rejects custom uri scheme uris if not using localhost', function () {
+        return i(this.provider).clientAdd({
+          application_type: 'native',
+          client_id: 'native-custom',
+          grant_types: ['implicit'],
+          response_types: ['id_token'],
+          token_endpoint_auth_method: 'none',
+          redirect_uris: ['com.example.app://foobar/op/callback'],
+        }).then(fail, (err) => {
+          expect(err).to.have.property('message', 'invalid_redirect_uri');
+          expect(err).to.have.property('error_description', 'redirect_uris for native clients using custom URI scheme must be using localhost as hostname');
+        });
+      });
     });
 
     describe('App-claimed HTTPS URI Redirection', function () {
-      it('allows claimed https uris');
-      it('rejects https if using loopback uris');
+      it('allows claimed https uris', function () {
+        return i(this.provider).clientAdd({
+          application_type: 'native',
+          client_id: 'native-custom',
+          grant_types: ['implicit'],
+          response_types: ['id_token'],
+          token_endpoint_auth_method: 'none',
+          redirect_uris: ['https://claimed.example.com/op/callback'],
+        });
+      });
+
+      it('rejects https if using loopback uris', function () {
+        return i(this.provider).clientAdd({
+          application_type: 'native',
+          client_id: 'native-custom',
+          grant_types: ['implicit'],
+          response_types: ['id_token'],
+          token_endpoint_auth_method: 'none',
+          redirect_uris: ['https://localhost/op/callback'],
+        }).then(fail, (err) => {
+          expect(err).to.have.property('message', 'invalid_redirect_uri');
+          expect(err).to.have.property('error_description', 'redirect_uris for native clients using claimed HTTPS URIs must not be using localhost as hostname');
+        });
+      });
     });
 
     describe('Loopback URI Redirection', function () {
-      it('allows http protocol localhost loopback uris');
-      it('allows http protocol IPv4 loopback uris');
-      it('allows http protocol IPv6 loopback uris');
-      it('rejects http protocol uris not using loopback uris');
-    });
-  });
+      it('allows http protocol localhost loopback uris', function () {
+        return i(this.provider).clientAdd({
+          application_type: 'native',
+          client_id: 'native-custom',
+          grant_types: ['implicit'],
+          response_types: ['id_token'],
+          token_endpoint_auth_method: 'none',
+          redirect_uris: ['http://localhost:2355/op/callback'],
+        }).then((client) => {
+          expect(client.redirectUris).to.contain('http://localhost/op/callback');
+          expect(client.redirectUriAllowed('http://localhost/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://localhost:80/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://localhost:443/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://localhost:2355/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://localhost:8888/op/callback')).to.be.true;
+        });
+      });
 
-  describe('authentication request validations', function () {
-    it('allows Loopback URI Redirection to provide a random port value');
+      it('allows http protocol IPv4 loopback uris', function () {
+        return i(this.provider).clientAdd({
+          application_type: 'native',
+          client_id: 'native-custom',
+          grant_types: ['implicit'],
+          response_types: ['id_token'],
+          token_endpoint_auth_method: 'none',
+          redirect_uris: ['http://127.0.0.1:2355/op/callback'],
+        }).then((client) => {
+          expect(client.redirectUris).to.contain('http://127.0.0.1/op/callback');
+          expect(client.redirectUriAllowed('http://127.0.0.1/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://127.0.0.1:80/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://127.0.0.1:443/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://127.0.0.1:2355/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://127.0.0.1:8888/op/callback')).to.be.true;
+        });
+      });
+
+      it('allows http protocol IPv6 loopback uris', function () {
+        return i(this.provider).clientAdd({
+          application_type: 'native',
+          client_id: 'native-custom',
+          grant_types: ['implicit'],
+          response_types: ['id_token'],
+          token_endpoint_auth_method: 'none',
+          redirect_uris: ['http://[::1]:2355/op/callback'],
+        }).then((client) => {
+          expect(client.redirectUris).to.contain('http://[::1]/op/callback');
+          expect(client.redirectUriAllowed('http://[::1]/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://[::1]:80/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://[::1]:443/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://[::1]:2355/op/callback')).to.be.true;
+          expect(client.redirectUriAllowed('http://[::1]:8888/op/callback')).to.be.true;
+        });
+      });
+
+      it('rejects http protocol uris not using loopback uris', function () {
+        return i(this.provider).clientAdd({
+          application_type: 'native',
+          client_id: 'native-custom',
+          grant_types: ['implicit'],
+          response_types: ['id_token'],
+          token_endpoint_auth_method: 'none',
+          redirect_uris: ['http://rp.example.com/op/callback'],
+        }).then(fail, (err) => {
+          expect(err).to.have.property('message', 'invalid_redirect_uri');
+          expect(err).to.have.property('error_description', 'redirect_uris for native clients using http as a protocol can only use loopback addresses as hostnames');
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
A non-breaking feature flag implementing native client redirect uri validations to conform with three redirect_uri options defined in https://tools.ietf.org/html/draft-ietf-oauth-native-apps-06

Closes #46 

The way I interpret the spec, in regards to what the OP should handle.

I don't believe it's intended to be able to combine the three redirect URI options, i.e. custom uri scheme, with any hostname and dynamic ports. So, when the feature flag is provided and application_type is native the following presets should be possible:

* App-declared Custom URI Scheme Redirection
any non http/https uri scheme, with localhost as hostname and no dynamic ports

* App-claimed HTTPS URI Redirection
https with any valid (non loopback) hostname and no dynamic ports

* Loopback URI Redirection
http protocol with localhost, 127.0.0.1 or [::1] hostnames and dynamic port

And that boils down to:
- when custom scheme is given, localhost must still be used, no dynamic ports
- when https uri is given, any non loopback hostname can be used, no dynamic ports
- when http is used, any of the loopbacks must be used, and dynamic ports are allowed