### PR TITLE
add clear single client from cache

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,7 +82,7 @@ Available [Client Metadata][client-metadata] is validated as defined by the spec
 
 Note: each oidc-provider caches the clients once they are loaded. When your adapter-stored client
 configuration changes you should either reload your processes or trigger a cache clear
-(`provider.Client.cacheClear()`).
+(`provider.Client.cacheClear()` or `provider.Client.cacheClear(id)`).
 
 **via Provider interface**  
 To add pre-established clients use the `initialize` method on a oidc-provider instance. This accepts

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -327,11 +327,19 @@ module.exports = function getClient(provider) {
       return undefined;
     }
 
-    static cacheClear() {
-      cache.forEach((client) => {
-        if (client.noManage) return;
-        cache.del(client.clientId);
-      });
+    static cacheClear(id) {
+      if (id) {
+        if (cache.has(id)) {
+          const found = cache.get(id);
+          if (found.noManage) return;
+          cache.del(id);
+        }
+      } else {
+        cache.forEach((client) => {
+          if (client.noManage) return;
+          cache.del(client.clientId);
+        });
+      }
     }
 
     static needsSecret(metadata) {

--- a/test/configuration/clients.test.js
+++ b/test/configuration/clients.test.js
@@ -32,6 +32,54 @@ describe('provider.Client', () => {
       expect(await this.provider.Client.find('client')).not.to.be.ok;
     });
 
+    it('keeps the fixed client in cache given id', async function () {
+      expect(await this.provider.Client.find('fixed')).to.be.ok;
+      this.provider.Client.cacheClear('fixed');
+      expect(await this.provider.Client.find('fixed')).to.be.ok;
+    });
+
+    it('removes the adapter backed client from chache given id', async function () {
+      await i(this.provider).clientAdd({
+        client_id: 'client',
+        client_secret: 'secret',
+        redirect_uris: ['https://client.example.com/cb'],
+      });
+      expect(await this.provider.Client.find('client')).to.be.ok;
+      this.provider.Client.cacheClear('client');
+      expect(await this.provider.Client.find('client')).not.to.be.ok;
+    });
+
+    it('removes only wanted adapter backed client from chache', async function () {
+      await i(this.provider).clientAdd({
+        client_id: 'client',
+        client_secret: 'secret',
+        redirect_uris: ['https://client.example.com/cb'],
+      });
+      await i(this.provider).clientAdd({
+        client_id: 'clientStay',
+        client_secret: 'secret',
+        redirect_uris: ['https://client.example.com/cb'],
+      });
+      expect(await this.provider.Client.find('client')).to.be.ok;
+      expect(await this.provider.Client.find('clientStay')).to.be.ok;
+      this.provider.Client.cacheClear('client');
+      expect(await this.provider.Client.find('client')).not.to.be.ok;
+      expect(await this.provider.Client.find('clientStay')).to.be.ok;
+      this.provider.Client.cacheClear('clientStay');
+    });
+
+    it('leaves adapter backed clients intact in case of not found', async function () {
+      await i(this.provider).clientAdd({
+        client_id: 'client',
+        client_secret: 'secret',
+        redirect_uris: ['https://client.example.com/cb'],
+      });
+      expect(await this.provider.Client.find('client')).to.be.ok;
+      this.provider.Client.cacheClear('another');
+      expect(await this.provider.Client.find('client')).to.be.ok;
+      this.provider.Client.cacheClear('client');
+    });
+
     it('has a Schema class getter that can work its magic', async function () {
       expect(this.provider.Client.Schema).to.be.ok;
 

--- a/test/configuration/clients.test.js
+++ b/test/configuration/clients.test.js
@@ -38,7 +38,7 @@ describe('provider.Client', () => {
       expect(await this.provider.Client.find('fixed')).to.be.ok;
     });
 
-    it('removes the adapter backed client from chache given id', async function () {
+    it('removes the adapter backed client from cache given id', async function () {
       await i(this.provider).clientAdd({
         client_id: 'client',
         client_secret: 'secret',
@@ -49,7 +49,7 @@ describe('provider.Client', () => {
       expect(await this.provider.Client.find('client')).not.to.be.ok;
     });
 
-    it('removes only wanted adapter backed client from chache', async function () {
+    it('removes only wanted adapter backed client from cache', async function () {
       await i(this.provider).clientAdd({
         client_id: 'client',
         client_secret: 'secret',


### PR DESCRIPTION
Relates to https://github.com/panva/node-oidc-provider/issues/143.

I was not sure wether it would be preferable to add a different function or use the existing one.