### PR TITLE
Added new configuration property to allow unsafe redirect uris

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,6 +106,29 @@ const clients = [
 oidc.initialize({ clients }).then(fulfillmentHandler, rejectionHandler);
 ```
 
+If you use the "implicit" `grant_type` and the `application_type` "web" (default), then `redirect_uris` with the scheme 
+*http* or the host *localhost* are rejected by default. To enable unsafe `redirect_uris` you can set the configuration
+property `allow_unsafe_redirect_uris` to true. **Do not activate this behavior in production!**
+
+```js
+const oidc = new Provider('http://localhost:3000');
+const clients = [
+  {
+    allow_unsafe_redirect_uris: true, // Do not activate this behavior in production!
+    token_endpoint_auth_method: 'none',
+    client_id: 'mywebsite',
+    grant_types: ['implicit'],
+    response_types: ['id_token'],
+    redirect_uris: ['http://localhost/cb'],
+  },
+  {
+    // ...
+  },
+];
+
+oidc.initialize({ clients }).then(fulfillmentHandler, rejectionHandler);
+```
+
 **via Adapter**  
 Storing client metadata in your storage is recommended for distributed deployments. Also when you
 want to provide a client configuration GUI or plan on changing this data often. Clients get loaded

--- a/lib/consts/client_attributes.js
+++ b/lib/consts/client_attributes.js
@@ -1,4 +1,5 @@
 const RECOGNIZED_METADATA = [
+  'allow_unsafe_redirect_uris',
   'application_type',
   'client_id_issued_at',
   'client_id',
@@ -28,6 +29,7 @@ const RECOGNIZED_METADATA = [
 ];
 
 const DEFAULT = {
+  allow_unsafe_redirect_uris: false,
   application_type: 'web',
   grant_types: ['authorization_code'],
   id_token_signed_response_alg: 'RS256',

--- a/lib/helpers/client_schema.js
+++ b/lib/helpers/client_schema.js
@@ -377,14 +377,16 @@ module.exports = function getSchema(provider) {
 
         switch (this.application_type) { // eslint-disable-line default-case
           case 'web': {
-            const { hostname, protocol } = parseRedirectUri(redirectUri);
+            if (this.allow_unsafe_redirect_uris !== true) {
+              const { hostname, protocol } = parseRedirectUri(redirectUri);
 
-            if (this.grant_types.includes('implicit') && protocol === 'http:') {
-              invalidate('redirect_uris for web clients using implicit flow MUST only register URLs using the https scheme');
-            }
+              if (this.grant_types.includes('implicit') && protocol === 'http:') {
+                invalidate('redirect_uris for web clients using implicit flow MUST only register URLs using the https scheme');
+              }
 
-            if (this.grant_types.includes('implicit') && hostname === 'localhost') {
-              invalidate('redirect_uris for web clients using implicit flow must not be using localhost');
+              if (this.grant_types.includes('implicit') && hostname === 'localhost') {
+                invalidate('redirect_uris for web clients using implicit flow must not be using localhost');
+              }
             }
             break;
           }

--- a/test/configuration/client_metadata.test.js
+++ b/test/configuration/client_metadata.test.js
@@ -299,6 +299,12 @@ describe('Client metadata validation', () => {
       grant_types: ['implicit', 'authorization_code'],
       response_types: ['code id_token'],
     });
+    allows(this.title, ['https://localhost'], undefined, {
+      allow_unsafe_redirect_uris: true,
+      application_type: 'web',
+      grant_types: ['implicit', 'authorization_code'],
+      response_types: ['code id_token'],
+    });
     allows(this.title, ['http://localhost'], undefined, {
       application_type: 'web',
     });
@@ -344,6 +350,12 @@ describe('Client metadata validation', () => {
       },
     });
     rejects(this.title, ['http://foo/bar'], undefined, {
+      application_type: 'web',
+      grant_types: ['implicit'],
+      response_types: ['id_token'],
+    });
+    allows(this.title, ['http://foo/bar'], undefined, {
+      allow_unsafe_redirect_uris: true,
       application_type: 'web',
       grant_types: ['implicit'],
       response_types: ['id_token'],


### PR DESCRIPTION
In our project we use your oidc provider as internal test server. For that it would be very useful to allow unsafe redirect_uris, because we want to use localhost and http for local development.
Please see the updated configuration.md for more details.