### PR TITLE
Enable primature end of an interaction via an error result object

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -265,6 +265,16 @@ router.post('/interaction/:grant', async (ctx, next) => {
 
   ['custom prompt name resolved']: {},
 }
+
+// optionally, interactions can be primaturely exited with a an error by providing a result
+// object as follow:
+{
+  // an error field used as error code indicating a failure during the interaction
+  error: 'access_denied',
+
+  // an optional description for this error
+  error_description: 'Insufficient permissions: scope out of reach for this Account',
+}
 ```
 
 

--- a/lib/shared/resume.js
+++ b/lib/shared/resume.js
@@ -1,3 +1,5 @@
+const assert = require('assert');
+const createError = require('http-errors');
 const uuid = require('uuid/v4');
 const url = require('url');
 const _ = require('lodash');
@@ -28,6 +30,19 @@ module.exports = function getResumeAction(provider) {
       path: url.parse(ctx.oidc.urlFor('resume', { grant: ctx.oidc.uuid })).pathname,
     });
     ctx.cookies.set(provider.cookieName('resume'), null, clearOpts);
+
+    if (result.error) {
+      assert(!result.login, 'login shouldn\'t be provided with an error result');
+      assert(!result.consent, 'consent shouldn\'t be provided with an error result');
+      assert(typeof result.error === 'string', 'error should be a string');
+
+      const description = result.error_description
+        ? { error_description: result.error_description }
+        : undefined;
+      const err = createError(400, result.error, description);
+
+      ctx.throw(err);
+    }
 
     if (result.login) {
       if (!result.login.remember) ctx.oidc.session.transient = true;

--- a/test/interaction/interaction.test.js
+++ b/test/interaction/interaction.test.js
@@ -332,6 +332,43 @@ describe('resume after interaction', () => {
     });
   });
 
+  context('interaction errors', () => {
+    it('should abort an interaction when given an error result object (no description)', function () {
+      const auth = new this.AuthorizationRequest({
+        response_type: 'code',
+        scope: 'openid',
+      });
+
+      setup.call(this, auth, {
+        error: 'access_denied',
+      });
+
+      return this.agent.get('/auth/resume')
+        .expect(302)
+        .expect(auth.validateState)
+        .expect(auth.validateError('access_denied'))
+        .expect(auth.validateErrorDescription(''))
+    });
+
+    it('should abort an interaction when given an error result object (with description)', function () {
+      const auth = new this.AuthorizationRequest({
+        response_type: 'code',
+        scope: 'openid',
+      });
+
+      setup.call(this, auth, {
+        error: 'access_denied',
+        error_description: 'scope out of reach',
+      });
+
+      return this.agent.get('/auth/resume')
+        .expect(302)
+        .expect(auth.validateState)
+        .expect(auth.validateError('access_denied'))
+        .expect(auth.validateErrorDescription('scope out of reach'))
+    });
+  });
+
   context('custom prompts', () => {
     before(function () { return this.login(); });
     after(function () { return this.logout(); });

--- a/test/interaction/interaction.test.js
+++ b/test/interaction/interaction.test.js
@@ -350,6 +350,24 @@ describe('resume after interaction', () => {
         .expect(auth.validateErrorDescription(''))
     });
 
+    it('should abort an interaction when given an error result object (with state)', function () {
+      const auth = new this.AuthorizationRequest({
+        response_type: 'code',
+        scope: 'openid',
+        state: 'bf458-00aa3',
+      });
+
+      setup.call(this, auth, {
+        error: 'access_denied',
+      });
+
+      return this.agent.get('/auth/resume')
+        .expect(302)
+        .expect(auth.validateState)
+        .expect(auth.validateError('access_denied'))
+        .expect(auth.validateErrorDescription(''))
+    });
+
     it('should abort an interaction when given an error result object (with description)', function () {
       const auth = new this.AuthorizationRequest({
         response_type: 'code',


### PR DESCRIPTION
See #167 

I've also added an optional  `error_status_code` field to the error object to be more consistent with other errors created by the provider. When not defined, it default to 400.