### PR TITLE
2.15.0 changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yay for [SemVer](http://semver.org/).
 **Table of Contents**
 
 <!-- TOC START min:2 max:2 link:true update:true -->
+  - [2.15.0](#2150)
   - [2.14.x](#214x)
   - [2.13.x](#213x)
   - [2.12.0](#2120)
@@ -23,6 +24,14 @@ Yay for [SemVer](http://semver.org/).
   - [^1.0.0](#100)
 
 <!-- TOC END -->
+## 2.15.0
+- [DIFF](https://github.com/panva/node-oidc-provider/compare/v2.14.1...v2.15.0)
+- add `provider.use((ctx, next) => {})` middleware support
+- add `provider.listen(port_or_socket)`
+- add attribute delegates `proxy`, `keys`, `env`, `subdomainOffset` from provider to the underlying
+  koa app
+- updated docs
+
 ## 2.14.x
 ### 2.14.1
 - [DIFF](https://github.com/panva/node-oidc-provider/compare/v2.14.0...v2.14.1)

--- a/README.md
+++ b/README.md
@@ -105,9 +105,16 @@ const clients = [{
 }];
 
 const oidc = new Provider('http://localhost:3000', configuration);
-oidc.initialize({ clients }).then(function () {
-  console.log(oidc.callback); // => express/nodejs style application callback (req, res)
-  console.log(oidc.app); // => koa2.x application
+
+(async () => {
+  await oidc.initialize({ clients });
+  // oidc.callback => express/nodejs style application callback (req, res)
+  // oidc.app => koa2.x application
+  oidc.listen(3000);
+  console.log('oidc-provider listening on port 3000, check http://localhost:3000/.well-known/openid-configuration');
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
 });
 ```
 

--- a/example/index.js
+++ b/example/index.js
@@ -32,14 +32,14 @@ provider.initialize({
     root: path.join(__dirname, 'views'),
   });
 
-  provider.app.keys = ['some secret key', 'and also the old one'];
+  provider.keys = ['some secret key', 'and also the old one'];
 
   if (process.env.NODE_ENV === 'production') {
-    provider.app.proxy = true;
+    provider.proxy = true;
     set(config, 'cookies.short.secure', true);
     set(config, 'cookies.long.secure', true);
 
-    provider.app.middleware.unshift(async (ctx, next) => {
+    provider.use(async (ctx, next) => {
       if (ctx.secure) {
         await next();
       } else if (ctx.method === 'GET' || ctx.method === 'HEAD') {
@@ -115,9 +115,9 @@ provider.initialize({
     await next();
   });
 
-  provider.app.use(router.routes());
+  provider.use(router.routes());
 })
-  .then(() => provider.app.listen(port))
+  .then(() => provider.listen(port))
   .catch((err) => {
     console.error(err);
     process.exit(1);

--- a/lib/helpers/http/index.js
+++ b/lib/helpers/http/index.js
@@ -14,6 +14,4 @@ const httpWrapper = {
   },
 };
 
-httpWrapper.useGot();
-
 module.exports = httpWrapper;

--- a/lib/helpers/initialize_app.js
+++ b/lib/helpers/initialize_app.js
@@ -1,4 +1,3 @@
-const Koa = require('koa');
 const Router = require('koa-router');
 const getCors = require('kcors');
 const instance = require('./weak_cache');
@@ -30,9 +29,7 @@ const discoveryRoute = '/.well-known/openid-configuration';
 
 module.exports = function initializeApp() {
   const configuration = instance(this).configuration();
-  const app = new Koa();
-
-  instance(this).app = app;
+  const { app } = instance(this);
 
   const router = new Router();
   instance(this).router = router;
@@ -140,6 +137,7 @@ module.exports = function initializeApp() {
 
     return next();
   }
+  proxyWarning.firstInternal = true;
 
   app.use(proxyWarning);
   app.use(contextEnsureOidc(this));

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,6 +1,8 @@
 const pkg = require('../package.json');
 
 const assert = require('assert');
+const Koa = require('koa');
+const delegate = require('delegates');
 const http = require('http');
 const events = require('events');
 const _ = require('lodash');
@@ -83,8 +85,8 @@ class Provider extends events.EventEmitter {
       if (path) return _.get(conf, path);
       return conf;
     };
+    instance(this).app = new Koa();
 
-    instance(this).initialized = false;
     instance(this).defaultHttpOptions = _.clone(DEFAULT_HTTP_OPTIONS);
     instance(this).responseModes = new Map();
     instance(this).grantTypeHandlers = new Map();
@@ -105,13 +107,22 @@ class Provider extends events.EventEmitter {
 
   initialize({ adapter, clients = [], keystore } = {}) {
     if (this.initialized) throw new Error('already initialized');
+    if (instance(this).initializing) {
+      throw new Error('already initializing');
+    } else {
+      instance(this).initializing = true;
+    }
 
     return initializeKeystore.call(this, keystore)
       .then(() => initializeAdapter.call(this, adapter))
       .then(() => initializeApp.call(this))
       .then(() => initializeClients.call(this, clients))
       .then(() => { instance(this).initialized = true; })
-      .then(() => this);
+      .then(() => this)
+      .catch((err) => {
+        instance(this).initializing = false;
+        throw err;
+      });
   }
 
   urlFor(name, opt) { return url.resolve(this.issuer, this.pathFor(name, opt)); }
@@ -186,14 +197,36 @@ class Provider extends events.EventEmitter {
     }, this.defaultHttpOptions, values);
   }
 
+  use(fn) {
+    instance(this).app.use(fn);
+    if (this.initialized) {
+      // note: get the fn back since it might've been changed from generator to fn by koa-convert
+      const newMw = instance(this).app.middleware.pop();
+      const internalIndex = this.app.middleware.findIndex(mw => !!mw.firstInternal);
+      this.app.middleware.splice(internalIndex, 0, newMw);
+    }
+  }
+
   get defaultHttpOptions() { return instance(this).defaultHttpOptions; }
 
   set defaultHttpOptions(value) {
     instance(this).defaultHttpOptions = _.merge({}, DEFAULT_HTTP_OPTIONS, value);
   }
 
-  get app() { checkInit(this); return instance(this).app; }
-  get callback() { /* istanbul ignore next */ return this.app.callback(); }
+  get app() {
+    checkInit(this);
+    return instance(this).app;
+  }
+
+  get callback() {
+    return this.app.callback();
+  }
+
+  listen(...args) {
+    /* istanbul ignore next */
+    return this.app.listen(...args);
+  }
+
   get BaseToken() { return instance(this).BaseToken; }
   get Account() { return instance(this).Account; }
   get IdToken() { return instance(this).IdToken; }
@@ -205,10 +238,9 @@ class Provider extends events.EventEmitter {
   get ClientCredentials() { return instance(this).ClientCredentials; }
   get InitialAccessToken() { return instance(this).InitialAccessToken; }
   get RegistrationAccessToken() { return instance(this).RegistrationAccessToken; }
-  get initialized() { return instance(this).initialized; }
+  get initialized() { return !!instance(this).initialized; }
 
   static useGot() { // eslint-disable-line class-methods-use-this
-    /* istanbul ignore next */
     httpWrapper.useGot();
   }
   static useRequest() { // eslint-disable-line class-methods-use-this
@@ -216,5 +248,13 @@ class Provider extends events.EventEmitter {
     httpWrapper.useRequest();
   }
 }
+
+Provider.useGot();
+
+delegate(Provider.prototype, 'app')
+  .access('env')
+  .access('proxy')
+  .access('subdomainOffset')
+  .access('keys');
 
 module.exports = Provider;

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "base64url": "^2.0.0",
     "debug": "^3.1.0",
+    "delegates": "^1.0.0",
     "ejs": "^2.5.2",
     "got": "^8.0.0",
     "http-errors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-provider",
-  "version": "2.14.1",
+  "version": "2.15.0",
   "description": "OpenID Provider (OP) implementation for Node.js OpenID Connect servers.",
   "keywords": [
     "auth",

--- a/test/provider/provider_instance.test.js
+++ b/test/provider/provider_instance.test.js
@@ -27,10 +27,13 @@ describe('provider instance', () => {
   describe('#initialize', () => {
     it('does not allow to be initialized twice', (done) => {
       const provider = new Provider('http://localhost');
-      provider.initialize().then(() => {
-        expect(() => { provider.initialize(); }).to.throw('already initialized');
-        done();
+      provider.initialize({ keystore: {} }).catch(() => {
+        provider.initialize().then(() => {
+          expect(() => { provider.initialize(); }).to.throw('already initialized');
+          done();
+        });
       });
+      expect(() => { provider.initialize(); }).to.throw('already initializing');
     });
   });
 

--- a/test/session_management/authorization.test.js
+++ b/test/session_management/authorization.test.js
@@ -39,7 +39,7 @@ describe('session management', () => {
 
     describe('[session_management] check_session_iframe', () => {
       before(function () {
-        this.provider.app.middleware.unshift(async (ctx, next) => {
+        this.provider.use(async (ctx, next) => {
           ctx.response.set('X-Frame-Options', 'SAMEORIGIN');
           ctx.response.set('Content-Security-Policy', "default-src 'none'; frame-ancestors 'self' example.com *.example.net; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self';");
           await next();

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -260,7 +260,7 @@ module.exports = function testHelper(dir, basename, mountTo) {
           app.use(mount(mountTo, provider.app));
           global.server.on('request', app.callback());
         } else {
-          global.server.on('request', provider.app.callback());
+          global.server.on('request', provider.callback);
         }
 
         agent = supertest(global.server);


### PR DESCRIPTION
2.15.0
- [DIFF](https://github.com/panva/node-oidc-provider/compare/v2.14.1...v2.15.0)
- add `provider.use((ctx, next) => {})` middleware support
- add `provider.listen(port_or_socket)`
- add attribute delegates `proxy`, `keys`, `env`, `subdomainOffset` from provider to the underlying koa app
- updated docs