### PR TITLE
More resilient logout form

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1173,7 +1173,7 @@ async logoutSource(ctx, form) {
 <body>
 <script>
   function logout() {
-    var form = document.forms[0];
+    var form = document.getElementById('op.logoutForm');
     var input = document.createElement('input');
     input.type = 'hidden';
     input.name = 'logout';
@@ -1185,7 +1185,7 @@ async logoutSource(ctx, form) {
 ${form}
 Do you want to logout from OP too?
 <button onclick="logout()">Yes</button>
-<button onclick="document.forms[0].submit()">Please, don't!</button>
+<button onclick="document.getElementById('op.logoutForm').submit()">Please, don't!</button>
 </body>
 </html>`;
 }

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -346,7 +346,7 @@ const DEFAULTS = {
 <body>
   <script>
     function logout() {
-      var form = document.forms[0];
+      var form = document.getElementById('op.logoutForm');
       var input = document.createElement('input');
       input.type = 'hidden';
       input.name = 'logout';
@@ -358,7 +358,7 @@ const DEFAULTS = {
   ${form}
   Do you want to logout from OP too?
   <button onclick="logout()">Yes</button>
-  <button onclick="document.forms[0].submit()">Please, don't!</button>
+  <button onclick="document.getElementById('op.logoutForm').submit()">Please, don't!</button>
 </body>
 </html>`;
   },


### PR DESCRIPTION
by using an id instead of relying on the form being the first form in the web document.

Also renaming op.logoutForm into oidc-provider.logoutForm using a kind of namespace to avoid conflict and make code browsing and discovery easier.