### PR TITLE
Make third party check helper url configurable

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -518,9 +518,10 @@ To disable removing frame-ancestors from Content-Security-Policy and X-Frame-Opt
 const configuration = { features: { sessionManagement: { keepHeaders: true } } };
 ```
 
-In order for the Session Managmenet feature to work, the User-Agent must allow access to Third-Party 
-cookies. oidc-provider checks if this feature is enabled using a [CDN hosted](https://rawgit.com/)
-[iframe][third-party-cookies-git]. It is recommended to host these helper pages on your own
+In order for the Session Management features to avoid endless "changed" events, the User-Agent 
+must allow access to Third-Party cookies. oidc-provider checks if this is enabled 
+using a [CDN hosted](https://rawgit.com/) [iframe][third-party-cookies-git].
+It is recommended to host these helper pages on your own
 (on a different domain from the one you host oidc-provider on). Once hosted, set the
 `cookies.thirdPartyCheckUrl` to an absolute URL for the start page. See [this][third-party-cookies-so] for more info.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -518,11 +518,11 @@ To disable removing frame-ancestors from Content-Security-Policy and X-Frame-Opt
 const configuration = { features: { sessionManagement: { keepHeaders: true } } };
 ```
 
-In order for the Session Managmenet feature to work, the UA must support Third-Party cookies.
-OIDC-provider checks if this feature is enabled using an [iframe][third-party-cookies-git]
-and testing, but you should use your own pages when you go live. To do so, set the
-`cookies.thirdPartyCheckUrl` to a link for the start page. Remember this should be
-hosted under a **different domain**). See [this][third-party-cookies-so] for more info.
+In order for the Session Managmenet feature to work, the User-Agent must allow access to Third-Party 
+cookies. oidc-provider checks if this feature is enabled using a [CDN hosted](https://rawgit.com/)
+[iframe][third-party-cookies-git]. It is recommended to host these helper pages on your own
+(on a different domain from the one you host oidc-provider on). Once hosted, set the
+`cookies.thirdPartyCheckUrl` to an absolute URL for the start page. See [this][third-party-cookies-so] for more info.
 
 **Back-Channel Logout features**  
 Enables features described in [Back-Channel Logout 1.0 - draft 04][backchannel-logout].

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -518,6 +518,11 @@ To disable removing frame-ancestors from Content-Security-Policy and X-Frame-Opt
 const configuration = { features: { sessionManagement: { keepHeaders: true } } };
 ```
 
+In order for the Session Managmenet feature to work, the UA must support Third-Party cookies.
+OIDC-provider checks if this feature is enabled using an [iframe][third-party-cookies-git]
+and testing, but you should use your own pages when you go live. To do so, set the
+`cookies.thirdPartyCheckUrl` to a link for the start page. Remember this should be
+hosted under a **different domain**). See [this][third-party-cookies-so] for more info.
 
 **Back-Channel Logout features**  
 Enables features described in [Back-Channel Logout 1.0 - draft 04][backchannel-logout].
@@ -1429,3 +1434,5 @@ default value:
 [defaults]: /lib/helpers/defaults.js
 [cookie-module]: https://github.com/pillarjs/cookies#cookiesset-name--value---options--
 [keygrip-module]: https://www.npmjs.com/package/keygrip
+[third-party-cookies-git]: https://github.com/mindmup/3rdpartycookiecheck
+[third-party-cookies-so]: https://stackoverflow.com/questions/3550790/check-if-third-party-cookies-are-enabled/7104048#7104048

--- a/lib/actions/check_session.js
+++ b/lib/actions/check_session.js
@@ -2,6 +2,7 @@ const instance = require('../helpers/weak_cache');
 
 module.exports = function checkSessionAction(provider) {
   const removeHeaders = !instance(provider).configuration('features.sessionManagement.keepHeaders');
+  const thirdPartyCheckUrl = instance(provider).configuration('cookies.thirdPartyCheckUrl');
 
   return async function checkSessionIframe(ctx, next) {
     const debug = ctx.query.debug !== undefined;
@@ -83,7 +84,7 @@ module.exports = function checkSessionAction(provider) {
 
     window.addEventListener('message', receiveMessage, false);
   </script>
-  <iframe src="https://cdn.rawgit.com/panva/3rdpartycookiecheck/92fead3f/start.html" style="display:none" />
+  <iframe src="${thirdPartyCheckUrl}" style="display:none" />
 
   </body>
   </html>`;

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -117,6 +117,15 @@ const DEFAULTS = {
      *   and re-signed
      */
     keys: [],
+
+    /*
+     * cookies.thirdPartyCheckUrl
+     *
+     * description: URL for 3rd party cookies support helper
+     * affects: sessionManagement feature
+     *
+     */
+    thirdPartyCheckUrl: 'https://cdn.rawgit.com/panva/3rdpartycookiecheck/92fead3f/start.html',
   },
 
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -93,6 +93,12 @@ class Provider extends events.EventEmitter {
     } else {
       attention.warn('configuration cookies.keys is missing, this option is critical to detect and ignore tampered cookies');
     }
+
+    if (setup.features && setup.features.sessionManagement
+        && (!setup.cookies || !setup.cookies.thirdPartyCheckUrl)) {
+      attention.warn('configuration cookies.thirdPartyCheckUrl is missing, it should be set when running in production');
+    }
+
     instance(this).app = app;
 
     instance(this).defaultHttpOptions = _.clone(DEFAULT_HTTP_OPTIONS);


### PR DESCRIPTION
I've added a configuration option for linking the 1st step of third party cookies support helper. The github dependency is ok for development and testing, but I think every user using this lib in production should provide their own hosting (making sure the host isn't the same as the OIDC one).

https://github.com/panva/node-oidc-provider/issues/221#issuecomment-370734677

> (As a final note — don’t use someone else’s server to test third-party cookies without their permission. It could break spontaneously or inject malware. And it’s rude.)
https://stackoverflow.com/a/7104048