### PR TITLE
Additional ID Token audiences helper

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -687,6 +687,20 @@ default value:
 []
 ```
 
+### audiences
+
+Helper used by the OP to push additional audiences to issued ID Tokens and other signed responses. The return value should either be falsy to omit adding additional audiences or an array of strings to push.  
+affects: id token audiences, signed userinfo audiences  
+
+default value:
+```js
+async audiences(ctx, id, token) {
+  // token is a reference to the token used for which a given account is being loaded,
+  // is undefined in scenarios where claims are returned from authorization endpoint
+  return undefined;
+}
+```
+
 ### claims
 
 List of the Claim Names of the Claims that the OpenID Provider MAY be able to supply values for.  
@@ -841,7 +855,7 @@ default value:
 
 ### findById
 
-Helper used by the OP to load your account and retrieve it's avaialble claims. The return value should be a Promise and #claims() can return a Promise too  
+Helper used by the OP to load your account and retrieve it's available claims. The return value should be a Promise and #claims() can return a Promise too  
 affects: authorization, authorization_code and refresh_token grants, id token claims  
 
 default value:

--- a/lib/actions/authorization/process_response_types.js
+++ b/lib/actions/authorization/process_response_types.js
@@ -3,8 +3,8 @@ const instance = require('../../helpers/weak_cache');
 
 module.exports = (provider) => {
   const { IdToken, AccessToken, AuthorizationCode } = provider;
-  const pkce = instance(provider).configuration('features.pkce');
-  const backchannelLogout = instance(provider).configuration('features.backchannelLogout');
+
+  const { features: { pkce, backchannelLogout }, audiences } = instance(provider).configuration();
 
   async function tokenHandler(ctx) {
     const at = new AccessToken({
@@ -100,7 +100,9 @@ module.exports = (provider) => {
     }
 
     if (res.id_token) {
-      res.id_token = await res.id_token.sign(ctx.oidc.client);
+      res.id_token = await res.id_token.sign(ctx.oidc.client, {
+        audiences: await audiences(ctx, ctx.oidc.account.accountId),
+      });
     }
 
     return res;

--- a/lib/actions/grants/authorization_code.js
+++ b/lib/actions/grants/authorization_code.js
@@ -7,7 +7,7 @@ const presence = require('../../helpers/validate_presence');
 const instance = require('../../helpers/weak_cache');
 
 module.exports.handler = function getAuthorizationCodeHandler(provider) {
-  const pkce = instance(provider).configuration('features.pkce');
+  const { features: { pkce, alwaysIssueRefresh }, audiences } = instance(provider).configuration();
   return async function authorizationCodeResponse(ctx, next) {
     presence(ctx, ['code', 'redirect_uri']);
 
@@ -79,10 +79,8 @@ module.exports.handler = function getAuthorizationCodeHandler(provider) {
 
     let refreshToken;
     const grantPresent = ctx.oidc.client.grantTypes.includes('refresh_token');
-    const shouldIssue = instance(provider).configuration('features.alwaysIssueRefresh') ||
-      code.scope.split(' ').includes('offline_access');
 
-    if (grantPresent && shouldIssue) {
+    if (grantPresent && (alwaysIssueRefresh || code.scope.split(' ').includes('offline_access'))) {
       const rt = new RefreshToken({
         accountId: account.accountId,
         acr: code.acr,
@@ -113,7 +111,9 @@ module.exports.handler = function getAuthorizationCodeHandler(provider) {
     token.set('rt_hash', refreshToken);
     token.set('sid', code.sid);
 
-    const idToken = await token.sign(ctx.oidc.client);
+    const idToken = await token.sign(ctx.oidc.client, {
+      audiences: await audiences(ctx, code.accountId, code),
+    });
 
     ctx.body = {
       access_token: accessToken,

--- a/lib/actions/grants/refresh_token.js
+++ b/lib/actions/grants/refresh_token.js
@@ -4,6 +4,8 @@ const presence = require('../../helpers/validate_presence');
 const instance = require('../../helpers/weak_cache');
 
 module.exports.handler = function getRefreshTokenHandler(provider) {
+  const { refreshTokenRotation, audiences } = instance(provider).configuration();
+
   return async function refreshTokenResponse(ctx, next) {
     presence(ctx, ['refresh_token']);
 
@@ -45,7 +47,7 @@ module.exports.handler = function getRefreshTokenHandler(provider) {
       ctx.throw(new InvalidGrantError('refresh token invalid (referenced account not found)'));
     }
 
-    if (instance(provider).configuration('refreshTokenRotation') === 'rotateAndConsume') {
+    if (refreshTokenRotation === 'rotateAndConsume') {
       try {
         if (refreshToken.consumed) {
           ctx.throw(new InvalidGrantError('refresh token already used'));
@@ -99,7 +101,9 @@ module.exports.handler = function getRefreshTokenHandler(provider) {
     token.set('rt_hash', refreshTokenValue);
     token.set('sid', refreshToken.sid);
 
-    const idToken = await token.sign(ctx.oidc.client);
+    const idToken = await token.sign(ctx.oidc.client, {
+      audiences: await audiences(ctx, refreshToken.accountId, refreshToken),
+    });
 
     ctx.body = {
       access_token: accessToken,

--- a/lib/actions/userinfo.js
+++ b/lib/actions/userinfo.js
@@ -20,12 +20,19 @@ const parseBody = bodyParser('application/x-www-form-urlencoded');
 const getParams = params(PARAM_LIST);
 
 module.exports = function userinfoAction(provider) {
-  const Claims = getMask(instance(provider).configuration());
+  const {
+    pairwiseSalt,
+    claims: claimsConfig,
+    claimsSupported,
+    audiences,
+  } = instance(provider).configuration();
+
+  const Claims = getMask({ pairwiseSalt, claimsSupported, claims: claimsConfig });
 
   return compose([
     errorHandler(provider, 'userinfo.error'),
 
-    async function seWWWAuthenticateHeader(ctx, next) {
+    async function setWWWAuthenticateHeader(ctx, next) {
       try {
         await next();
       } catch (err) {
@@ -119,6 +126,11 @@ module.exports = function userinfoAction(provider) {
         token.mask = claims;
 
         ctx.body = await token.sign(client, {
+          audiences: await audiences(
+            ctx,
+            ctx.oidc.accessToken.accountId,
+            ctx.oidc.accessToken,
+          ),
           expiresAt: ctx.oidc.accessToken.exp,
           use: 'userinfo',
         });

--- a/lib/helpers/claims.js
+++ b/lib/helpers/claims.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const assert = require('assert');
 const crypto = require('crypto');
 
-module.exports = function getClaims(config) {
+module.exports = function getClaims({ pairwiseSalt, claims: claimConfig, claimsSupported }) {
   return class Claims {
     static sub(accountId, sector) {
       if (!accountId) return undefined;
@@ -11,7 +11,7 @@ module.exports = function getClaims(config) {
         return crypto.createHash('sha256')
           .update(sector)
           .update(accountId)
-          .update(config.pairwiseSalt)
+          .update(pairwiseSalt)
           .digest('hex');
       }
 
@@ -30,7 +30,7 @@ module.exports = function getClaims(config) {
 
     scope(value = '') {
       assert(_.isEmpty(this.filter), 'scope cannot be assigned after mask has been set');
-      value.split(' ').forEach(a => this.mask(config.claims[a]));
+      value.split(' ').forEach(a => this.mask(claimConfig[a]));
       return this;
     }
 
@@ -65,7 +65,7 @@ module.exports = function getClaims(config) {
           return false;
         })
         .keys()
-        .intersection(config.claimsSupported)
+        .intersection(claimsSupported)
         .value();
 
       const claims = _.pick(available, include);

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -381,9 +381,24 @@ const DEFAULTS = {
 
 
   /*
+   * audiences
+   *
+   * description: Helper used by the OP to push additional audiences to issued ID Tokens and other
+   *   signed responses. The return value should either be falsy to omit adding additional audiences
+   *   or an array of strings to push.
+   * affects: id token audiences, signed userinfo audiences
+   */
+  async audiences(ctx, id, token) { // eslint-disable-line no-unused-vars
+    // token is a reference to the token used for which a given account is being loaded,
+    // is undefined in scenarios where claims are returned from authorization endpoint
+    return undefined;
+  },
+
+
+  /*
    * findById
    *
-   * description: Helper used by the OP to load your account and retrieve it's avaialble claims. The
+   * description: Helper used by the OP to load your account and retrieve it's available claims. The
    *   return value should be a Promise and #claims() can return a Promise too
    * affects: authorization, authorization_code and refresh_token grants, id token claims
    */

--- a/lib/helpers/jwt.js
+++ b/lib/helpers/jwt.js
@@ -24,9 +24,10 @@ class JWT {
     const timestamp = epochTime();
 
     Object.assign(payload, {
-      iat: payload.iat ? payload.iat : timestamp,
-      exp: options.expiresIn ? timestamp + options.expiresIn : payload.exp,
       aud: options.audience ? options.audience : payload.aud,
+      azp: options.authorizedParty ? options.authorizedParty : payload.azp,
+      exp: options.expiresIn ? timestamp + options.expiresIn : payload.exp,
+      iat: payload.iat ? payload.iat : timestamp,
       iss: options.issuer ? options.issuer : payload.iss,
       sub: options.subject ? options.subject : payload.sub,
     });

--- a/lib/models/id_token.js
+++ b/lib/models/id_token.js
@@ -73,7 +73,7 @@ module.exports = function getIdToken(provider) {
         const key = keystore && keystore.get({ alg });
 
         return JWT.sign(payload, key, alg, {
-          authorizedParty: client.clientId,
+          authorizedParty: audiences ? client.clientId : undefined,
           audience: audiences ? ensureConform(audiences, client.clientId) : client.clientId,
           expiresIn: noExp ? undefined : (expiresIn || this.constructor.expiresIn),
           issuer: provider.issuer,

--- a/lib/models/id_token.js
+++ b/lib/models/id_token.js
@@ -10,6 +10,17 @@ const instance = require('../helpers/weak_cache');
 
 const hashes = ['at_hash', 'c_hash', 'rt_hash', 's_hash'];
 
+function ensureConform(audiences, clientId) {
+  assert(Array.isArray(audiences), 'audiences must be an array');
+
+  const value = Array.from(audiences);
+  if (!value.includes(clientId)) {
+    value.unshift(clientId);
+  }
+
+  return value;
+}
+
 module.exports = function getIdToken(provider) {
   const Claims = getMask(instance(provider).configuration());
 
@@ -37,7 +48,12 @@ module.exports = function getIdToken(provider) {
       return merge(mask.result(), this.extra);
     }
 
-    async sign(client, { use = 'idtoken', expiresAt = null, noExp = null } = {}) {
+    async sign(client, {
+      use = 'idtoken',
+      audiences = null,
+      expiresAt = null,
+      noExp = null,
+    } = {}) {
       const expiresIn = (() => {
         if (expiresAt) return expiresAt - epochTime();
         return undefined;
@@ -57,7 +73,8 @@ module.exports = function getIdToken(provider) {
         const key = keystore && keystore.get({ alg });
 
         return JWT.sign(payload, key, alg, {
-          audience: client.clientId,
+          authorizedParty: client.clientId,
+          audience: audiences ? ensureConform(audiences, client.clientId) : client.clientId,
           expiresIn: noExp ? undefined : (expiresIn || this.constructor.expiresIn),
           issuer: provider.issuer,
           subject: payload.sub,

--- a/test/backchannel_logout/backchannel_logout.test.js
+++ b/test/backchannel_logout/backchannel_logout.test.js
@@ -35,7 +35,7 @@ describe('Back-Channel Logout 1.0', () => {
         .filteringRequestBody((body) => {
           expect(body).to.match(/^logout_token=(([\w-]+\.?){3})$/);
           const decoded = JSON.parse(base64url.decode(RegExp.$1.split('.')[1]));
-          expect(decoded).to.have.all.keys('sub', 'events', 'iat', 'aud', 'iss', 'jti');
+          expect(decoded).to.have.all.keys('sub', 'events', 'iat', 'aud', 'iss', 'jti', 'azp');
           expect(decoded).to.have.property('events').and.eql({ 'http://schemas.openid.net/event/backchannel-logout': {} });
           expect(decoded).to.have.property('aud', 'client');
           expect(decoded).to.have.property('sub', 'subject');

--- a/test/backchannel_logout/backchannel_logout.test.js
+++ b/test/backchannel_logout/backchannel_logout.test.js
@@ -35,7 +35,7 @@ describe('Back-Channel Logout 1.0', () => {
         .filteringRequestBody((body) => {
           expect(body).to.match(/^logout_token=(([\w-]+\.?){3})$/);
           const decoded = JSON.parse(base64url.decode(RegExp.$1.split('.')[1]));
-          expect(decoded).to.have.all.keys('sub', 'events', 'iat', 'aud', 'iss', 'jti', 'azp');
+          expect(decoded).to.have.all.keys('sub', 'events', 'iat', 'aud', 'iss', 'jti');
           expect(decoded).to.have.property('events').and.eql({ 'http://schemas.openid.net/event/backchannel-logout': {} });
           expect(decoded).to.have.property('aud', 'client');
           expect(decoded).to.have.property('sub', 'subject');

--- a/test/configuration/audiences.config.js
+++ b/test/configuration/audiences.config.js
@@ -1,0 +1,17 @@
+const { clone } = require('lodash');
+const config = clone(require('../default.config'));
+
+config.features = { alwaysIssueRefresh: true };
+config.audiences = () => ['foo', 'bar'];
+
+module.exports = {
+  config,
+  client: {
+    client_id: 'client',
+    client_secret: 'secret',
+    grant_types: ['implicit', 'authorization_code', 'refresh_token'],
+    response_types: ['code id_token token'],
+    redirect_uris: ['https://client.example.com/cb'],
+    userinfo_signed_response_alg: 'RS256',
+  },
+};

--- a/test/configuration/audiences.test.js
+++ b/test/configuration/audiences.test.js
@@ -1,0 +1,88 @@
+const bootstrap = require('../test_helper');
+const url = require('url');
+const { expect } = require('chai');
+const JWT = require('../../lib/helpers/jwt');
+
+const route = '/auth';
+const verb = 'get';
+
+describe('audiences helper', () => {
+  before(bootstrap(__dirname, 'audiences')); // provider, agent, AuthorizationRequest, wrap
+  before(function () { return this.login(); });
+  before(async function () {
+    const auth = new this.AuthorizationRequest({
+      response_type: 'code id_token token',
+      scope: 'openid',
+    });
+
+    await this.wrap({ route, verb, auth })
+      .expect(302)
+      .expect(auth.validateFragment)
+      .expect((response) => {
+        const {
+          query: {
+            id_token,
+            code,
+            access_token,
+          },
+        } = url.parse(response.headers.location, true);
+
+        this.access_token = access_token;
+        this.code = code;
+        this.id_token = id_token;
+      });
+  });
+
+  it('pushes audiences to id tokens issued by the authorization endpoint', function () {
+    const { payload: { aud, azp } } = JWT.decode(this.id_token);
+    expect(aud).to.be.an('array').and.eql(['client', 'foo', 'bar']);
+    expect(azp).to.equal('client');
+  });
+
+  it('pushes audiences to signed userinfo responses', function () {
+    return this.agent.get('/me')
+      .set('Authorization', `Bearer ${this.access_token}`)
+      .expect(200)
+      .expect('content-type', 'application/jwt; charset=utf-8')
+      .expect((response) => {
+        const { payload: { aud, azp } } = JWT.decode(response.text);
+        expect(aud).to.be.an('array').and.eql(['client', 'foo', 'bar']);
+        expect(azp).to.equal('client');
+      });
+  });
+
+  it('pushes audiences to id tokens issued by the token endpoint', async function () {
+    await this.agent.post('/token')
+      .auth('client', 'secret')
+      .type('form')
+      .send({
+        code: this.code,
+        grant_type: 'authorization_code',
+        redirect_uri: 'https://client.example.com/cb',
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(response.body).to.have.property('refresh_token');
+        this.refresh_token = response.body.refresh_token;
+        expect(response.body).to.have.property('id_token');
+        const { payload: { aud, azp } } = JWT.decode(response.body.id_token);
+        expect(aud).to.be.an('array').and.eql(['client', 'foo', 'bar']);
+        expect(azp).to.equal('client');
+      });
+
+    await this.agent.post('/token')
+      .auth('client', 'secret')
+      .type('form')
+      .send({
+        refresh_token: this.refresh_token,
+        grant_type: 'refresh_token',
+      })
+      .expect(200)
+      .expect((response) => {
+        expect(response.body).to.have.property('id_token');
+        const { payload: { aud, azp } } = JWT.decode(response.body.id_token);
+        expect(aud).to.be.an('array').and.eql(['client', 'foo', 'bar']);
+        expect(azp).to.equal('client');
+      });
+  });
+});


### PR DESCRIPTION
**audiences**

Helper used by the OP to push additional audiences to issued ID Tokens and other signed responses. The return value should either be falsy to omit adding additional audiences or an array of strings to push.  
affects: id token audiences, signed userinfo audiences  

default value:
```js
async audiences(ctx, accountId, token) {
  // token is a reference to the token used for which a given account is being loaded,
  // is undefined in scenarios where claims are returned from authorization endpoint
  return undefined;
}
```

  