### PR TITLE
fix returning token introspection details for consumed token

### DIFF
--- a/lib/actions/introspection.js
+++ b/lib/actions/introspection.js
@@ -100,13 +100,17 @@ module.exports = function introspectionAction(provider) {
           ]).then(findResult);
       }
 
+      if (!token || !token.isValid) {
+        return;
+      }
+
       if (ctx.oidc.client.introspectionEndpointAuthMethod === 'none') {
-        if (token && token.clientId !== ctx.oidc.client.clientId) {
+        if (token.clientId !== ctx.oidc.client.clientId) {
           return;
         }
       }
 
-      switch (token && token.kind) {
+      switch (token.kind) {
         case 'AccessToken':
           ctx.body.token_type = 'access_token';
           break;

--- a/test/introspection/introspection.test.js
+++ b/test/introspection/introspection.test.js
@@ -395,5 +395,28 @@ describe('introspection features', () => {
           expect(response.body).to.have.keys('active');
         });
     });
+
+    it('responds only with active=false when token is already consumed', async function () {
+      const at = new this.provider.AccessToken({
+        accountId: 'accountId',
+        clientId: 'client',
+        scope: 'scope',
+      });
+
+      const token = await at.save();
+      await at.consume();
+
+      return this.agent.post(route)
+        .auth('client', 'secret')
+        .send({
+          token,
+        })
+        .type('form')
+        .expect(200)
+        .expect((response) => {
+          expect(response.body).to.have.property('active', false);
+          expect(response.body).to.have.keys('active');
+        });
+    });
   });
 });


### PR DESCRIPTION
The endpoint does not show any details about expired or revoked token. However, consumed token was returned with `active=false` but also with all details that could lead to security issues.

Possible BC break but no one should depend on it because it is not correct behavior.