### PR TITLE
Use minDomainAtoms config when calculating session state

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -518,8 +518,26 @@ To disable removing frame-ancestors from Content-Security-Policy and X-Frame-Opt
 const configuration = { features: { sessionManagement: { keepHeaders: true } } };
 ```
 
+To calculate session state, oidc-provider uses the client's host (extracted from
+the `redirect_uri`). The `minDomainAtoms` configuration param can be used to select how
+many domain atoms will be used in the calculation. Setting the value of the param to 1
+would only use the domain's TLD, if set to 2 it will use the domain's TLD and second
+level domain i.e.
 
-**Back-Channel Logout features**  
+| redirect_uri              | minDomainAtoms| Value used for session state calculation  |
+| :------------------------ |:-------------:| -----------------------------------------:|
+| `https://qux.foo.bar.com` |       1       |                             `https://com` |
+| `https://qux.foo.bar.com` |       2       |                         `https://bar.com` |
+| `https://qux.foo.bar.com` |       3       |                     `https://foo.bar.com` |
+
+This can be useful for when a client uses multiple subdomains dynamically. To set the
+value
+```js
+const configuration = { features: { sessionManagement: { minDomainAtoms: 2 } } };
+```
+
+
+**Back-Channel Logout features**
 Enables features described in [Back-Channel Logout 1.0 - draft 04][backchannel-logout].
 ```js
 const configuration = { features: { sessionManagement: true, backchannelLogout: Boolean[false] } };

--- a/lib/actions/authorization/respond.js
+++ b/lib/actions/authorization/respond.js
@@ -23,11 +23,16 @@ module.exports = provider => async function respond(ctx, next) {
   if (instance(provider).configuration('features.sessionManagement')) {
     const salt = crypto.randomBytes(8).toString('hex');
     const state = String(session.authTime());
+    const hostUrl = new URL(params.redirect_uri);
+    const minDomainAtoms = instance(provider).configuration('features.sessionManagement.minDomainAtoms') || 0;
+    const domainAtoms = hostUrl.host.split('.');
+    const domainAtomsLength = domainAtoms.length;
+    const hostDomain = `${hostUrl.protocol}//${domainAtoms.slice(-1 * minDomainAtoms, domainAtomsLength).join('.')}`;
 
     const shasum = crypto.createHash('sha256')
       .update(params.client_id)
       .update(' ')
-      .update(new URL(params.redirect_uri).origin)
+      .update(hostDomain)
       .update(' ')
       .update(state)
       .update(' ')

--- a/lib/actions/check_session.js
+++ b/lib/actions/check_session.js
@@ -2,6 +2,7 @@ const instance = require('../helpers/weak_cache');
 
 module.exports = function checkSessionAction(provider) {
   const removeHeaders = !instance(provider).configuration('features.sessionManagement.keepHeaders');
+  const minDomainAtoms = instance(provider).configuration('features.sessionManagement.minDomainAtoms') || 0;
 
   return async function checkSessionIframe(ctx, next) {
     const debug = ctx.query.debug !== undefined;
@@ -44,7 +45,12 @@ module.exports = function checkSessionAction(provider) {
 
         var opbs = getOPBrowserState(clientId);
         var shaObj = new jsSHA('SHA-256', 'TEXT');
-        shaObj.update(clientId + ' ' + e.origin + ' ' + opbs + ' ' + salt);
+        var hostUrl = document.createElement('a');
+        hostUrl.href = e.origin;
+        var domainAtoms = hostUrl.host.split('.');
+        var domainAtomsLength = domainAtoms.length;
+        var hostDomain = hostUrl.protocol + '//' + domainAtoms.slice(-${minDomainAtoms}, domainAtomsLength).join('.');
+        shaObj.update(clientId + ' ' + hostDomain + ' ' + opbs + ' ' + salt);
         var expected = shaObj.getHash('HEX') + ['.' + salt];
         if (debug && console) console.log('OP computed session state: ' + expected);
 


### PR DESCRIPTION
When the session management feat is enabled, the client's subdomain is used to calculate the session's state, according to recommendations made by the spec. There is a use case, however, where an app might use multiple subdomains without them being actually different OIDC clients. e.g. after logging in `www.myprofile.com` user A gets redirected to `stavros.myprofile.com` while a user B would get redirected to `panva.myprofile.com`. When this happens and we want to use the session management feature, we would want to load it from the original client `www.profile.com` but this isn't possible since the browser would restrict calls to the parent window. So for a setup like this we want an iframe from `stavros.myprofile.com` to be able to validate the session for changes while the client is on another subdomain `www.profile.com`. I've introduced an optional configuration `minDomainAtoms` on the sessionManagement feature to shorten the URL as wished.

The RFC states:
> Here, the session_state is calculated in this particular way, but it is entirely up to the OP how to do it under the requirements defined in this specification.

So I guess it's up to the implementor to optimize. What do you think?