### PR TITLE
enable metadata passing in the 'result' object stored alongside the authorization sid

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -256,6 +256,13 @@ router.post('/interaction/:grant', async (ctx, next) => {
     // include it use when i.e. offline_access was not given, or user declined to provide address
     scope: 'space separated list of scopes',
   },
+  
+  // meta is a free object you may store alongside an authorization. It can be useful
+  // during the interactionCheck to verify information on the ongoing session.
+  meta: {
+    // object structure up-to-you
+  },
+
   ['custom prompt name resolved']: {},
 }
 ```

--- a/lib/models/session.js
+++ b/lib/models/session.js
@@ -11,6 +11,16 @@ module.exports = function getSession(provider) {
     return adapter;
   }
 
+  function authorizationFor(clientId) {
+    this.authorizations = this.authorizations || {};
+    const key = String(clientId);
+    if (!this.authorizations[key]) {
+      this.authorizations[key] = {};
+    }
+
+    return this.authorizations[key];
+  }
+
   class Session {
     constructor(id, data) {
       if (data) Object.assign(this, data);
@@ -47,15 +57,25 @@ module.exports = function getSession(provider) {
     }
 
     sidFor(clientId, value) {
-      this.authorizations = this.authorizations || {};
-      const key = String(clientId);
+      const authorization = authorizationFor.call(this, clientId);
+
       if (value) {
-        if (!this.authorizations[key]) this.authorizations[key] = {};
-        this.authorizations[key].sid = value;
+        authorization.sid = value;
         return undefined;
       }
 
-      return this.authorizations[key] && this.authorizations[key].sid;
+      return authorization.sid;
+    }
+
+    metaFor(clientId, value) {
+      const authorization = authorizationFor.call(this, clientId);
+
+      if (value) {
+        authorization.meta = value;
+        return undefined;
+      }
+
+      return authorization.meta;
     }
 
     static async find(id) {

--- a/lib/shared/resume.js
+++ b/lib/shared/resume.js
@@ -48,6 +48,10 @@ module.exports = function getResumeAction(provider) {
       ctx.oidc.session.sidFor(ctx.query.client_id, uuid());
     }
 
+    if (!_.isEmpty(result) && _.isObjectLike(result.meta)) {
+      ctx.oidc.session.metaFor(ctx.query.client_id, result.meta);
+    }
+
     ctx.oidc.result = result;
 
     await next();

--- a/test/backchannel_logout/backchannel_logout.test.js
+++ b/test/backchannel_logout/backchannel_logout.test.js
@@ -140,7 +140,7 @@ describe('Back-Channel Logout 1.0', () => {
     });
 
     it('triggers the backchannelLogout for visited clients', async function () {
-      const session = this.getSession(this.agent);
+      const session = this.getSession();
       session.logout = { secret: '123', postLogoutRedirectUri: '/' };
       const params = { logout: 'yes', xsrf: '123' };
       const client = await this.provider.Client.find('client');
@@ -162,7 +162,7 @@ describe('Back-Channel Logout 1.0', () => {
     });
 
     it('ignores the backchannelLogout when client does not support', async function () {
-      this.getSession(this.agent).logout = { secret: '123', postLogoutRedirectUri: '/' };
+      this.getSession().logout = { secret: '123', postLogoutRedirectUri: '/' };
       const params = { logout: 'yes', xsrf: '123' };
       const client = await this.provider.Client.find('client');
       delete client.backchannelLogoutUri;

--- a/test/interaction/interaction.test.js
+++ b/test/interaction/interaction.test.js
@@ -325,9 +325,9 @@ describe('resume after interaction', () => {
 
       return this.agent.get('/auth/resume')
         .expect(() => {
-          const authorization = this.getSession().authorizations[config.client.client_id];
-          expect(authorization).to.have.property('meta');
-          expect(authorization.meta).to.have.property('scope');
+          const meta = this.getSession({ instantiate: true }).metaFor(config.client.client_id);
+          expect(meta).to.be.ok;
+          expect(meta).to.have.property('scope');
         });
     });
   });

--- a/test/interaction/interaction.test.js
+++ b/test/interaction/interaction.test.js
@@ -2,6 +2,7 @@
 
 const uuid = require('uuid/v4');
 const bootstrap = require('../test_helper');
+const config = require('./interaction.config.js');
 
 const expire = new Date();
 expire.setDate(expire.getDate() + 1);
@@ -302,6 +303,32 @@ describe('resume after interaction', () => {
         .expect(auth.validateClientLocation)
         .expect(auth.validateError('consent_required'))
         .expect(auth.validateErrorDescription('prompt consent was not resolved'));
+    });
+  });
+
+  context('meta results', () => {
+    it('should process and store meta-informations provided alongside login', function () {
+      const auth = new this.AuthorizationRequest({
+        response_type: 'code',
+        scope: 'openid',
+      });
+
+      setup.call(this, auth, {
+        login: {
+          account: uuid(),
+          remember: true,
+        },
+        meta: {
+          scope: 'openid',
+        },
+      });
+
+      return this.agent.get('/auth/resume')
+        .expect(() => {
+          const authorization = this.getSession().authorizations[config.client.client_id];
+          expect(authorization).to.have.property('meta');
+          expect(authorization.meta).to.have.property('scope');
+        });
     });
   });
 

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -196,10 +196,16 @@ module.exports = function testHelper(dir, basename, mountTo) {
     };
   };
 
-  function getSession() {
+  function getSession(opts = { instantiate: false }) {
     const { value: sessionId } = agent.jar.getCookie('_session', { path: '/' });
     const key = TestAdapter.for('Session').key(sessionId);
-    return TestAdapter.for('Session').get(key);
+    const raw = TestAdapter.for('Session').get(key);
+
+    if (opts.instantiate) {
+      return raw ? new provider.Session(sessionId, raw) : raw;
+    }
+
+    return raw;
   }
 
   function getSessionId() {


### PR DESCRIPTION
See #164 

I went for a free object rather than storing directly the scopes as it is a bit more flexible. Let me know.