### PR TITLE
Allow system clock skew

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ actions and i.e. emit metrics or that react to specific triggers. In some scenar
 change the defined behavior.  
 See the list of available emitted [event names](/docs/events.md) and their description.
 
+### Allow for system clock skew
+It is possible the OP or RP environment has a system clock skew, to set a clock tolerance (in seconds)
+
+```js
+oidc.CLOCK_TOLERANCE = 5; // to allow a 5 second skew
+```
+
+
 
 [travis-image]: https://img.shields.io/travis/panva/node-oidc-provider/master.svg?style=flat-square&maxAge=7200
 [travis-url]: https://travis-ci.org/panva/node-oidc-provider

--- a/lib/actions/authorization/decode_request.js
+++ b/lib/actions/authorization/decode_request.js
@@ -97,7 +97,7 @@ module.exports = (provider, whitelist) => {
         const opts = {
           issuer: payload.iss ? client.clientId : undefined,
           audience: payload.aud ? provider.issuer : undefined,
-          clockTolerance: provider.CLOCK_TOLERANCE
+          clockTolerance: provider.CLOCK_TOLERANCE,
         };
         await JWT.verify(params.request, client.keystore, opts);
         wasSignedOrEncrypted = true;

--- a/lib/actions/authorization/decode_request.js
+++ b/lib/actions/authorization/decode_request.js
@@ -97,6 +97,7 @@ module.exports = (provider, whitelist) => {
         const opts = {
           issuer: payload.iss ? client.clientId : undefined,
           audience: payload.aud ? provider.issuer : undefined,
+          clockTolerance: provider.CLOCK_TOLERANCE
         };
         await JWT.verify(params.request, client.keystore, opts);
         wasSignedOrEncrypted = true;

--- a/lib/helpers/jwt.js
+++ b/lib/helpers/jwt.js
@@ -54,22 +54,23 @@ class JWT {
 
   static assertPayload(payload, options = {}) {
     const timestamp = Math.ceil(Date.now() / 1000);
+    const clockTolerance = options.clockTolerance || 0;
 
     assert.equal(typeof payload, 'object', 'payload is not of JWT type (JSON serialized object)');
 
     if (typeof payload.nbf !== 'undefined' && !options.ignoreNotBefore) {
       assert.equal(typeof payload.nbf, 'number', 'invalid nbf value');
-      assert(payload.nbf <= timestamp, 'jwt not active yet');
+      assert(payload.nbf <= timestamp + clockTolerance, 'jwt not active yet');
     }
 
     if (typeof payload.iat !== 'undefined' && !options.ignoreIssued) {
       assert.equal(typeof payload.iat, 'number', 'invalid iat value');
-      assert(payload.iat <= timestamp, 'jwt issued in the future');
+      assert(payload.iat <= timestamp + clockTolerance, 'jwt issued in the future');
     }
 
     if (typeof payload.exp !== 'undefined' && !options.ignoreExpiration) {
       assert.equal(typeof payload.exp, 'number', 'invalid exp value');
-      assert(timestamp < payload.exp, 'jwt expired');
+      assert(timestamp - clockTolerance < payload.exp, 'jwt expired');
     }
 
     if (options.audience) {

--- a/lib/models/base_token.js
+++ b/lib/models/base_token.js
@@ -167,7 +167,7 @@ module.exports = function getBaseToken(provider) {
       JWT.assertPayload(payload, {
         ignoreExpiration: options.ignoreExpiration,
         issuer: provider.issuer,
-        clockTolerance: provider.clockTolerance
+        clockTolerance: provider.CLOCK_TOLERANCE
       });
       return payload;
     }

--- a/lib/models/base_token.js
+++ b/lib/models/base_token.js
@@ -167,7 +167,7 @@ module.exports = function getBaseToken(provider) {
       JWT.assertPayload(payload, {
         ignoreExpiration: options.ignoreExpiration,
         issuer: provider.issuer,
-        clockTolerance: provider.CLOCK_TOLERANCE
+        clockTolerance: provider.CLOCK_TOLERANCE,
       });
       return payload;
     }

--- a/lib/models/base_token.js
+++ b/lib/models/base_token.js
@@ -167,6 +167,7 @@ module.exports = function getBaseToken(provider) {
       JWT.assertPayload(payload, {
         ignoreExpiration: options.ignoreExpiration,
         issuer: provider.issuer,
+        clockTolerance: provider.clockTolerance
       });
       return payload;
     }

--- a/lib/models/id_token.js
+++ b/lib/models/id_token.js
@@ -84,7 +84,7 @@ module.exports = function getIdToken(provider) {
 
     static async validate(jwt, client) {
       const alg = client.idTokenSignedResponseAlg;
-      const opts = { ignoreExpiration: true, issuer: provider.issuer };
+      const opts = { ignoreExpiration: true, issuer: provider.issuer, clockTolerance: provider.CLOCK_TOLERANCE };
 
       const keyOrStore = (() => {
         if (/^(ES|RS)\d{3}/.exec(alg)) {

--- a/lib/models/id_token.js
+++ b/lib/models/id_token.js
@@ -84,7 +84,11 @@ module.exports = function getIdToken(provider) {
 
     static async validate(jwt, client) {
       const alg = client.idTokenSignedResponseAlg;
-      const opts = { ignoreExpiration: true, issuer: provider.issuer, clockTolerance: provider.CLOCK_TOLERANCE };
+      const opts = {
+        ignoreExpiration: true,
+        issuer: provider.issuer,
+        clockTolerance: provider.CLOCK_TOLERANCE,
+      };
 
       const keyOrStore = (() => {
         if (/^(ES|RS)\d{3}/.exec(alg)) {

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -67,6 +67,8 @@ class Provider extends events.EventEmitter {
 
     this.issuer = issuer;
 
+    this.CLOCK_TOLERANCE = 0;
+
     const conf = getConfiguration(setup);
 
     instance(this).configuration = function configuration(path) {

--- a/lib/shared/token_jwt_auth.js
+++ b/lib/shared/token_jwt_auth.js
@@ -84,7 +84,7 @@ module.exports = function getTokenJwtAuth(provider, endpoint) {
       await JWT.verify(ctx.oidc.params.client_assertion, keystore, {
         audience: endpointUri,
         issuer: ctx.oidc.client.clientId,
-        clockTolerance: provider.CLOCK_TOLERANCE
+        clockTolerance: provider.CLOCK_TOLERANCE,
       });
     } catch (err) {
       ctx.throw(new InvalidClientError(err.message));

--- a/lib/shared/token_jwt_auth.js
+++ b/lib/shared/token_jwt_auth.js
@@ -84,6 +84,7 @@ module.exports = function getTokenJwtAuth(provider, endpoint) {
       await JWT.verify(ctx.oidc.params.client_assertion, keystore, {
         audience: endpointUri,
         issuer: ctx.oidc.client.clientId,
+        clockTolerance: provider.CLOCK_TOLERANCE
       });
     } catch (err) {
       ctx.throw(new InvalidClientError(err.message));

--- a/test/jwt/jsonwebtoken.test.js
+++ b/test/jwt/jsonwebtoken.test.js
@@ -115,6 +115,14 @@ describe('JSON Web Token (JWT) RFC7519 implementation', () => {
         }));
     });
 
+    it('nbf accepted within set clock tolerance', () => {
+      const key = keystore.get({ kty: 'oct' });
+      return JWT.sign({ data: true, nbf: epochTime() + 5 }, key, 'HS256')
+        .then(jwt => JWT.verify(jwt, key, {
+          clockTolerance: 10,
+        }));
+    });
+
     it('nbf invalid', () => {
       const key = keystore.get({ kty: 'oct' });
       return JWT.sign({ data: true, nbf: 'not a nbf' }, key, 'HS256')
@@ -153,6 +161,16 @@ describe('JSON Web Token (JWT) RFC7519 implementation', () => {
         }));
     });
 
+    it('iat accepted within set clock tolerance', () => {
+      const key = keystore.get({ kty: 'oct' });
+      return JWT.sign({ data: true, iat: epochTime() + 5 }, key, 'HS256', {
+        noTimestamp: true,
+      })
+        .then(jwt => JWT.verify(jwt, key, {
+          clockTolerance: 10,
+        }));
+    });
+
     it('iat invalid', () => {
       const key = keystore.get({ kty: 'oct' });
       return JWT.sign({ data: true, iat: 'not an iat' }, key, 'HS256', {
@@ -186,6 +204,14 @@ describe('JSON Web Token (JWT) RFC7519 implementation', () => {
       return JWT.sign({ data: true, exp: epochTime() - 3600 }, key, 'HS256')
         .then(jwt => JWT.verify(jwt, key, {
           ignoreExpiration: true,
+        }));
+    });
+
+    it('exp accepted within set clock tolerance', () => {
+      const key = keystore.get({ kty: 'oct' });
+      return JWT.sign({ data: true, exp: epochTime() - 5 }, key, 'HS256')
+        .then(jwt => JWT.verify(jwt, key, {
+          clockTolerance: 10,
         }));
     });
 

--- a/test/request/jwt_request.test.js
+++ b/test/request/jwt_request.test.js
@@ -147,7 +147,7 @@ describe('request parameter features', () => {
             expect(actual.query).to.have.property('code');
           }));
       });
-      
+
 
       it('works with signed by an actual HS', async function () {
         const key = (await this.provider.Client.find('client-with-HS-sig')).keystore.get({

--- a/test/request/jwt_request.test.js
+++ b/test/request/jwt_request.test.js
@@ -29,6 +29,7 @@ describe('request parameter features', () => {
         return this.login();
       });
       after(function () {
+        this.provider.CLOCK_TOLERANCE = 0;
         return this.logout();
       });
 
@@ -114,6 +115,39 @@ describe('request parameter features', () => {
             expect(actual.query).to.have.property('code');
           }));
       });
+
+      it('can accept request objects issued within acceptable system clock skew', async function () {
+        const key = (await this.provider.Client.find('client-with-HS-sig')).keystore.get({
+          alg: 'HS256',
+        });
+        this.provider.CLOCK_TOLERANCE = 10;
+        return JWT.sign({
+          iat: Math.ceil(Date.now() / 1000) + 5,
+          client_id: 'client-with-HS-sig',
+          response_type: 'code',
+          redirect_uri: 'https://client.example.com/cb',
+        }, key, 'HS256', { issuer: 'client-with-HS-sig', audience: this.provider.issuer }).then(request => this.wrap({
+          agent: this.agent,
+          route,
+          verb,
+          auth: {
+            request,
+            scope: 'openid',
+            client_id: 'client-with-HS-sig',
+            response_type: 'code',
+          },
+        })
+          .expect(302)
+          .expect((response) => {
+            const expected = parse('https://client.example.com/cb', true);
+            const actual = parse(response.headers.location, true);
+            ['protocol', 'host', 'pathname'].forEach((attr) => {
+              expect(actual[attr]).to.equal(expected[attr]);
+            });
+            expect(actual.query).to.have.property('code');
+          }));
+      });
+      
 
       it('works with signed by an actual HS', async function () {
         const key = (await this.provider.Client.find('client-with-HS-sig')).keystore.get({

--- a/test/token_auth/client_auth.test.js
+++ b/test/token_auth/client_auth.test.js
@@ -638,5 +638,25 @@ describe('client authentication options', () => {
         .type('form')
         .expect(this.responses.tokenAuthSucceeded));
     });
+
+    it('accepts client assertions issued within acceptable system clock skew', function () {
+      this.provider.CLOCK_TOLERANCE = 10;
+      return JWT.sign({
+        jti: uuid(),
+        aud: this.provider.issuer + this.provider.pathFor('token'),
+        sub: 'client-jwt-key',
+        iss: 'client-jwt-key',
+        iat: Math.ceil(Date.now() / 1000) + 5,
+      }, privateKey, 'RS256', {
+        expiresIn: 60,
+      }).then(assertion => this.agent.post(route)
+        .send({
+          client_assertion: assertion,
+          grant_type: 'implicit',
+          client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
+        })
+        .type('form')
+        .expect(this.responses.tokenAuthSucceeded));
+    });
   });
 });


### PR DESCRIPTION
This fixes an issue we had where client assertions and request objects
were being rejected because the systems clocks of the OP and RP
were out of alignment.

I used the same variable name and method of configuration as https://github.com/panva/node-openid-client