### PR TITLE
fix error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,8 +31,10 @@ Yay for [SemVer](http://semver.org/).
 <!-- TOC END -->
 
 ## Unreleased
-- fix non-spec errors `restricted_response_type` and `restricted_grant_type` to be `unauthorized_client`
-  instead
+- fixes non-spec errors `restricted_response_type` and `restricted_grant_type` to be UnauthorizedClient
+  (`unauthorized_client`) instead as specified in RFC6749
+- adds AccessDenied (`access_denied`) and TemporarilyUnavailable (`temporarily_unavailable`) errors
+  to the list of exported errors
 
 ## 4.0.1
 - 2018-06-01 [DIFF](https://github.com/panva/node-oidc-provider/compare/v3.0.3...v4.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Yay for [SemVer](http://semver.org/).
 **Table of Contents**
 
 <!-- TOC START min:2 max:2 link:true update:true -->
+- [Unreleased](#unreleased)
 - [4.0.1](#401)
 - [3.0.x](#30x)
 - [2.18.x](#218x)
@@ -28,6 +29,11 @@ Yay for [SemVer](http://semver.org/).
 - [2.0.x](#20x)
 
 <!-- TOC END -->
+
+## Unreleased
+- fix non-spec errors `restricted_response_type` and `restricted_grant_type` to be `unauthorized_client`
+  instead
+
 ## 4.0.1
 - 2018-06-01 [DIFF](https://github.com/panva/node-oidc-provider/compare/v3.0.3...v4.0.1)
 

--- a/lib/actions/authorization/check_response_type.js
+++ b/lib/actions/authorization/check_response_type.js
@@ -1,7 +1,7 @@
 const instance = require('../../helpers/weak_cache');
 const {
   UnsupportedResponseType,
-  RestrictedResponseType,
+  UnauthorizedClient,
 } = require('../../helpers/errors');
 
 /*
@@ -9,7 +9,7 @@ const {
  * configuration
  *
  * @throws: unsupported_response_type
- * @throws: restricted_response_type
+ * @throws: unauthorized_client
  */
 module.exports = provider => async function checkResponseType(ctx, next) {
   const { params } = ctx.oidc;
@@ -20,7 +20,7 @@ module.exports = provider => async function checkResponseType(ctx, next) {
   }
 
   if (!ctx.oidc.client.responseTypeAllowed(params.response_type)) {
-    ctx.throw(new RestrictedResponseType());
+    ctx.throw(new UnauthorizedClient('response_type not allowed for this client'));
   }
 
   await next();

--- a/lib/actions/token.js
+++ b/lib/actions/token.js
@@ -6,7 +6,7 @@ const instance = require('../helpers/weak_cache');
 const {
   InvalidRequest,
   UnsupportedGrantType,
-  RestrictedGrantType,
+  UnauthorizedClient,
 } = require('../helpers/errors');
 
 const noCache = require('../shared/no_cache');
@@ -32,7 +32,7 @@ module.exports = function tokenAction(provider) {
 
     async function allowedGrantTypeCheck(ctx, next) {
       if (!ctx.oidc.client.grantTypeAllowed(ctx.oidc.params.grant_type)) {
-        ctx.throw(new RestrictedGrantType());
+        ctx.throw(new UnauthorizedClient('requested grant type is restricted to this client'));
       }
 
       await next();

--- a/lib/helpers/errors.js
+++ b/lib/helpers/errors.js
@@ -94,8 +94,9 @@ const classes = [
   ['registration_not_supported', 'registration parameter provided but not supported'],
   ['request_not_supported', 'request parameter provided but not supported'],
   ['request_uri_not_supported', 'request_uri parameter provided but not supported'],
-  ['restricted_grant_type', 'requested grant type is restricted to this client'],
-  ['restricted_response_type', 'response_type not allowed for this client'],
+  ['restricted_grant_type', 'requested grant type is restricted to this client'], // TODO: Deprecated Error
+  ['restricted_response_type', 'response_type not allowed for this client'], // TODO: Deprecated Error
+  ['unauthorized_client'],
   ['unsupported_grant_type', 'unsupported grant_type requested'],
   ['unsupported_response_mode', 'unsupported response_mode requested'],
   ['unsupported_response_type', 'unsupported response_type requested'],

--- a/lib/helpers/errors.js
+++ b/lib/helpers/errors.js
@@ -88,6 +88,8 @@ class InvalidGrant extends OIDCProviderError {
 }
 
 const classes = [
+  ['temporarily_unavailable'],
+  ['access_denied'],
   ['invalid_request_object'],
   ['invalid_request_uri'],
   ['redirect_uri_mismatch', 'redirect_uri did not match any client\'s registered redirect_uris'],

--- a/test/client_auth/client_auth.test.js
+++ b/test/client_auth/client_auth.test.js
@@ -10,7 +10,7 @@ const { expect } = require('chai');
 const route = '/token';
 
 const tokenAuthSucceeded = {
-  error: 'restricted_grant_type',
+  error: 'unauthorized_client',
   error_description: 'requested grant type is restricted to this client',
 };
 

--- a/test/core/basic/code.authorization.test.js
+++ b/test/core/basic/code.authorization.test.js
@@ -590,7 +590,7 @@ describe('BASIC code', () => {
           .expect(auth.validatePresence(['error', 'error_description', 'state']))
           .expect(auth.validateState)
           .expect(auth.validateClientLocation)
-          .expect(auth.validateError('restricted_response_type'))
+          .expect(auth.validateError('unauthorized_client'))
           .expect(auth.validateErrorDescription('response_type not allowed for this client'));
       });
 

--- a/test/provider/provider_class.test.js
+++ b/test/provider/provider_class.test.js
@@ -9,6 +9,7 @@ describe('Provider', () => {
       expect(Provider[method]).to.equal(JWK[method]);
     });
     expect(Provider.errors).to.have.keys([
+      'AccessDenied',
       'InvalidClient',
       'InvalidClientAuth',
       'InvalidClientMetadata',
@@ -24,6 +25,7 @@ describe('Provider', () => {
       'RequestUriNotSupported',
       'RestrictedGrantType',
       'RestrictedResponseType',
+      'TemporarilyUnavailable',
       'UnauthorizedClient',
       'UnsupportedGrantType',
       'UnsupportedResponseMode',

--- a/test/provider/provider_class.test.js
+++ b/test/provider/provider_class.test.js
@@ -24,6 +24,7 @@ describe('Provider', () => {
       'RequestUriNotSupported',
       'RestrictedGrantType',
       'RestrictedResponseType',
+      'UnauthorizedClient',
       'UnsupportedGrantType',
       'UnsupportedResponseMode',
       'UnsupportedResponseType',


### PR DESCRIPTION
- fixes non-spec errors `restricted_response_type` and `restricted_grant_type` to be UnauthorizedClient (`unauthorized_client`) instead as specified in RFC6749
- adds AccessDenied (`access_denied`) and TemporarilyUnavailable (`temporarily_unavailable`) errors to the list of exported errors