### PR TITLE
storage and token formats support (legacy, opaque, JWT)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Yay for [SemVer](http://semver.org/).
 
 **Table of Contents**
 
-<!-- TOC START min:2 max:2 link:true update:true -->
+<!-- TOC depthFrom:2 depthTo:2 withLinks:1 updateOnSave:1 orderedList:0 -->
+
 - [Unreleased](#unreleased)
 - [4.0.x](#40x)
 - [3.0.x](#30x)
@@ -28,7 +29,7 @@ Yay for [SemVer](http://semver.org/).
 - [2.1.0](#210)
 - [2.0.x](#20x)
 
-<!-- TOC END -->
+<!-- /TOC -->
 
 ## Unreleased
 - [DIFF](https://github.com/panva/node-oidc-provider/compare/v4.0.3...master)
@@ -37,7 +38,7 @@ Yay for [SemVer](http://semver.org/).
 
 Added `formats` configuration option. This option allows to configure the token storage and value
 formats. The different values change how a token value is generated as well as what properties get
-sent to the adapter for storage. Defined three formats:
+sent to the adapter for storage. Three formats are defined:
 
 - `legacy` is the current and default format until next major release. no changes in the format sent
   to adapter
@@ -48,10 +49,11 @@ sent to the adapter for storage. Defined three formats:
   property `jwt`. The signing algorithm for these tokens uses the client's
   `id_token_signed_response_alg` value and falls back to `RS256` for tokens with no relation to a
   client or when the client's alg is `none`
-- this feature uses the previously defined public token API of `[klass].prototype.getValueAndPayload,
+
+This feature uses the previously defined public token API of `[klass].prototype.getValueAndPayload,
 [klass].prototype.constructor.getTokenId, [klass].prototype.constructor.verify` and adds a new one
-`[klass].prototype.constructor.generateTokenId`. See the inline comment docs for more detail on those
-- further format ideas and suggestions are welcome
+`[klass].prototype.constructor.generateTokenId`. See the inline comment docs for more detail on those.
+Further format ideas and suggestions are welcome.
 
 **Fixes**
 - fixed edge cases where client and provider signing keys would be used for encryption and vice versa

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ Further format ideas and suggestions are welcome.
 - fixed `defaultHttpOptions` to be as documented
 - adjusted error_description to be more descriptive when PKCE plain value fallback is not possible
   due to the plain method not being supported
+- fixed `audiences` helper results to assert that an array of strings is returned
 
 ## 4.0.x
 ### 4.0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Yay for [SemVer](http://semver.org/).
 ## Unreleased
 - [DIFF](https://github.com/panva/node-oidc-provider/compare/v4.0.3...master)
 - fixed edge cases where client and provider signing keys would be used for encryption and vice versa
+- fixed client `request_object_signing_alg` and `contact` validations
+- fixed `defaultHttpOptions` to be as documented
 - adjusted error_description to be more descriptive when PKCE plain value fallback is not possible
   due to the plain method not being supported
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,28 @@ Yay for [SemVer](http://semver.org/).
 
 ## Unreleased
 - [DIFF](https://github.com/panva/node-oidc-provider/compare/v4.0.3...master)
+
+**New Features**
+
+Added `formats` configuration option. This option allows to configure the token storage and value
+formats. The different values change how a token value is generated as well as what properties get
+sent to the adapter for storage. Defined three formats:
+
+- `legacy` is the current and default format until next major release. no changes in the format sent
+  to adapter
+- `opaque` formatted tokens have a different value then `legacy` and in addition store what was in
+  legacy format encoded under `payload` as root properties, this makes analysing the data in your
+  storage way easier
+- `jwt` formatted tokens are issued as JWTs and stored the same as `opaque` only with additional
+  property `jwt`. The signing algorithm for these tokens uses the client's
+  `id_token_signed_response_alg` value and falls back to `RS256` for tokens with no relation to a
+  client or when the client's alg is `none`
+- this feature uses the previously defined public token API of `[klass].prototype.getValueAndPayload,
+[klass].prototype.constructor.getTokenId, [klass].prototype.constructor.verify` and adds a new one
+`[klass].prototype.constructor.generateTokenId`. See the inline comment docs for more detail on those
+- further format ideas and suggestions are welcome
+
+**Fixes**
 - fixed edge cases where client and provider signing keys would be used for encryption and vice versa
 - fixed client `request_object_signing_alg` and `contact` validations
 - fixed `defaultHttpOptions` to be as documented
@@ -58,7 +80,7 @@ Yay for [SemVer](http://semver.org/).
 ### 4.0.1
 - 2018-06-01 [DIFF](https://github.com/panva/node-oidc-provider/compare/v3.0.3...v4.0.1)
 
-#### Breaking changes
+**Breaking changes**
 - minimal version of node lts/carbon is required (>=8.9.0)
 - **Client Metadata** - null property values are no longer ignored
   - clients pushed through `#initialize()` must not submit properties with null values
@@ -159,7 +181,7 @@ Yay for [SemVer](http://semver.org/).
   - removed deprecated `#provider.setSessionAccountId()` helper method. Use `#provider.setProviderSession()`
     instead
 
-#### Enhancements
+**Enhancements**
 - **Session Changes**
   - stored sessions now have an `exp` property allowing the provider to ignore expired but
     still returned sessions

--- a/README.md
+++ b/README.md
@@ -13,12 +13,16 @@ introduces various breaking changes. See the CHANGELOG for a complete list of de
 
 **Table of Contents**
 
-  - [Implemented specs & features](#implemented-specs--features)
-  - [Certification](#certification)
-  - [Get started](#get-started)
-  - [Configuration and Initialization](#configuration-and-initialization)
-  - [Debugging](#debugging)
-  - [Events](#events)
+<!-- TOC depthFrom:2 depthTo:3 withLinks:1 updateOnSave:1 orderedList:0 -->
+
+- [Implemented specs & features](#implemented-specs--features)
+- [Certification](#certification)
+- [Get started](#get-started)
+- [Configuration and Initialization](#configuration-and-initialization)
+- [Debugging](#debugging)
+- [Events](#events)
+
+<!-- /TOC -->
 
 ## Implemented specs & features
 
@@ -61,7 +65,7 @@ of the OpenID Connect™ protocol.
 [![build][conformance-image]][conformance-url]
 
 
-## Sponsor
+<h2>Sponsor</h2>
 <table>
   <tbody>
     <tr>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1056,13 +1056,13 @@ default value:
   requestUri: true,
   oauthNativeApps: true,
   pkce: true,
+  alwaysIssueRefresh: false,
   backchannelLogout: false,
-  frontchannelLogout: false,
   claimsParameter: false,
   clientCredentials: false,
   encryption: false,
+  frontchannelLogout: false,
   introspection: false,
-  alwaysIssueRefresh: false,
   registration: false,
   registrationManagement: false,
   request: false,
@@ -1096,6 +1096,24 @@ async findById(ctx, sub, token) {
     },
   };
 }
+```
+
+### formats
+
+TODO  
+
+affects: properties passed to adapters for token types, issued token formats  
+recommendation: set default to `opaque` if you're still developing your application, `legacy` will not be the default in the major versions coming forward. It is not recommended to set `jwt` as default, if you need it, it's most likely just for Access Tokens.  
+
+default value:
+```js
+{ default: 'legacy',
+  AccessToken: undefined,
+  AuthorizationCode: undefined,
+  RefreshToken: undefined,
+  ClientCredentials: undefined,
+  InitialAccessToken: undefined,
+  RegistrationAccessToken: undefined }
 ```
 
 ### frontchannelLogoutPendingSource

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,13 +1,14 @@
 # Configuration
 
-oidc-provider allows to be extended and configured in various ways to fit a variety of uses. You
-SHOULD tell your instance how to find your user accounts, where to store and retrieve persisted data
-from and where your user-interaction happens. The [example](/example) application is a good starting
-point to get an idea of what you should provide.
+oidc-provider allows to be extended and configured in various ways to fit a variety of use cases. You
+will have to configure your instance with how to find your user accounts, where to store and retrieve
+persisted data from and where your end-user interactions happen. The [example](/example) application
+is a good starting point to get an idea of what you should provide.
 
 **Table of Contents**
 
-<!-- TOC START min:2 max:3 link:true update:true -->
+<!-- TOC depthFrom:2 depthTo:3 withLinks:1 updateOnSave:1 orderedList:2 -->
+
 - [Default configuration values](#default-configuration-values)
 - [Accounts](#accounts)
 - [Clients](#clients)
@@ -28,49 +29,51 @@ point to get an idea of what you should provide.
 - [Registering module middlewares (helmet, ip-filters, rate-limiters, etc)](#registering-module-middlewares-helmet-ip-filters-rate-limiters-etc)
 - [Pre- and post-middlewares](#pre--and-post-middlewares)
 - [Mounting oidc-provider](#mounting-oidc-provider)
-  - [to an express application](#to-an-express-application)
-  - [to a koa application](#to-a-koa-application)
+	- [to an express application](#to-an-express-application)
+	- [to a koa application](#to-a-koa-application)
 - [Trusting TLS offloading proxies](#trusting-tls-offloading-proxies)
+- [Aggregated and Distributed claims](#aggregated-and-distributed-claims)
 - [Configuration options](#configuration-options)
-  - [acrValues](#acrvalues)
-  - [audiences](#audiences)
-  - [claims](#claims)
-  - [clientCacheDuration](#clientcacheduration)
-  - [clockTolerance](#clocktolerance)
-  - [cookies](#cookies)
-  - [cookies.keys](#cookieskeys)
-  - [cookies.long](#cookieslong)
-  - [cookies.names](#cookiesnames)
-  - [cookies.short](#cookiesshort)
-  - [cookies.thirdPartyCheckUrl](#cookiesthirdpartycheckurl)
-  - [discovery](#discovery)
-  - [extraClientMetadata](#extraclientmetadata)
-  - [extraClientMetadata.properties](#extraclientmetadataproperties)
-  - [extraClientMetadata.validator](#extraclientmetadatavalidator)
-  - [extraParams](#extraparams)
-  - [features](#features)
-  - [findById](#findbyid)
-  - [frontchannelLogoutPendingSource](#frontchannellogoutpendingsource)
-  - [interactionCheck](#interactioncheck)
-  - [interactionUrl](#interactionurl)
-  - [introspectionEndpointAuthMethods](#introspectionendpointauthmethods)
-  - [logoutSource](#logoutsource)
-  - [pairwiseSalt](#pairwisesalt)
-  - [postLogoutRedirectUri](#postlogoutredirecturi)
-  - [prompts](#prompts)
-  - [refreshTokenRotation](#refreshtokenrotation)
-  - [renderError](#rendererror)
-  - [responseTypes](#responsetypes)
-  - [revocationEndpointAuthMethods](#revocationendpointauthmethods)
-  - [routes](#routes)
-  - [scopes](#scopes)
-  - [subjectTypes](#subjecttypes)
-  - [tokenEndpointAuthMethods](#tokenendpointauthmethods)
-  - [ttl](#ttl)
-  - [uniqueness](#uniqueness)
-  - [unsupported](#unsupported)
+	- [acrValues](#acrvalues)
+	- [audiences](#audiences)
+	- [claims](#claims)
+	- [clientCacheDuration](#clientcacheduration)
+	- [clockTolerance](#clocktolerance)
+	- [cookies](#cookies)
+	- [cookies.keys](#cookieskeys)
+	- [cookies.long](#cookieslong)
+	- [cookies.names](#cookiesnames)
+	- [cookies.short](#cookiesshort)
+	- [cookies.thirdPartyCheckUrl](#cookiesthirdpartycheckurl)
+	- [discovery](#discovery)
+	- [extraClientMetadata](#extraclientmetadata)
+	- [extraClientMetadata.properties](#extraclientmetadataproperties)
+	- [extraClientMetadata.validator](#extraclientmetadatavalidator)
+	- [extraParams](#extraparams)
+	- [features](#features)
+	- [findById](#findbyid)
+	- [formats](#formats)
+	- [frontchannelLogoutPendingSource](#frontchannellogoutpendingsource)
+	- [interactionCheck](#interactioncheck)
+	- [interactionUrl](#interactionurl)
+	- [introspectionEndpointAuthMethods](#introspectionendpointauthmethods)
+	- [logoutSource](#logoutsource)
+	- [pairwiseSalt](#pairwisesalt)
+	- [postLogoutRedirectUri](#postlogoutredirecturi)
+	- [prompts](#prompts)
+	- [refreshTokenRotation](#refreshtokenrotation)
+	- [renderError](#rendererror)
+	- [responseTypes](#responsetypes)
+	- [revocationEndpointAuthMethods](#revocationendpointauthmethods)
+	- [routes](#routes)
+	- [scopes](#scopes)
+	- [subjectTypes](#subjecttypes)
+	- [tokenEndpointAuthMethods](#tokenendpointauthmethods)
+	- [ttl](#ttl)
+	- [uniqueness](#uniqueness)
+	- [unsupported](#unsupported)
 
-<!-- TOC END -->
+<!-- /TOC -->
 
 ## Default configuration values
 Default values are available for all configuration options. Available in [code][defaults] as well as
@@ -86,28 +89,12 @@ to the claims your issuer supports. Tell oidc-provider how to find your account 
 
 ```js
 const oidc = new Provider('http://localhost:3000', {
+  formats: { default: 'opaque' },
   async findById(ctx, id) {
     return {
       accountId: id,
       async claims(use, scope) { return { sub: id }; },
     };
-  }
-});
-```
-
-**Aggregated and Distributed claims**  
-Returning aggregated and distributed claims is as easy as having your Account#claims method return
-the two necessary members `_claim_sources` and `_claim_names` with the
-[expected][aggregated-distributed-claims] properties. oidc-provider will include only the
-sources for claims that are part of the request scope, omitting the ones that the RP did not request
-and leaving out the entire `_claim_sources` and `_claim_sources` if they bear no requested claims.
-
-Note: to make sure the RPs can expect these claims you should configure your discovery to return
-the respective claim types via the `claim_types_supported` property.
-```js
-const oidc = new Provider('http://localhost:3000', {
-  discovery: {
-    claim_types_supported: ['normal', 'aggregated', 'distributed']
   }
 });
 ```
@@ -126,14 +113,17 @@ endpoint authentication, Session Management, Front and Back-Channel Logout, etc.
 
 Note: each oidc-provider caches the clients once they are loaded. When your adapter-stored client
 configuration changes you should either reload your processes or trigger a cache clear
-(`provider.Client.cacheClear()` or `provider.Client.cacheClear(id)`).
+(`provider.Client.cacheClear()` to clear the complete cache or `provider.Client.cacheClear(id)` to
+clear a specific client instance from cache).
 
 **via Provider interface**  
 To add pre-established clients use the `initialize` method on a oidc-provider instance. This accepts
 a clients array with metadata objects and rejects when the client metadata would be invalid.
 
 ```js
-const oidc = new Provider('http://localhost:3000');
+const provider = new Provider('http://localhost:3000', {
+  formats: { default: 'opaque' },
+});
 const clients = [
   {
     token_endpoint_auth_method: 'none',
@@ -147,7 +137,7 @@ const clients = [
   },
 ];
 
-oidc.initialize({ clients }).then(fulfillmentHandler, rejectionHandler);
+provider.initialize({ clients }).then(fulfillmentHandler, rejectionHandler);
 ```
 
 **via Adapter**  
@@ -166,11 +156,12 @@ See [Certificates](/docs/keystores.md).
 
 ## Configuring available claims
 The `claims` configuration parameter can be used to define which claims fall under what scope
-as well as to expose additional claims that are available to RPs via the claims authorization
+as well as to expose additional claims that are available to RPs via the `claims` authorization
 parameter. The configuration value uses the following scheme:
 
 ```js
 new Provider('http://localhost:3000', {
+  formats: { default: 'opaque' },
   claims: {
     [scope name]: ['claim name', 'claim name'],
     // or
@@ -188,6 +179,7 @@ To follow the [Core-defined scope-to-claim mapping][core-account-claims] use:
 
 ```js
 new Provider('http://localhost:3000', {
+  formats: { default: 'opaque' },
   claims: {
     address: ['address'],
     email: ['email', 'email_verified'],
@@ -210,13 +202,15 @@ long as you develop, configure and generally just play around since every time y
 process all information will be lost. As soon as you cannot live with this limitation you will be
 required to provide your own custom adapter constructor for oidc-provider to
 use. This constructor will be called for every model accessed the first time it
-is needed. A static `connect` method is called if present during the initialize phase.
+is needed. A static `connect` method is called if present during the `provider.initialize()` call.
 
 ```js
 const MyAdapter = require('./my_adapter');
-const oidc = new Provider('http://localhost:3000');
-oidc.initialize({
-  adapter: MyAdapter
+const provider = new Provider('http://localhost:3000', {
+  formats: { default: 'opaque' },
+});
+provider.initialize({
+  adapter: MyAdapter,
 });
 ```
 
@@ -236,7 +230,7 @@ those in, here is how oidc-provider allows you to do so:
 When oidc-provider cannot fulfill the authorization request for any of the possible reasons (missing
 user session, requested ACR not fulfilled, prompt requested, ...) it will resolve an `interactionUrl`
 (configurable) and redirect the User-Agent to that url. Before doing so it will save a short-lived
-session and its identifier dumped into a cookie scoped to the resolved interaction path.
+session and dump its identifier into a cookie scoped to the resolved interaction path.
 
 This session contains:
 
@@ -277,14 +271,12 @@ router.get('/interaction/:grant', async (ctx, next) => {
 ```js
 // with express
 expressApp.post('/interaction/:grant/login', async (req, res) => {
-  await provider.interactionFinished(req, res, results); // result object below
-  // ...
+  return provider.interactionFinished(req, res, results); // result object below
 });
 
 // with koa
 router.post('/interaction/:grant', async (ctx, next) => {
-  await provider.interactionFinished(ctx.req, ctx.res, results); // result object below
-  // ...
+  return provider.interactionFinished(ctx.req, ctx.res, results); // result object below
 });
 
 // results should be an object with some or all the following properties
@@ -500,8 +492,8 @@ const configuration = { features: { revocation: Boolean[false] } };
 
 **OAuth 2.0 Native Apps Best Current Practice**
 Changes `redirect_uris` validations for clients with application_type `native` to those defined in
-[OAuth 2.0 for Native Apps][oauth-native-apps]. If pkce is not enabled it will be enabled
-automatically so that AppAuth SDKs work out of the box. (🤞)
+[OAuth 2.0 for Native Apps][oauth-native-apps]. If PKCE is not enabled it will be force-enabled
+automatically.
 ```js
 const configuration = { features: { oauthNativeApps: Boolean[true] } };
 ```
@@ -519,7 +511,7 @@ To disable removing frame-ancestors from Content-Security-Policy and X-Frame-Opt
 const configuration = { features: { sessionManagement: { keepHeaders: true } } };
 ```
 
-In order for the Session Management features to avoid endless "changed" events, the User-Agent
+In order for the Session Management features to avoid endless `"changed"` events, the User-Agent
 must allow access to Third-Party cookies. oidc-provider checks if this is enabled
 using a [CDN hosted](https://rawgit.com/) [iframe][third-party-cookies-git].
 It is recommended to host these helper pages on your own
@@ -546,12 +538,12 @@ Enables features described in [Dynamic Client Registration 1.0][registration].
 const configuration = { features: { registration: Boolean[false] } };
 ```
 
-To provide your own factory to get a new client_id:
+To provide your own client_id value factory:
 ```js
 const configuration = { features: { registration: { idFactory: () => randomValue() } } };
 ```
 
-To provide your own factory to get a random client_secret:
+To provide your own client_secret value factory:
 ```js
 const configuration = { features: { registration: { secretFactory: () => randomValue() } } };
 ```
@@ -567,7 +559,7 @@ registration to be an object like so:
 ```js
 const configuration = { features: { registration: { initialAccessToken: true } } };
 
-// adding a token and retrieving it's value
+// adding a token and retrieving its value
 new (provider.InitialAccessToken)({}).save().then(console.log);
 ```
 
@@ -644,11 +636,12 @@ provider.registerGrantType('password', function passwordGrantTypeFactory(provide
 
 
 ## Extending Authorization with Custom Parameters
-You can extend the whitelisted parameters of authorization/authentication endpoint beyond the
-defaults. These will be available in ctx.oidc.params as well as passed to the interaction session
+You can extend the whitelisted parameters of authorization endpoint beyond the defaults. These will
+be available in `ctx.oidc.params` as well as passed to the interaction session
 object for you to read.
 ```js
 const oidc = new Provider('http://localhost:3000', {
+  formats: { default: 'opaque' },
   extraParams: ['utm_campaign', 'utm_medium', 'utm_source', 'utm_term'],
 });
 ```
@@ -658,10 +651,11 @@ const oidc = new Provider('http://localhost:3000', {
 You can extend the returned discovery properties beyond the defaults
 ```js
 const oidc = new Provider('http://localhost:3000', {
+  formats: { default: 'opaque' },
   discovery: {
     service_documentation: 'http://server.example.com/connect/service_documentation.html',
     ui_locales_supported: ['en-US', 'en-GB', 'en-CA', 'fr-FR', 'fr-CA'],
-    version: '3.1'
+    version: '3.1',
   }
 });
 ```
@@ -673,9 +667,10 @@ See the specific routes in [default configuration][defaults].
 
 ```js
 const oidc = new Provider('http://localhost:3000', {
+  formats: { default: 'opaque' },
   routes: {
     authorization: '/authz',
-    certificates: '/jwks'
+    certificates: '/jwks.json',
   }
 });
 ```
@@ -737,6 +732,7 @@ Confirm your httpOptions by
 console.log('httpOptions %j', provider.defaultHttpOptions);
 ```
 
+
 ## Authentication Context Class Reference
 Supply an array of string values to acrValues configuration option to set `acr_values_supported`.
 Passing an empty array disables the acr claim and removes `acr_values_supported` from discovery.
@@ -782,23 +778,18 @@ provider.use(async (ctx, next) => {
 
 ## Mounting oidc-provider
 The following snippets show how a provider instance can be mounted to existing applications with a
-path prefix. As shown it is recommended to rewrite the well-known uri calls so that they get handled
-by the provider.
+path prefix.
 
 ### to an express application
 ```js
-const rewrite = require('express-urlrewrite');
 const prefix = '/oidc';
-expressApp.use(rewrite('/.well-known/*', `${prefix}/.well-known/$1`));
 expressApp.use(prefix, oidc.callback);
 ```
 
 ### to a koa application
 ```js
-const rewrite = require('koa-rewrite');
 const mount = require('koa-mount');
 const prefix = '/oidc';
-koaApp.use(rewrite('/.well-known/(.*)', `${prefix}/.well-known/$1`));
 koaApp.use(mount(prefix, oidc.app));
 ```
 
@@ -840,12 +831,32 @@ location / {
 }
 ```
 
+
+## Aggregated and Distributed claims
+Returning aggregated and distributed claims is as easy as having your Account#claims method return
+the two necessary members `_claim_sources` and `_claim_names` with the
+[expected][aggregated-distributed-claims] properties. oidc-provider will include only the
+sources for claims that are part of the request scope, omitting the ones that the RP did not request
+and leaving out the entire `_claim_sources` and `_claim_sources` if they bear no requested claims.
+
+Note: to make sure the RPs can expect these claims you should configure your discovery to return
+the respective claim types via the `claim_types_supported` property.
+```js
+const oidc = new Provider('http://localhost:3000', {
+  formats: { default: 'opaque' },
+  discovery: {
+    claim_types_supported: ['normal', 'aggregated', 'distributed']
+  }
+});
+```
+
+
 ## Configuration options
 
 <!-- START CONF OPTIONS -->
 ### acrValues
 
-Array of strings, the Authentication Context Class References that OP supports. First one in the list will be the one used for authentication requests unless one was provided as part of an interaction result. Use a value with 'session' meaning as the first.  
+Array of strings, the Authentication Context Class References that OP supports.  
 
 affects: discovery, ID Token acr claim values  
 
@@ -856,9 +867,9 @@ default value:
 
 ### audiences
 
-Helper used by the OP to push additional audiences to issued ID Tokens and other signed responses. The return value should either be falsy to omit adding additional audiences or an array of strings to push.  
+Helper used by the OP to push additional audiences to issued ID, Access and ClientCredentials Tokens as well as other signed responses. The return value should either be falsy to omit adding additional audiences or an array of strings to push.  
 
-affects: id token audiences, signed userinfo audiences  
+affects: id token audiences, access token audiences, client credential audiences, signed userinfo audiences  
 
 default value:
 ```js
@@ -894,6 +905,7 @@ default value:
 A `Number` value (in seconds) describing how long a dynamically loaded client should remain cached.  
 
 affects: adapter-backed client cache duration  
+recommendation: do not set to a low value or completely disable this, client properties are validated upon loading up and this may be potentially an expensive operation, sometimes even requesting resources from the network (i.e. client jwks_uri, sector_identifier_uri etc).  
 
 default value:
 ```js
@@ -904,7 +916,7 @@ Infinity
 
 A `Number` value (in seconds) describing the allowed system clock skew  
 
-affects: JWT (ID token, client assertion) validations.  
+affects: JWT (ID token, client assertion) and Token expiration validations  
 recommendation: Set to a reasonable value (60) to cover server-side client and oidc-provider server clock skew  
 
 default value:
@@ -1026,8 +1038,8 @@ default value:
 ```js
 validator(key, value, metadata) {
   // validations for key, value, other related metadata
-  // throw new Provider.InvalidClientMetadata() to reject the client metadata (see all errors on
-  //   Provider)
+  // throw new Provider.errors.InvalidClientMetadata() to reject the client metadata (see all
+  //   errors on Provider.errors)
   // metadata[key] = value; to assign values
   // return not necessary, metadata is already a reference.
 }
@@ -1035,7 +1047,7 @@ validator(key, value, metadata) {
 
 ### extraParams
 
-Pass an iterable object (i.e. Array or set of strings) to extend the parameters recognized by the authorization endpoint. These parameters are then available in ctx.oidc.params as well as passed to interaction session details  
+Pass an iterable object (i.e. Array or set of strings) to extend the parameters recognised by the authorization endpoint. These parameters are then available in `ctx.oidc.params` as well as passed to interaction session details  
 
 affects: authorization, interaction  
 
@@ -1072,7 +1084,7 @@ default value:
 
 ### findById
 
-Helper used by the OP to load your account and retrieve it's available claims. The return value should be a Promise and #claims() can return a Promise too  
+Helper used by the OP to load an account and retrieve its available claims. The return value should be a Promise and #claims() can return a Promise too  
 
 affects: authorization, authorization_code and refresh_token grants, id token claims  
 
@@ -1100,7 +1112,10 @@ async findById(ctx, sub, token) {
 
 ### formats
 
-TODO  
+This option allows to configure the token storage and value formats. The different values change how a token value is generated as well as what properties get sent to the adapter for storage. Three formats are defined, see the expected [Adapter API](/example/my_adapter.js) for each format's specifics.  
+- `legacy` is the current and default format until next major release. No changes in the format sent to adapter. 
+- `opaque` formatted tokens have a different value then `legacy` and in addition store what was in legacy format encoded under `payload` as root properties, this makes analysing the data in your storage way easier 
+- `jwt` formatted tokens are issued as JWTs and stored the same as `opaque` only with additional property `jwt`. The signing algorithm for these tokens uses the client's `id_token_signed_response_alg` value and falls back to `RS256` for tokens with no relation to a client or when the client's alg is `none`  
 
 affects: properties passed to adapters for token types, issued token formats  
 recommendation: set default to `opaque` if you're still developing your application, `legacy` will not be the default in the major versions coming forward. It is not recommended to set `jwt` as default, if you need it, it's most likely just for Access Tokens.  
@@ -1289,7 +1304,9 @@ default value:
 
 ### refreshTokenRotation
 
-Configures if and how the OP rotates refresh tokens after they are used. Supported values are 1) `"none"` when refresh tokens are not rotated and their initial expiration date is final or 2) `"rotateAndConsume"` when refresh tokens are rotated when used, current token is marked as consumed and new one is issued with new TTL, when a consumed refresh token is encountered an error is returned instead and the whole token chain (grant) is revoked.  
+Configures if and how the OP rotates refresh tokens after they are used. Supported values are 
+- `none` when refresh tokens are not rotated and their initial expiration date is final or 
+- `rotateAndConsume` when refresh tokens are rotated when used, current token is marked as consumed and new one is issued with new TTL, when a consumed refresh token is encountered an error is returned instead and the whole token chain (grant) is revoked  
 
 affects: refresh token rotation and adjacent revocation  
 
@@ -1300,9 +1317,9 @@ default value:
 
 ### renderError
 
-Helper used by the OP to present errors which are not meant to be 'forwarded' to the RP's redirect_uri  
+Helper used by the OP to present errors to the User-Agent  
 
-affects: presentation of errors encountered during authorization  
+affects: presentation of errors encountered during End-User flows  
 
 default value:
 ```js
@@ -1384,7 +1401,9 @@ default value:
 
 ### subjectTypes
 
-List of the Subject Identifier types that this OP supports. Valid types include 'pairwise' and 'public'.  
+List of the Subject Identifier types that this OP supports. Valid types are 
+- `public` 
+- `pairwise`  
 
 affects: discovery, registration, registration management, ID Token and Userinfo sub claim values  
 

--- a/docs/keystores.md
+++ b/docs/keystores.md
@@ -8,14 +8,15 @@ object with the private keys during `#initialize()` call.
 
 **Table of Contents**
 
-<!-- TOC START min:2 max:2 link:true update:true -->
-  - [Certificates Keystore (jwks_uri)](#certificates-keystore-jwks_uri)
-  - [Generating new keys](#generating-new-keys)
-  - [Generating all keys for all features](#generating-all-keys-for-all-features)
-  - [Transforming existing keys from other formats](#transforming-existing-keys-from-other-formats)
-  - [Signing Key Rotation](#signing-key-rotation)
+<!-- TOC depthFrom:2 depthTo:3 withLinks:1 updateOnSave:1 orderedList:0 -->
 
-<!-- TOC END -->
+- [Certificates Keystore (jwks_uri)](#certificates-keystore-jwks_uri)
+- [Generating new keys](#generating-new-keys)
+- [Generating all keys for all features](#generating-all-keys-for-all-features)
+- [Transforming existing keys from other formats](#transforming-existing-keys-from-other-formats)
+- [Signing Key Rotation](#signing-key-rotation)
+
+<!-- /TOC -->
 
 ## Certificates Keystore (jwks_uri)
 To configure your Provider instance with your own signing and encryption keys you will need at the

--- a/docs/update-configuration.js
+++ b/docs/update-configuration.js
@@ -18,6 +18,9 @@ class Block {
       while (buffer.indexOf('*') === 0 || buffer.indexOf(' ') === 0) {
         buffer = buffer.slice(1);
       }
+      if (buffer.indexOf('-') === 0) {
+        buffer = Buffer.concat([Buffer.from('\n'), buffer]);
+      }
       this[this.active] = Buffer.concat([this[this.active], Buffer.from(' '), buffer]);
     }
   }

--- a/example/adapters/bookshelf_postgresql_adapter.js
+++ b/example/adapters/bookshelf_postgresql_adapter.js
@@ -25,6 +25,8 @@
 //   expires_at timestamp
 // );
 
+// TODO: @madarche adapt for new storage formats support (opaque and jwt)
+
 const knexCreate = require('knex'); // eslint-disable-line import/no-unresolved
 const bookshelfCreate = require('bookshelf'); // eslint-disable-line import/no-unresolved
 

--- a/example/adapters/redis.js
+++ b/example/adapters/redis.js
@@ -5,6 +5,12 @@ const client = new Redis(process.env.REDIS_URL, {
   keyPrefix: 'oidc:',
 });
 
+const grantable = [
+  'AccessToken',
+  'AuthorizationCode',
+  'RefreshToken',
+];
+
 function grantKeyFor(id) {
   return `grant:${id}`;
 }
@@ -14,17 +20,57 @@ class RedisAdapter {
     this.name = name;
   }
 
-  key(id) {
-    return `${this.name}:${id}`;
+  upsert(id, payload, expiresIn) {
+    const key = this.key(id);
+    const store = grantable.includes(this.name) ? {
+      dump: JSON.stringify(payload),
+      ...(payload.grantId ? { grantId: payload.grantId } : undefined),
+    } : JSON.stringify(payload);
+
+    const multi = client.multi();
+    multi[grantable.includes(this.name) ? 'hmset' : 'set'](key, store);
+
+    if (expiresIn) {
+      multi.expire(key, expiresIn);
+    }
+
+    if (payload.grantId) {
+      const grantKey = grantKeyFor(payload.grantId);
+      multi.rpush(grantKey, key);
+    }
+
+    return multi.exec();
+  }
+
+  async find(id) {
+    const data = grantable.includes(this.name) ?
+      await client.hgetall(this.key(id)) :
+      await client.get(this.key(id));
+
+    if (isEmpty(data)) {
+      return undefined;
+    }
+
+    if (typeof data === 'string') {
+      return JSON.parse(data);
+    }
+    const { dump, ...rest } = data;
+    return {
+      ...rest,
+      ...JSON.parse(dump),
+    };
   }
 
   async destroy(id) {
     const key = this.key(id);
-    const grantId = await client.hget(key, 'grantId');
-    const tokens = await client.lrange(grantKeyFor(grantId), 0, -1);
-    const deletions = tokens.map(token => client.del(token));
+    const deletions = [];
+    if (grantable.includes(this.name)) {
+      const grantId = await client.hget(key, 'grantId');
+      const tokens = await client.lrange(grantKeyFor(grantId), 0, -1);
+      tokens.forEach(token => deletions.push(client.del(token)));
+      deletions.push(client.del(grantKeyFor(grantId)));
+    }
     deletions.push(client.del(key));
-    deletions.push(client.del(grantKeyFor(grantId)));
     await deletions;
   }
 
@@ -32,40 +78,8 @@ class RedisAdapter {
     return client.hset(this.key(id), 'consumed', Math.floor(Date.now() / 1000));
   }
 
-  async find(id) {
-    const data = await client.hgetall(this.key(id));
-    if (isEmpty(data)) {
-      return undefined;
-    } else if (data.dump !== undefined) {
-      return JSON.parse(data.dump);
-    }
-    return data;
-  }
-
-  upsert(id, payload, expiresIn) {
-    const key = this.key(id);
-    let toStore = payload;
-
-    // Clients are not simple objects where value is always a string
-    // redis does only allow string values =>
-    // work around it to keep the adapter interface simple
-    if (this.name === 'Client' || this.name === 'Session') {
-      toStore = { dump: JSON.stringify(payload) };
-    }
-
-    const multi = client.multi();
-    multi.hmset(key, toStore);
-
-    if (expiresIn) {
-      multi.expire(key, expiresIn);
-    }
-
-    if (toStore.grantId) {
-      const grantKey = grantKeyFor(toStore.grantId);
-      multi.rpush(grantKey, key);
-    }
-
-    return multi.exec();
+  key(id) {
+    return `${this.name}:${id}`;
   }
 }
 

--- a/example/adapters/sequelize.js
+++ b/example/adapters/sequelize.js
@@ -1,15 +1,12 @@
-/* eslint-disable */
-
 /*
  * This is a very rough-edged example, the idea is to still work with the fact that oidc-provider
  * has a rather "dynamic" schema. This example uses sequelize with sqlite, and all dynamic data
- * uses JSON fields. uuid is set to be the primary key and grantId should be additionaly indexed
- * for token models.
+ * uses JSON fields. id is set to be the primary key, grantId should be additionaly indexed for
+ * models where these fields are set.
 */
 
-'use strict';
+const Sequelize = require('sequelize'); // eslint-disable-line import/no-unresolved
 
-const Sequelize = require('sequelize');
 const sequelize = new Sequelize('database', 'username', 'password', {
   dialect: 'sqlite',
   storage: 'db.sqlite',
@@ -32,7 +29,7 @@ const models = [
   'RegistrationAccessToken',
 ].reduce((map, name) => {
   map.set(name, sequelize.define(name, {
-    uuid: { type: Sequelize.STRING, primaryKey: true },
+    id: { type: Sequelize.STRING, primaryKey: true },
     grantId: { type: Sequelize.UUIDV4 },
     data: { type: Sequelize.JSON },
     expiresAt: { type: Sequelize.DATE },
@@ -49,39 +46,40 @@ class SequelizeAdapter {
     this.name = name;
   }
 
-  async upsert(id, payload, expiresIn) {
-    return this.model.upsert(Object.assign(
-      {},
-      { data: payload },
-      { uuid: id },
-      payload.grantId ? { grantId: payload.grantId } : undefined,
-      expiresIn ? { expiresAt: new Date(Date.now() + (expiresIn * 1000)) } : undefined ));
+  async upsert(id, data, expiresIn) {
+    return this.model.upsert({
+      id,
+      data,
+      ...(data.grantId ? { grantId: data.grantId } : undefined),
+      ...(expiresIn ? { expiresAt: new Date(Date.now() + (expiresIn * 1000)) } : undefined),
+    });
   }
 
   async find(id) {
     return this.model.findByPrimary(id).then((found) => {
-      if (found) {
-        return found.consumedAt ? Object.assign({}, found.data, { consumed: true }) : found.data;
-      }
-      return undefined;
+      if (!found) return undefined;
+      return {
+        ...found.data,
+        ...(found.consumedAt ? { consumed: true } : undefined),
+      };
     });
-  }
-
-  async consume(id) {
-    return this.model.update({ consumedAt: new Date() }, { where: { uuid: id }});
   }
 
   async destroy(id) {
     if (grantable.includes(this.name)) {
-      return this.model.findByPrimary(id).then((({ grantId }) => {
-        return Promise.all(grantable.map(name => models.get(name).destroy({ where: { grantId }})));
-      }));
+      return this.model.findByPrimary(id).then((({ grantId }) => (
+        Promise.all(grantable.map(name => models.get(name).destroy({ where: { grantId } })))
+      )));
     }
 
-    return this.model.destroy({ where: { uuid: id }});
+    return this.model.destroy({ where: { id } });
   }
 
-  static async connect(provider) {
+  async consume(id) {
+    return this.model.update({ consumedAt: new Date() }, { where: { id } });
+  }
+
+  static async connect() {
     return sequelize.sync();
   }
 }

--- a/example/express.js
+++ b/example/express.js
@@ -6,7 +6,9 @@ const express = require('express'); // eslint-disable-line import/no-unresolved
 
 const app = express();
 
-const provider = new Provider('http://localhost:3000/op');
+const provider = new Provider('http://localhost:3000/op', {
+  formats: { default: 'opaque' },
+});
 
 provider.initialize().then(() => {
   app.use('/op', provider.callback);

--- a/example/my_adapter.js
+++ b/example/my_adapter.js
@@ -35,23 +35,50 @@ class MyAdapter {
      *
      * When this is one of AccessToken, AuthorizationCode, RefreshToken, ClientCredentials,
      * InitialAccessToken or RegistrationAccessToken the payload will contain the following
-     * properties:
-     * - grantId {string} the original id assigned to a grant (authorization request)
+     * properties depending on the used `formats` value for the given token (or default).
+     *
+     * when `legacy`
+     * - grantId {string} grant identifier, tokens with the same value belong together
      * - header {string} oidc-provider tokens are themselves JWTs, this is the header part of the token
      * - payload {string} second part of the token
      * - signature {string} the signature of the token
      *
-     * Hint: you can JSON.parse(base64decode( ... )) the header and payload to get the token
-     * properties and store them too, they may be helpful for getting insights on your usage.
+     * Hint for legacy format: you can JSON.parse(base64decode( ... )) the header and payload to get
+     * the token properties and store them too, they may be helpful for getting insights on your usage.
      * Modifying any of header, payload or signature values will result in the token being invalid,
      * remember that oidc-provider will do a JWT signature check of both the received and stored
      * token to detect potential manipulation.
+     *
+     * when `opaque`
+     * - jti {string} unique identifier of the token
+     * - kind {string} token class name
+     * - exp {number} - timestamp of the token's expiration
+     * - iat {number} - timestamp of the token's creation
+     * - iss {string} - issuer identifier, useful in multi-provider instance apps
+     * - accountId {string} - account identifier the token belongs to
+     * - clientId {string} client identifier the token belongs to
+     * - aud {array of strings} array of audiences the token is intended for
+     * - authTime {number} timestamp of the end-user's authentication
+     * - claims {object} requested claims (see claims parameter in OIDC Core 1.0)
+     * - codeChallenge {string} - client provided PKCE code_challenge value
+     * - codeChallengeMethod {string} - client provided PKCE code_challenge_method value
+     * - grantId {string} - grant identifier, tokens with the same value belong together
+     * - nonce {string} - random nonce from an authorization request
+     * - redirectUri {string} - redirect_uri value from an authorization request
+     * - scope {string} - scope value from on authorization request
+     * - sid {string} - session identifier the token comes from
+     *
+     *
+     * when `jwt`
+     * - same as `opaque` with the addition of
+     * - jwt {string} the jwt value returned to the client
      *
      * Hint2: in order to fulfill all OAuth2.0 behaviors in regards to invalidating and expiring
      * potentially misused or sniffed tokens you should keep track of all tokens that belong to the
      * same grantId.
      *
-     * Client model will only use this when registered through Dynamic Registration features.
+     * Client model will only use this when registered through Dynamic Registration features and
+     * will contain all client properties.
      *
      * OIDC Session model payload contains the following properties:
      * - account {string} the session account identifier
@@ -67,7 +94,7 @@ class MyAdapter {
      * - uuid {string} - uuid of the grant
      * - params {object} - parsed recognized parameters object
      * - signed {array} - array of parameter names (keys) that were received from a signed and/or
-     *                    encrypted request/_uri object
+     *                    symmetrically encrypted request/_uri object
      * - result {object} - interaction results object is expected here
      *
      */

--- a/example/my_adapter.js
+++ b/example/my_adapter.js
@@ -116,7 +116,8 @@ class MyAdapter {
   /**
    *
    * Mark a stored oidc-provider model as consumed (not yet expired though!). Future finds for this
-   * id should be fulfilled with an object containing additional property named "consumed".
+   * id should be fulfilled with an object containing additional property named "consumed" with a
+   * truthy value (timestamp, date, boolean, etc).
    *
    * @return {Promise} Promise fulfilled when the operation succeeded. Rejected with error when
    * encountered.

--- a/example/my_adapter.js
+++ b/example/my_adapter.js
@@ -71,7 +71,7 @@ class MyAdapter {
      *
      * when `jwt`
      * - same as `opaque` with the addition of
-     * - jwt {string} the jwt value returned to the client
+     * - jwt {string} - the jwt value returned to the client
      *
      * Hint2: in order to fulfill all OAuth2.0 behaviors in regards to invalidating and expiring
      * potentially misused or sniffed tokens you should keep track of all tokens that belong to the

--- a/example/settings.js
+++ b/example/settings.js
@@ -39,6 +39,10 @@ module.exports.config = {
     revocation: true, // defaults to false
     sessionManagement: true, // defaults to false
   },
+  formats: {
+    default: 'opaque',
+    AccessToken: 'jwt',
+  },
   subjectTypes: ['public', 'pairwise'],
   pairwiseSalt: 'da1c442b365b563dfc121f285a11eedee5bbff7110d55c88',
   interactionUrl: function interactionUrl(ctx, interaction) { // eslint-disable-line no-unused-vars
@@ -48,7 +52,6 @@ module.exports.config = {
   ttl: {
     AccessToken: 1 * 60 * 60, // 1 hour in seconds
     AuthorizationCode: 10 * 60, // 10 minutes in seconds
-    ClientCredentials: 10 * 60, // 10 minutes in seconds
     IdToken: 1 * 60 * 60, // 1 hour in seconds
     RefreshToken: 1 * 24 * 60 * 60, // 1 day in seconds
 

--- a/lib/actions/authorization/process_response_types.js
+++ b/lib/actions/authorization/process_response_types.js
@@ -62,11 +62,9 @@ module.exports = (provider) => {
   async function idTokenHandler(ctx) {
     const token = new IdToken({
       ...await ctx.oidc.account.claims('id_token', ctx.oidc.params.scope),
-      ...{
-        acr: ctx.oidc.acr,
-        amr: ctx.oidc.amr,
-        auth_time: ctx.oidc.session.authTime(),
-      },
+      acr: ctx.oidc.acr,
+      amr: ctx.oidc.amr,
+      auth_time: ctx.oidc.session.authTime(),
     }, ctx.oidc.client.sectorIdentifier);
 
     token.scope = ctx.oidc.params.scope;

--- a/lib/actions/authorization/respond.js
+++ b/lib/actions/authorization/respond.js
@@ -38,7 +38,10 @@ module.exports = provider => async function respond(ctx, next) {
     const stateCookieName = `${provider.cookieName('state')}.${params.client_id}`;
     cookies.set(
       stateCookieName, state,
-      { ...instance(provider).configuration('cookies.long'), ...{ httpOnly: false } },
+      {
+        ...instance(provider).configuration('cookies.long'),
+        httpOnly: false,
+      },
     );
 
     res.session_state = `${sessionStr}.${salt}`;

--- a/lib/actions/grants/authorization_code.js
+++ b/lib/actions/grants/authorization_code.js
@@ -107,11 +107,9 @@ module.exports.handler = function getAuthorizationCodeHandler(provider) {
 
     const token = new IdToken({
       ...await account.claims('id_token', code.scope),
-      ...{
-        acr: code.acr,
-        amr: code.amr,
-        auth_time: code.authTime,
-      },
+      acr: code.acr,
+      amr: code.amr,
+      auth_time: code.authTime,
     }, ctx.oidc.client.sectorIdentifier);
 
     token.scope = code.scope;

--- a/lib/adapters/memory_adapter.js
+++ b/lib/adapters/memory_adapter.js
@@ -18,7 +18,9 @@ class MemoryAdapter {
 
   destroy(id) {
     const key = this.key(id);
-    const grantId = storage.get(key) && storage.get(key).grantId;
+
+    const found = storage.get(key);
+    const grantId = found && found.grantId;
 
     storage.del(key);
 

--- a/lib/helpers/client_schema.js
+++ b/lib/helpers/client_schema.js
@@ -95,36 +95,34 @@ module.exports = function getSchema(provider) {
 
   const ENUM = {
     ...ENUMS,
-    ...{
-      default_acr_values: () => configuration.acrValues,
-      grant_types: () => configuration.grantTypes,
-      id_token_encrypted_response_alg: () => configuration.idTokenEncryptionAlgValues,
-      id_token_encrypted_response_enc: () => configuration.idTokenEncryptionEncValues,
-      id_token_signed_response_alg: (metadata) => {
-        if (!metadata.response_types.join(' ').includes('id_token')) {
-          return configuration.idTokenSigningAlgValues;
-        }
-        return _.without(configuration.idTokenSigningAlgValues, 'none');
-      },
-      request_object_signing_alg: () => configuration.requestObjectSigningAlgValues,
-      request_object_encryption_alg: () => configuration.requestObjectEncryptionAlgValues,
-      request_object_encryption_enc: () => configuration.requestObjectEncryptionEncValues,
-      response_types: () => configuration.responseTypes,
-      subject_type: () => configuration.subjectTypes,
-      token_endpoint_auth_method: () => configuration.tokenEndpointAuthMethods,
-      token_endpoint_auth_signing_alg: () => configuration.tokenEndpointAuthSigningAlgValues,
-      userinfo_encrypted_response_alg: () => configuration.userinfoEncryptionAlgValues,
-      userinfo_encrypted_response_enc: () => configuration.userinfoEncryptionEncValues,
-      userinfo_signed_response_alg: () => configuration.userinfoSigningAlgValues,
-
-      // must be after token_* specific
-      introspection_endpoint_auth_method: () => configuration.introspectionEndpointAuthMethods,
-      introspection_endpoint_auth_signing_alg: () =>
-        configuration.introspectionEndpointAuthSigningAlgValues,
-      revocation_endpoint_auth_method: () => configuration.revocationEndpointAuthMethods,
-      revocation_endpoint_auth_signing_alg: () =>
-        configuration.revocationEndpointAuthSigningAlgValues,
+    default_acr_values: () => configuration.acrValues,
+    grant_types: () => configuration.grantTypes,
+    id_token_encrypted_response_alg: () => configuration.idTokenEncryptionAlgValues,
+    id_token_encrypted_response_enc: () => configuration.idTokenEncryptionEncValues,
+    id_token_signed_response_alg: (metadata) => {
+      if (!metadata.response_types.join(' ').includes('id_token')) {
+        return configuration.idTokenSigningAlgValues;
+      }
+      return _.without(configuration.idTokenSigningAlgValues, 'none');
     },
+    request_object_signing_alg: () => configuration.requestObjectSigningAlgValues,
+    request_object_encryption_alg: () => configuration.requestObjectEncryptionAlgValues,
+    request_object_encryption_enc: () => configuration.requestObjectEncryptionEncValues,
+    response_types: () => configuration.responseTypes,
+    subject_type: () => configuration.subjectTypes,
+    token_endpoint_auth_method: () => configuration.tokenEndpointAuthMethods,
+    token_endpoint_auth_signing_alg: () => configuration.tokenEndpointAuthSigningAlgValues,
+    userinfo_encrypted_response_alg: () => configuration.userinfoEncryptionAlgValues,
+    userinfo_encrypted_response_enc: () => configuration.userinfoEncryptionEncValues,
+    userinfo_signed_response_alg: () => configuration.userinfoSigningAlgValues,
+
+    // must be after token_* specific
+    introspection_endpoint_auth_method: () => configuration.introspectionEndpointAuthMethods,
+    introspection_endpoint_auth_signing_alg: () =>
+      configuration.introspectionEndpointAuthSigningAlgValues,
+    revocation_endpoint_auth_method: () => configuration.revocationEndpointAuthMethods,
+    revocation_endpoint_auth_signing_alg: () =>
+      configuration.revocationEndpointAuthSigningAlgValues,
   };
 
   class Schema {

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -171,18 +171,38 @@ const DEFAULTS = {
     oauthNativeApps: true,
     pkce: true,
 
+    alwaysIssueRefresh: false,
     backchannelLogout: false,
-    frontchannelLogout: false,
     claimsParameter: false,
     clientCredentials: false,
     encryption: false,
+    frontchannelLogout: false,
     introspection: false,
-    alwaysIssueRefresh: false,
     registration: false,
     registrationManagement: false,
     request: false,
     revocation: false,
     sessionManagement: false,
+  },
+
+  /*
+   * formats
+   *
+   * description: TODO
+   * affects: properties passed to adapters for token types, issued token formats
+   * recommendation: set default to `opaque` if you're still developing your application, `legacy`
+   *   will not be the default in the major versions coming forward. It is not recommended to set
+   *   `jwt` as default, if you need it, it's most likely just for Access Tokens.
+   */
+  formats: {
+    default: 'legacy',
+
+    AccessToken: undefined,
+    AuthorizationCode: undefined,
+    RefreshToken: undefined,
+    ClientCredentials: undefined,
+    InitialAccessToken: undefined,
+    RegistrationAccessToken: undefined,
   },
 
 

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -19,8 +19,6 @@ const DEFAULTS = {
    * acrValues
    *
    * description: Array of strings, the Authentication Context Class References that OP supports.
-   *   First one in the list will be the one used for authentication requests unless one was
-   *   provided as part of an interaction result. Use a value with 'session' meaning as the first.
    * affects: discovery, ID Token acr claim values
    */
   acrValues: [],
@@ -44,6 +42,9 @@ const DEFAULTS = {
    * description: A `Number` value (in seconds) describing how long a dynamically loaded client
    *    should remain cached.
    * affects: adapter-backed client cache duration
+   * recommendation: do not set to a low value or completely disable this, client properties are
+   *   validated upon loading up and this may be potentially an expensive operation, sometimes even
+   *   requesting resources from the network (i.e. client jwks_uri, sector_identifier_uri etc).
    */
   clientCacheDuration: Infinity,
 
@@ -52,7 +53,7 @@ const DEFAULTS = {
    * clockTolerance
    *
    * description: A `Number` value (in seconds) describing the allowed system clock skew
-   * affects: JWT (ID token, client assertion) validations.
+   * affects: JWT (ID token, client assertion) and Token expiration validations
    * recommendation: Set to a reasonable value (60) to cover server-side client and oidc-provider
    *   server clock skew
    */
@@ -127,7 +128,7 @@ const DEFAULTS = {
      * affects: sessionManagement feature
      *
      */
-    thirdPartyCheckUrl: 'https://cdn.rawgit.com/panva/3rdpartycookiecheck/92fead3f/start.html',
+    thirdPartyCheckUrl: 'https://cdn.rawgit.com/panva/3rdpartycookiecheck/92fead3f/start.html', // TODO: move under sessionManagement in next major
   },
 
 
@@ -152,8 +153,8 @@ const DEFAULTS = {
    * extraParams
    *
    * description: Pass an iterable object (i.e. array or set of strings) to extend the parameters
-   *   recognized by the authorization endpoint. These parameters are then available in
-   *   ctx.oidc.params as well as passed to interaction session details
+   *   recognised by the authorization endpoint. These parameters are then available in
+   *   `ctx.oidc.params` as well as passed to interaction session details
    * affects: authorization, interaction
    */
   extraParams: [],
@@ -188,7 +189,20 @@ const DEFAULTS = {
   /*
    * formats
    *
-   * description: TODO
+   * description: This option allows to configure the token storage and value formats. The different
+   *   values change how a token value is generated as well as what properties get sent to the
+   *   adapter for storage. Three formats are defined, see the expected
+   *   [Adapter API](/example/my_adapter.js) for each format's specifics.
+   *
+   *   - `legacy` is the current and default format until next major release. no changes in the
+   *     format sent to adapter.
+   *   - `opaque` formatted tokens have a different value then `legacy` and in addition store what
+   *     was in legacy format encoded under `payload` as root properties, this makes analysing the
+   *     data in your storage way easier
+   *   - `jwt` formatted tokens are issued as JWTs and stored the same as `opaque` only with
+   *     additional property `jwt`. The signing algorithm for these tokens uses the client's
+   *     `id_token_signed_response_alg` value and falls back to `RS256` for tokens with no relation
+   *     to a client or when the client's alg is `none`
    * affects: properties passed to adapters for token types, issued token formats
    * recommendation: set default to `opaque` if you're still developing your application, `legacy`
    *   will not be the default in the major versions coming forward. It is not recommended to set
@@ -263,8 +277,9 @@ const DEFAULTS = {
   /*
    * subjectTypes
    *
-   * description: List of the Subject Identifier types that this OP supports. Valid types include
-   *   'pairwise' and 'public'.
+   * description: List of the Subject Identifier types that this OP supports. Valid types are
+   *   - `public`
+   *   - `pairwise`
    * affects: discovery, registration, registration management, ID Token and Userinfo sub claim
    *   values
    */
@@ -277,6 +292,7 @@ const DEFAULTS = {
    * description: Salt used by OP when resolving pairwise ID Token and Userinfo sub claim value
    * affects: ID Token and Userinfo sub claim values
    */
+  // TODO: pairwise helper instead, might do salting, might do random generation and mapping
   pairwiseSalt: '',
 
 
@@ -340,8 +356,8 @@ const DEFAULTS = {
     validator(key, value, metadata) { // eslint-disable-line no-unused-vars
       // validations for key, value, other related metadata
 
-      // throw new Provider.InvalidClientMetadata() to reject the client metadata (see all errors on
-      //   Provider)
+      // throw new Provider.errors.InvalidClientMetadata() to reject the client metadata (see all
+      //   errors on Provider.errors)
 
       // metadata[key] = value; to assign values
 
@@ -463,9 +479,8 @@ const DEFAULTS = {
   /*
    * renderError
    *
-   * description: Helper used by the OP to present errors which are not meant to be 'forwarded' to
-   *   the RP's redirect_uri
-   * affects: presentation of errors encountered during authorization
+   * description: Helper used by the OP to present errors to the User-Agent
+   * affects: presentation of errors encountered during End-User flows
    */
   async renderError(ctx, out, error) { // eslint-disable-line no-unused-vars
     changeme('renderError', 'customize the look of the error page');
@@ -530,10 +545,11 @@ const DEFAULTS = {
   /*
    * audiences
    *
-   * description: Helper used by the OP to push additional audiences to issued ID Tokens and other
-   *   signed responses. The return value should either be falsy to omit adding additional audiences
-   *   or an array of strings to push.
-   * affects: id token audiences, signed userinfo audiences
+   * description: Helper used by the OP to push additional audiences to issued ID, Access and
+   *   ClientCredentials Tokens as well as other signed responses. The return value should either be
+   *   falsy to omit adding additional audiences or an array of strings to push.
+   * affects: id token audiences, access token audiences, client credential audiences, signed
+   *   userinfo audiences
    */
   async audiences(ctx, sub, token, use, scope) { // eslint-disable-line no-unused-vars
     // @param ctx   - koa request context
@@ -550,7 +566,7 @@ const DEFAULTS = {
   /*
    * findById
    *
-   * description: Helper used by the OP to load your account and retrieve it's available claims. The
+   * description: Helper used by the OP to load an account and retrieve its available claims. The
    *   return value should be a Promise and #claims() can return a Promise too
    * affects: authorization, authorization_code and refresh_token grants, id token claims
    */
@@ -561,7 +577,7 @@ const DEFAULTS = {
     //   is undefined in scenarios where claims are returned from authorization endpoint
     changeme('findById', 'to use your own account model');
     return {
-      accountId: sub,
+      accountId: sub, // TODO: sub property in the future
       // @param use   - can either be "id_token" or "userinfo", depending on
       //   where the specific claims are intended to be put in
       // @param scope - the intended scope, while oidc-provider will mask
@@ -601,10 +617,11 @@ const DEFAULTS = {
    * refreshTokenRotation
    *
    * description: Configures if and how the OP rotates refresh tokens after they are used. Supported
-   *   values are 1) `"none"` when refresh tokens are not rotated and their initial expiration date
-   *   is final or 2) `"rotateAndConsume"` when refresh tokens are rotated when used, current token
-   *   is marked as consumed and new one is issued with new TTL, when a consumed refresh token is
-   *   encountered an error is returned instead and the whole token chain (grant) is revoked.
+   *   values are
+   *   - `none` when refresh tokens are not rotated and their initial expiration date is final or
+   *   - `rotateAndConsume` when refresh tokens are rotated when used, current token is marked as
+   *     consumed and new one is issued with new TTL, when a consumed refresh token is
+   *     encountered an error is returned instead and the whole token chain (grant) is revoked
    * affects: refresh token rotation and adjacent revocation
    */
   refreshTokenRotation: 'rotateAndConsume',

--- a/lib/helpers/ensure_conform.js
+++ b/lib/helpers/ensure_conform.js
@@ -4,6 +4,9 @@ module.exports = function ensureConform(audiences, clientId) {
   assert(Array.isArray(audiences), 'audiences must be an array');
 
   const value = Array.from(audiences);
+  value.forEach((audience) => {
+    assert(audience && typeof audience === 'string', 'audiences must be non-empty string values');
+  });
   if (!value.includes(clientId)) {
     value.unshift(clientId);
   }

--- a/lib/models/access_token.js
+++ b/lib/models/access_token.js
@@ -1,18 +1,20 @@
 const setAudiences = require('./mixins/set_audiences');
 const hasFormat = require('./mixins/has_format');
+const apply = require('./mixins/apply');
 
-module.exports = function getAccessToken(provider) {
-  return class AccessToken extends setAudiences(hasFormat(provider, 'AccessToken', provider.BaseToken)) {
-    static get IN_PAYLOAD() {
-      return [
-        ...super.IN_PAYLOAD,
+module.exports = provider => class AccessToken extends apply([
+  setAudiences,
+  hasFormat(provider, 'AccessToken', provider.BaseToken),
+]) {
+  static get IN_PAYLOAD() {
+    return [
+      ...super.IN_PAYLOAD,
 
-        'accountId',
-        'claims',
-        'grantId',
-        'aud',
-        'scope',
-      ];
-    }
-  };
+      'accountId',
+      'claims',
+      'grantId',
+      'aud',
+      'scope',
+    ];
+  }
 };

--- a/lib/models/access_token.js
+++ b/lib/models/access_token.js
@@ -1,7 +1,8 @@
 const setAudiences = require('./mixins/set_audiences');
+const hasFormat = require('./mixins/has_format');
 
-module.exports = function getAccessToken({ BaseToken }) {
-  return class AccessToken extends setAudiences(BaseToken) {
+module.exports = function getAccessToken(provider) {
+  return class AccessToken extends setAudiences(hasFormat(provider, 'AccessToken', provider.BaseToken)) {
     static get IN_PAYLOAD() {
       return [
         ...super.IN_PAYLOAD,

--- a/lib/models/authorization_code.js
+++ b/lib/models/authorization_code.js
@@ -1,14 +1,19 @@
 const storesPKCE = require('./mixins/stores_pkce');
 const storesAuth = require('./mixins/stores_auth');
 const hasFormat = require('./mixins/has_format');
+const consumable = require('./mixins/consumable');
+const apply = require('./mixins/apply');
 
-module.exports = function getAuthorizationCode(provider) {
-  return class AuthorizationCode extends storesAuth(storesPKCE(hasFormat(provider, 'AuthorizationCode', provider.BaseToken))) {
-    static get IN_PAYLOAD() {
-      return [
-        ...super.IN_PAYLOAD,
-        'redirectUri',
-      ];
-    }
-  };
+module.exports = provider => class AuthorizationCode extends apply([
+  consumable,
+  storesPKCE,
+  storesAuth,
+  hasFormat(provider, 'AuthorizationCode', provider.BaseToken),
+]) {
+  static get IN_PAYLOAD() {
+    return [
+      ...super.IN_PAYLOAD,
+      'redirectUri',
+    ];
+  }
 };

--- a/lib/models/authorization_code.js
+++ b/lib/models/authorization_code.js
@@ -1,8 +1,9 @@
 const storesPKCE = require('./mixins/stores_pkce');
 const storesAuth = require('./mixins/stores_auth');
+const hasFormat = require('./mixins/has_format');
 
-module.exports = function getAuthorizationCode({ BaseToken }) {
-  return class AuthorizationCode extends storesAuth(storesPKCE(BaseToken)) {
+module.exports = function getAuthorizationCode(provider) {
+  return class AuthorizationCode extends storesAuth(storesPKCE(hasFormat(provider, 'AuthorizationCode', provider.BaseToken))) {
     static get IN_PAYLOAD() {
       return [
         ...super.IN_PAYLOAD,

--- a/lib/models/base_token.js
+++ b/lib/models/base_token.js
@@ -23,8 +23,6 @@ module.exports = function getBaseToken(provider) {
     return adapterCache.get(obj);
   }
 
-  const { default: FORMAT } = instance(provider).configuration('formats');
-
   class Class {
     constructor({ jti, kind, ...payload } = {}) {
       Object.assign(this, payload);
@@ -49,7 +47,7 @@ module.exports = function getBaseToken(provider) {
     async save() {
       const [token, upsert] = await this.getValueAndPayload();
 
-      if (FORMAT === 'legacy' && !upsert.grantId) upsert.grantId = this.grantId;
+      if (this.constructor.format === 'legacy' && !upsert.grantId) upsert.grantId = this.grantId;
       await this.adapter.upsert(this.jti, upsert, this.remainingTTL);
       provider.emit('token.issued', this);
 

--- a/lib/models/base_token.js
+++ b/lib/models/base_token.js
@@ -4,16 +4,11 @@ const IN_PAYLOAD = [
   'kind',
 ];
 
-const { pick } = require('lodash');
-const constantEquals = require('../helpers/constant_equals');
 const assert = require('assert');
-const base64url = require('base64url');
-const uuid = require('uuid/v4');
-const { randomBytes } = require('crypto');
 
 const epochTime = require('../helpers/epoch_time');
 const instance = require('../helpers/weak_cache');
-const JWT = require('../helpers/jwt');
+const hasFormat = require('./mixins/has_format');
 
 const adapterCache = new WeakMap();
 
@@ -28,14 +23,16 @@ module.exports = function getBaseToken(provider) {
     return adapterCache.get(obj);
   }
 
-  return class BaseToken {
-    constructor(payload) {
+  const { default: FORMAT } = instance(provider).configuration('formats');
+
+  class Class {
+    constructor({ jti, kind, ...payload } = {}) {
       Object.assign(this, payload);
 
-      this.jti = this.jti || base64url(uuid());
+      assert(!kind || kind === this.constructor.name, 'kind mismatch');
 
-      this.kind = this.kind || this.constructor.name;
-      assert.equal(this.kind, this.constructor.name, 'kind mismatch');
+      this.jti = jti || this.constructor.generateTokenId();
+      this.kind = kind || this.constructor.name;
     }
 
     static get expiresIn() { return instance(provider).configuration(`ttl.${this.name}`); }
@@ -52,7 +49,7 @@ module.exports = function getBaseToken(provider) {
     async save() {
       const [token, upsert] = await this.getValueAndPayload();
 
-      if (this.grantId) upsert.grantId = this.grantId;
+      if (FORMAT === 'legacy' && !upsert.grantId) upsert.grantId = this.grantId;
       await this.adapter.upsert(this.jti, upsert, this.remainingTTL);
       provider.emit('token.issued', this);
 
@@ -92,8 +89,11 @@ module.exports = function getBaseToken(provider) {
         });
         assert(stored);
         const payload = await this.verify(token, stored, { ignoreExpiration });
-        const inst = new this(payload);
-        if (stored.consumed !== undefined) inst.consumed = stored.consumed;
+        assert.equal(jti, payload.jti);
+        const inst = new this({
+          ...payload,
+          ...(stored.consumed ? { consumed: stored.consumed } : undefined),
+        });
 
         return inst;
       } catch (err) {
@@ -113,71 +113,64 @@ module.exports = function getBaseToken(provider) {
     get expiration() {
       return this.expiresIn || this.constructor.expiresIn;
     }
+  }
 
-    /**
-     * @name getValueAndPayload
-     * @api public
-     *
-     * Return an Array instance with the first member being a string representation of the token as
-     * it should be returned to the client. Second member being an Object that should be passed to
-     * the adapter for storage.
-     *
-     */
-    async getValueAndPayload() {
-      const jwt = await JWT.sign(pick(this, this.constructor.IN_PAYLOAD), undefined, 'none', {
-        issuer: provider.issuer,
-        ...(this.exp ? undefined : { expiresIn: this.expiration }),
-      });
+  /**
+   * @name generateTokenId
+   * @static
+   * @api public
+   *
+   * Return a randomly generated Token instance ID (string)
+   *
+   * BaseToken.prototype.constructor.generateTokenId
+   *   see implementations for each format in lib/models/formats
+   */
 
-      const [header, payload] = jwt.split('.');
-      const signature = this.signature || base64url(randomBytes(64));
+  /**
+   * @name getValueAndPayload
+   * @api public
+   *
+   * Return an Array instance with the first member being a string representation of the token as
+   * it should be returned to the client. Second member being an Object that should be passed to
+   * the adapter for storage.
+   *
+   * BaseToken.prototype.getValueAndPayload
+   *   see implementations for each format in lib/models/formats
+   */
 
-      return [`${this.jti}${signature}`, {
-        header,
-        payload,
-        signature,
-      }];
-    }
+  /**
+   * @name getTokenId
+   * @static
+   * @api public
+   *
+   * Return the Token instance ID related to the presented token value. This ID will be passed to
+   * the adapter for lookup.
+   *
+   * @param token - the presented token string value
+   *
+   * BaseToken.prototype.constructor.getTokenId
+   *   see implementations for each format in lib/models/formats
+   */
 
-    /**
-     * @name getTokenId
-     * @api public
-     *
-     * Return the Token instance ID related to the presented token value. This ID will be passed to
-     * the adapter for lookup.
-     *
-     * @param token - the presented token string value
-     *
-     */
-    static getTokenId(token) {
-      return token.substring(0, 48);
-    }
+  /**
+   * @name verify
+   * @static
+   * @api public
+   *
+   * A verify function that asserts that the presented token is valid, not expired,
+   * or otherwise manipulated with.
+   *
+   * @param token - the presented token string value
+   * @param stored - data returned from the adapter token lookup
+   * @param options - options object
+   * @param options.ignoreExpiration - Boolean indicating whether expired but still stored
+   *   tokens should pass this verification.
+   *
+   * BaseToken.prototype.constructor.verify
+   *   see implementations for each format in lib/models/formats
+   */
 
-    /**
-     * @name verify
-     * @api public
-     *
-     * A verify function that asserts that the presented token is valid, not expired,
-     * or otherwise manipulated with.
-     *
-     * @param token - the presented token string value
-     * @param stored - data returned from the adapter token lookup
-     * @param options - options object
-     * @param options.ignoreExpiration - Boolean indicating whether expired but still stored
-     *   tokens should pass this verification.
-     *
-     */
-    static async verify(token, stored, options) {
-      assert(constantEquals(token.substring(48), stored.signature, 1000));
-      const { payload } = JWT.decode([stored.header, stored.payload, stored.signature].join('.'));
-      Object.assign(payload, { signature: stored.signature });
-      JWT.assertPayload(payload, {
-        ignoreExpiration: options.ignoreExpiration,
-        issuer: provider.issuer,
-        clockTolerance: instance(provider).configuration('clockTolerance'),
-        jti: this.getTokenId(token),
-      });
-      return payload;
-    }
-  };
+  class BaseToken extends hasFormat(provider, 'default', Class) {}
+
+  return BaseToken;
 };

--- a/lib/models/client_credentials.js
+++ b/lib/models/client_credentials.js
@@ -1,7 +1,8 @@
 const setAudiences = require('./mixins/set_audiences');
+const hasFormat = require('./mixins/has_format');
 
-module.exports = function getClientCredentials({ BaseToken }) {
-  return class ClientCredentials extends setAudiences(BaseToken) {
+module.exports = function getClientCredentials(provider) {
+  return class ClientCredentials extends setAudiences(hasFormat(provider, 'ClientCredentials', provider.BaseToken)) {
     static get IN_PAYLOAD() {
       return [
         ...super.IN_PAYLOAD,

--- a/lib/models/client_credentials.js
+++ b/lib/models/client_credentials.js
@@ -1,14 +1,16 @@
 const setAudiences = require('./mixins/set_audiences');
 const hasFormat = require('./mixins/has_format');
+const apply = require('./mixins/apply');
 
-module.exports = function getClientCredentials(provider) {
-  return class ClientCredentials extends setAudiences(hasFormat(provider, 'ClientCredentials', provider.BaseToken)) {
-    static get IN_PAYLOAD() {
-      return [
-        ...super.IN_PAYLOAD,
-        'aud',
-        'scope',
-      ];
-    }
-  };
+module.exports = provider => class ClientCredentials extends apply([
+  setAudiences,
+  hasFormat(provider, 'ClientCredentials', provider.BaseToken),
+]) {
+  static get IN_PAYLOAD() {
+    return [
+      ...super.IN_PAYLOAD,
+      'aud',
+      'scope',
+    ];
+  }
 };

--- a/lib/models/formats/index.js
+++ b/lib/models/formats/index.js
@@ -1,0 +1,9 @@
+const legacy = require('./legacy');
+const opaque = require('./opaque');
+const jwt = require('./jwt');
+
+module.exports = {
+  legacy,
+  opaque,
+  jwt,
+};

--- a/lib/models/formats/jwt.js
+++ b/lib/models/formats/jwt.js
@@ -1,0 +1,68 @@
+const instance = require('../../helpers/weak_cache');
+const base64url = require('base64url');
+const JWT = require('../../helpers/jwt');
+const assert = require('assert');
+const nanoid = require('nanoid');
+
+const opaqueFormat = require('./opaque');
+
+function getClaim(token, claim) {
+  return JSON.parse(base64url.decode(token.split('.')[1]))[claim];
+}
+
+const use = 'sig';
+const FALLBACK_ALG = 'RS256';
+
+module.exports = (provider) => {
+  const opaque = opaqueFormat(provider);
+
+  async function getSigningAlgAndKey(clientId) {
+    let alg = FALLBACK_ALG;
+    let client;
+    if (clientId) {
+      client = await provider.Client.find(clientId);
+      assert(client);
+      if (client.idTokenSignedResponseAlg !== 'none') {
+        alg = client.idTokenSignedResponseAlg;
+      }
+    }
+
+    const keystore = alg.startsWith('HS') ? client.keystore : instance(provider).keystore;
+    const key = keystore.get({ alg, use });
+
+    return { key, alg };
+  }
+
+  return {
+    generateTokenId() {
+      return nanoid();
+    },
+    async getValueAndPayload() {
+      const [, payload] = await opaque.getValueAndPayload.call(this);
+      const {
+        jti, sub, iss, iat, exp, scope, aud, clientId: azp,
+      } = payload;
+
+      let value;
+      if (this.jwt) {
+        value = this.jwt;
+      } else {
+        const { key, alg } = await getSigningAlgAndKey(azp);
+        value = await JWT.sign({
+          jti, sub, iss, iat, exp, scope, ...(aud ? { aud, azp } : { aud: azp }),
+        }, key, alg);
+      }
+      payload.jwt = value;
+
+      return [value, payload];
+    },
+    getTokenId(token) {
+      return getClaim(token, 'jti');
+    },
+    async verify(token, stored, { ignoreExpiration }) {
+      assert.equal(token, stored.jwt);
+      const jti = this.getTokenId(token);
+      return opaque.verify.call(this, jti, stored, { ignoreExpiration });
+    },
+  };
+};

--- a/lib/models/formats/legacy.js
+++ b/lib/models/formats/legacy.js
@@ -1,0 +1,51 @@
+const assert = require('assert');
+const { randomBytes } = require('crypto');
+const { pick } = require('lodash');
+const base64url = require('base64url');
+const uuid = require('uuid/v4');
+
+const { assertPayload, sign, decode } = require('../../helpers/jwt');
+const instance = require('../../helpers/weak_cache');
+
+module.exports = provider => ({
+  generateTokenId() {
+    return base64url(uuid());
+  },
+  async getValueAndPayload() {
+    const jwt = await sign(pick(this, this.constructor.IN_PAYLOAD), undefined, 'none', {
+      issuer: provider.issuer,
+      ...(this.exp ? undefined : { expiresIn: this.expiration }),
+    });
+
+    const [header, payload] = jwt.split('.');
+    let signature;
+
+    if (this.signature) {
+      ({ signature } = this);
+    } else {
+      signature = base64url(randomBytes(64));
+    }
+
+    return [`${this.jti}${signature}`, {
+      header,
+      payload,
+      signature,
+      ...(this.grantId ? { grantId: this.grantId } : undefined),
+    }];
+  },
+  getTokenId(token) {
+    return token.substring(0, 48);
+  },
+  async verify(token, stored, { ignoreExpiration } = {}) {
+    assert.equal(token.substring(48), stored.signature);
+    const { payload } = decode([stored.header, stored.payload, stored.signature].join('.'));
+    payload.signature = stored.signature;
+    assertPayload(payload, {
+      ignoreExpiration,
+      issuer: provider.issuer,
+      clockTolerance: instance(provider).configuration('clockTolerance'),
+      jti: this.getTokenId(token),
+    });
+    return payload;
+  },
+});

--- a/lib/models/formats/opaque.js
+++ b/lib/models/formats/opaque.js
@@ -1,0 +1,64 @@
+const nanoid = require('nanoid');
+const {
+  pickBy,
+  isUndefined,
+} = require('lodash');
+
+const { assertPayload } = require('../../helpers/jwt');
+const epochTime = require('../../helpers/epoch_time');
+const instance = require('../../helpers/weak_cache');
+
+module.exports = provider => ({
+  // For tokens having their surface reduced by authentication we aim for the recommended 160 bits,
+  // bearer tokens we aim for 256 bits.
+  //
+  // Default nanoid has a (26+26+10+2 = 64) symbol alphabet (6 bits). So with 6 bits per symbol, and
+  // 27 symbols, we arrive at (6*27 = 162) total bits while for Bearer we go for 43 symbols
+  // (6*27 = 258) total bits.
+
+  // >= 256 bits
+  //   RegistrationAccessToken
+  //   ClientCredentials
+  //   InitialAccessToken
+  //   AccessToken
+  // >= 160 bits
+  //   RefreshToken
+  //   AuthorizationCode
+  generateTokenId() {
+    switch (this.name) {
+      case 'RefreshToken':
+      case 'AuthorizationCode':
+        return nanoid(27);
+      default:
+        return nanoid(43);
+    }
+  },
+  async getValueAndPayload() {
+    const now = epochTime();
+    const exp = this.exp || now + this.expiration;
+    const payload = [this.jti, {
+      iat: this.iat || epochTime(),
+      iss: provider.issuer,
+      ...(exp ? { exp } : undefined),
+      ...pickBy(
+        this,
+        (value, key) => this.constructor.IN_PAYLOAD.includes(key) && !isUndefined(value),
+      ),
+    }];
+
+    return payload;
+  },
+  getTokenId(token) {
+    return token;
+  },
+  async verify(token, stored, { ignoreExpiration }) {
+    assertPayload(stored, {
+      ignoreExpiration,
+      issuer: provider.issuer,
+      clockTolerance: instance(provider).configuration('clockTolerance'),
+      jti: token,
+    });
+
+    return stored;
+  },
+});

--- a/lib/models/initial_access_token.js
+++ b/lib/models/initial_access_token.js
@@ -1,12 +1,14 @@
 const hasFormat = require('./mixins/has_format');
 
-module.exports = function getInitialAccessToken(provider) {
-  return class InitialAccessToken extends hasFormat(provider, 'InitialAccessToken', provider.BaseToken) {
-    static get IN_PAYLOAD() {
-      return [
-        'jti',
-        'kind',
-      ];
-    }
-  };
+module.exports = provider => class InitialAccessToken extends hasFormat(
+  provider,
+  'InitialAccessToken',
+  provider.BaseToken,
+) {
+  static get IN_PAYLOAD() {
+    return [
+      'jti',
+      'kind',
+    ];
+  }
 };

--- a/lib/models/initial_access_token.js
+++ b/lib/models/initial_access_token.js
@@ -1,5 +1,7 @@
-module.exports = function getInitialAccessToken({ BaseToken }) {
-  return class InitialAccessToken extends BaseToken {
+const hasFormat = require('./mixins/has_format');
+
+module.exports = function getInitialAccessToken(provider) {
+  return class InitialAccessToken extends hasFormat(provider, 'InitialAccessToken', provider.BaseToken) {
     static get IN_PAYLOAD() {
       return [
         'jti',

--- a/lib/models/mixins/apply.js
+++ b/lib/models/mixins/apply.js
@@ -1,0 +1,4 @@
+module.exports = function apply(mixins) {
+  const klass = mixins.pop();
+  return mixins.reduce((mixed, mixin) => mixin(mixed), klass);
+};

--- a/lib/models/mixins/consumable.js
+++ b/lib/models/mixins/consumable.js
@@ -1,0 +1,8 @@
+module.exports = superclass => class extends superclass {
+  static get IN_PAYLOAD() {
+    return [
+      ...super.IN_PAYLOAD,
+      'consumed',
+    ];
+  }
+};

--- a/lib/models/mixins/has_format.js
+++ b/lib/models/mixins/has_format.js
@@ -20,6 +20,8 @@ module.exports = (provider, type, superclass) => {
     klass.prototype.constructor.getTokenId = getTokenId;
     klass.prototype.constructor.verify = verify;
 
+    Object.defineProperty(klass.prototype.constructor, 'format', { value: FORMAT });
+
     return klass;
   }
 

--- a/lib/models/mixins/has_format.js
+++ b/lib/models/mixins/has_format.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const formats = require('../formats');
+const instance = require('../../helpers/weak_cache');
+
+module.exports = (provider, type, superclass) => {
+  const { [type]: FORMAT, default: DEFAULT } = instance(provider).configuration('formats');
+
+  if ((FORMAT && FORMAT !== DEFAULT) || type === 'default') {
+    assert(formats[FORMAT], `invalid format specified (${FORMAT})`);
+    const {
+      generateTokenId,
+      getValueAndPayload,
+      getTokenId,
+      verify,
+    } = formats[FORMAT](provider);
+
+    const klass = class extends superclass {};
+    klass.prototype.constructor.generateTokenId = generateTokenId;
+    klass.prototype.getValueAndPayload = getValueAndPayload;
+    klass.prototype.constructor.getTokenId = getTokenId;
+    klass.prototype.constructor.verify = verify;
+
+    return klass;
+  }
+
+  return superclass;
+};

--- a/lib/models/refresh_token.js
+++ b/lib/models/refresh_token.js
@@ -1,6 +1,10 @@
 const storesAuth = require('./mixins/stores_auth');
 const hasFormat = require('./mixins/has_format');
+const consumable = require('./mixins/consumable');
+const apply = require('./mixins/apply');
 
-module.exports = function getRefreshToken(provider) {
-  return class RefreshToken extends storesAuth(hasFormat(provider, 'RefreshToken', provider.BaseToken)) {};
-};
+module.exports = provider => class RefreshToken extends apply([
+  consumable,
+  storesAuth,
+  hasFormat(provider, 'RefreshToken', provider.BaseToken),
+]) {};

--- a/lib/models/refresh_token.js
+++ b/lib/models/refresh_token.js
@@ -1,5 +1,6 @@
 const storesAuth = require('./mixins/stores_auth');
+const hasFormat = require('./mixins/has_format');
 
-module.exports = function getRefreshToken({ BaseToken }) {
-  return class RefreshToken extends storesAuth(BaseToken) {};
+module.exports = function getRefreshToken(provider) {
+  return class RefreshToken extends storesAuth(hasFormat(provider, 'RefreshToken', provider.BaseToken)) {};
 };

--- a/lib/models/registration_access_token.js
+++ b/lib/models/registration_access_token.js
@@ -1,5 +1,7 @@
 const hasFormat = require('./mixins/has_format');
 
-module.exports = function getRegistrationAccessToken(provider) {
-  return class RegistrationAccessToken extends hasFormat(provider, 'RegistrationAccessToken', provider.BaseToken) {};
-};
+module.exports = provider => class RegistrationAccessToken extends hasFormat(
+  provider,
+  'RegistrationAccessToken',
+  provider.BaseToken,
+) {};

--- a/lib/models/registration_access_token.js
+++ b/lib/models/registration_access_token.js
@@ -1,3 +1,5 @@
-module.exports = function getRegistrationAccessToken({ BaseToken }) {
-  return class RegistrationAccessToken extends BaseToken {};
+const hasFormat = require('./mixins/has_format');
+
+module.exports = function getRegistrationAccessToken(provider) {
+  return class RegistrationAccessToken extends hasFormat(provider, 'RegistrationAccessToken', provider.BaseToken) {};
 };

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "koa-router": "^7.4.0",
     "lodash": "^4.17.10",
     "lru-cache": "^4.1.3",
+    "nanoid": "^1.0.3",
     "node-jose": "^1.0.0",
     "oidc-token-hash": "^3.0.1",
     "raw-body": "^2.3.3",
@@ -61,6 +62,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
+    "clear-module": "^2.1.0",
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.12.0",
@@ -73,7 +75,8 @@
     "nyc": "^12.0.2",
     "pre-commit": "^1.2.2",
     "sinon": "^6.0.0",
-    "supertest": "^3.1.0"
+    "supertest": "^3.1.0",
+    "timekeeper": "^2.1.2"
   },
   "engines": {
     "node": ">=8.9.0"

--- a/test/base_token/base_token.test.js
+++ b/test/base_token/base_token.test.js
@@ -105,6 +105,17 @@ describe('BaseToken', () => {
     expect(third).to.equal(second);
   });
 
+  it('consumed token save saves consumed', async function () {
+    let token = new this.provider.AuthorizationCode({
+      grantId: 'foo',
+      consumed: true,
+    });
+    const first = await token.save();
+
+    token = await this.provider.AuthorizationCode.find(first);
+    expect(token.consumed).to.be.true;
+  });
+
   it('rethrows adapter#find errors', async function () {
     this.adapter.find.restore();
     const adapterThrow = new Error('adapter throw!');

--- a/test/base_token/base_token.test.js
+++ b/test/base_token/base_token.test.js
@@ -134,6 +134,7 @@ describe('mixed formats for tokens', () => {
       this.provider.BaseToken, this.provider.AccessToken,
       this.provider.RefreshToken, this.provider.AuthorizationCode,
     ];
+
     const generateTokenId = models.map(m => m.generateTokenId);
     const getTokenId = models.map(m => m.getTokenId);
     const verify = models.map(m => m.getTokenId);

--- a/test/base_token/base_token_mixed_formats.config.js
+++ b/test/base_token/base_token_mixed_formats.config.js
@@ -1,0 +1,16 @@
+const { clone, shuffle } = require('lodash');
+const config = clone(require('../default.config'));
+
+const { formats: { default: FORMAT } } = require('../../lib/helpers/defaults');
+const [AccessToken, RefreshToken, AuthorizationCode] = shuffle(Object.keys(require('../../lib/models/formats')));
+
+config.formats = {
+  default: FORMAT,
+  AccessToken,
+  RefreshToken,
+  AuthorizationCode,
+};
+
+module.exports = {
+  config,
+};

--- a/test/configuration/adapter_test.test.js
+++ b/test/configuration/adapter_test.test.js
@@ -2,21 +2,30 @@ const Provider = require('../../lib');
 const { TestAdapter } = require('../models');
 
 const { AdapterTest } = Provider;
+const clientFactory = () => 'client';
+const client = {
+  client_id: 'client',
+  client_secret: 'secret',
+  redirect_uris: ['https://rp.example.com/cb'],
+};
 
 describe('AdapterTest', () => {
   it('passes with the default MemoryAdapter', async () => {
     const provider = new Provider('http://localhost');
-    await provider.initialize();
-    const test = new AdapterTest(provider);
+    await provider.initialize({
+      clients: [client],
+    });
+    const test = new AdapterTest(provider, undefined, clientFactory);
     await test.execute();
   });
 
   it('passes with the TestAdapter', async () => {
     const provider = new Provider('http://localhost');
     await provider.initialize({
+      clients: [client],
       adapter: TestAdapter,
     });
-    const test = new AdapterTest(provider);
+    const test = new AdapterTest(provider, undefined, clientFactory);
     await test.execute();
   });
 });

--- a/test/core/implicit/id_token+token.authorization.test.js
+++ b/test/core/implicit/id_token+token.authorization.test.js
@@ -1,7 +1,6 @@
 const bootstrap = require('../../test_helper');
 const url = require('url');
 const sinon = require('sinon');
-const base64url = require('base64url');
 const { expect } = require('chai');
 
 const route = '/auth';
@@ -56,11 +55,10 @@ describe('IMPLICIT id_token+token', () => {
           .expect(auth.validateClientLocation)
           .then((response) => {
             const { query: { access_token } } = url.parse(response.headers.location, true);
-            const jti = access_token.substring(0, 48);
-            const stored = this.TestAdapter.for('AccessToken').syncFind(jti);
-            const payload = JSON.parse(base64url.decode(stored.payload));
+            const jti = this.getTokenJti(access_token);
+            const stored = this.TestAdapter.for('AccessToken').syncFind(jti, { payload: true });
 
-            expect(payload).to.have.property('scope', 'openid');
+            expect(stored).to.have.property('scope', 'openid');
           });
       });
     });

--- a/test/dynamic_registration/dynamic_registration.test.js
+++ b/test/dynamic_registration/dynamic_registration.test.js
@@ -1,7 +1,6 @@
 const bootstrap = require('../test_helper');
 const { expect } = require('chai');
 const sinon = require('sinon');
-const base64url = require('base64url');
 
 function validateError(error) {
   const assert = error.exec ? 'match' : 'equal';
@@ -242,9 +241,9 @@ describe('registration features', () => {
 
         it('allows the developers to insert new tokens with no expiration', function () {
           return new this.provider.InitialAccessToken().save().then((v) => {
-            const jti = v.substring(0, 48);
-            const token = this.TestAdapter.for('InitialAccessToken').syncFind(jti);
-            expect(JSON.parse(base64url.decode(token.payload))).not.to.have.property('exp');
+            const jti = this.getTokenJti(v);
+            const token = this.TestAdapter.for('InitialAccessToken').syncFind(jti, { payload: true });
+            expect(token).not.to.have.property('exp');
           });
         });
 
@@ -252,9 +251,9 @@ describe('registration features', () => {
           return new this.provider.InitialAccessToken({
             expiresIn: 24 * 60 * 60,
           }).save().then((v) => {
-            const jti = v.substring(0, 48);
-            const token = this.TestAdapter.for('InitialAccessToken').syncFind(jti);
-            expect(JSON.parse(base64url.decode(token.payload))).to.have.property('exp');
+            const jti = this.getTokenJti(v);
+            const token = this.TestAdapter.for('InitialAccessToken').syncFind(jti, { payload: true });
+            expect(token).to.have.property('exp');
           });
         });
 

--- a/test/encryption/encryption.test.js
+++ b/test/encryption/encryption.test.js
@@ -109,7 +109,7 @@ const route = '/auth';
           response_type: 'code',
           redirect_uri: 'https://client.example.com/cb',
         }, null, 'none', { issuer: 'client', audience: this.provider.issuer }).then(signed =>
-          JWT.encrypt(signed, instance(this.provider).keystore.get({ kty: 'RSA' }), 'A128CBC-HS256', 'RSA1_5')).then(encrypted =>
+          JWT.encrypt(signed, i(this.provider).keystore.get({ kty: 'RSA' }), 'A128CBC-HS256', 'RSA1_5')).then(encrypted =>
           this.wrap({
             route,
             verb,
@@ -137,7 +137,7 @@ const route = '/auth';
           response_type: 'code',
           redirect_uri: 'https://client.example.com/cb',
         }, null, 'none', { issuer: 'client', audience: this.provider.issuer }).then(signed =>
-          JWT.encrypt(signed, instance(this.provider).keystore.get({ kty: 'RSA' }), 'A128CBC-HS256', 'RSA-OAEP')).then(encrypted =>
+          JWT.encrypt(signed, i(this.provider).keystore.get({ kty: 'RSA' }), 'A128CBC-HS256', 'RSA-OAEP')).then(encrypted =>
           this.wrap({
             route,
             verb,

--- a/test/pkce/pkce.test.js
+++ b/test/pkce/pkce.test.js
@@ -1,4 +1,3 @@
-const base64url = require('base64url');
 const bootstrap = require('../test_helper');
 const { parse: parseUrl } = require('url');
 const { expect } = require('chai');
@@ -21,12 +20,10 @@ describe('PKCE RFC7636', () => {
         .query(auth)
         .expect((response) => {
           const { query: { code } } = parseUrl(response.headers.location, true);
-          const jti = code.substring(0, 48);
-          const stored = this.TestAdapter.for('AuthorizationCode').syncFind(jti);
-          const payload = JSON.parse(base64url.decode(stored.payload));
-
-          expect(payload).to.have.property('codeChallengeMethod', 'plain');
-          expect(payload).to.have.property('codeChallenge', 'foobar');
+          const jti = this.getTokenJti(code);
+          const stored = this.TestAdapter.for('AuthorizationCode').syncFind(jti, { payload: true });
+          expect(stored).to.have.property('codeChallengeMethod', 'plain');
+          expect(stored).to.have.property('codeChallenge', 'foobar');
         });
     });
 
@@ -41,12 +38,11 @@ describe('PKCE RFC7636', () => {
         .query(auth)
         .expect((response) => {
           const { query: { code } } = parseUrl(response.headers.location, true);
-          const jti = code.substring(0, 48);
-          const stored = this.TestAdapter.for('AuthorizationCode').syncFind(jti);
-          const payload = JSON.parse(base64url.decode(stored.payload));
+          const jti = this.getTokenJti(code);
+          const stored = this.TestAdapter.for('AuthorizationCode').syncFind(jti, { payload: true });
 
-          expect(payload).to.have.property('codeChallengeMethod', 'plain');
-          expect(payload).to.have.property('codeChallenge', 'foobar');
+          expect(stored).to.have.property('codeChallengeMethod', 'plain');
+          expect(stored).to.have.property('codeChallenge', 'foobar');
         });
     });
 
@@ -178,12 +174,11 @@ describe('PKCE RFC7636', () => {
           .query(auth)
           .expect((response) => {
             const { query: { code } } = parseUrl(response.headers.location, true);
-            const jti = code.substring(0, 48);
-            const stored = this.TestAdapter.for('AuthorizationCode').syncFind(jti);
-            const payload = JSON.parse(base64url.decode(stored.payload));
+            const jti = this.getTokenJti(code);
+            const stored = this.TestAdapter.for('AuthorizationCode').syncFind(jti, { payload: true });
 
-            expect(payload).to.have.property('codeChallengeMethod', 'S256');
-            expect(payload).to.have.property('codeChallenge', 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM');
+            expect(stored).to.have.property('codeChallengeMethod', 'S256');
+            expect(stored).to.have.property('codeChallenge', 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM');
           });
       });
     });

--- a/test/registration_management/registration_management.test.js
+++ b/test/registration_management/registration_management.test.js
@@ -287,7 +287,7 @@ describe('OAuth 2.0 Dynamic Client Registration Management Protocol', () => {
             expect(spy.calledOnce).to.be.true;
             const args = spy.firstCall.args[0];
             expect(args.clientId).to.equal(client.client_id);
-            expect(response.body.registration_access_token.substring(0, 48)).to.equal(args.jti);
+            expect(this.getTokenJti(response.body.registration_access_token)).to.equal(args.jti);
           });
       });
     });

--- a/test/request/uri_request.test.js
+++ b/test/request/uri_request.test.js
@@ -5,11 +5,14 @@ const sinon = require('sinon');
 const nock = require('nock');
 const { expect } = require('chai');
 const { parse } = require('url');
+const timekeeper = require('timekeeper');
 
 const route = '/auth';
 
 describe('request Uri features', () => {
   before(bootstrap(__dirname)); // provider, agent, wrap
+
+  afterEach(() => timekeeper.reset());
 
   describe('configuration features.requestUri', () => {
     it('extends discovery', function () {
@@ -139,17 +142,13 @@ describe('request Uri features', () => {
           nock('https://client.example.com')
             .get('/cachedRequest')
             .reply(200, 'content24', {
-              'Cache-Control': 'private, max-age=1',
+              'Cache-Control': 'private, max-age=5',
             })
             .get('/cachedRequest')
             .reply(200, 'content82');
 
           const first = await cache.resolve('https://client.example.com/cachedRequest');
-          await new Promise((resolve) => {
-            setTimeout(() => {
-              resolve();
-            }, 1050);
-          });
+          timekeeper.travel(Date.now() + (10 * 1000));
           const second = await cache.resolve('https://client.example.com/cachedRequest');
 
           expect(first).to.equal('content24');
@@ -161,17 +160,13 @@ describe('request Uri features', () => {
           nock('https://client.example.com')
             .get('/cachedRequest')
             .reply(200, 'content24', {
-              Expires: new Date(Date.now() + 1000).toGMTString(),
+              Expires: new Date(Date.now() + (5 * 1000)).toGMTString(),
             })
             .get('/cachedRequest')
             .reply(200, 'content82');
 
           const first = await cache.resolve('https://client.example.com/cachedRequest');
-          await new Promise((resolve) => {
-            setTimeout(() => {
-              resolve();
-            }, 1050);
-          });
+          timekeeper.travel(Date.now() + (10 * 1000));
           const second = await cache.resolve('https://client.example.com/cachedRequest');
 
           expect(first).to.equal('content24');

--- a/test/revocation/revocation.config.js
+++ b/test/revocation/revocation.config.js
@@ -5,9 +5,16 @@ config.features = { revocation: true, clientCredentials: true };
 
 module.exports = {
   config,
-  client: {
-    client_id: 'client',
-    client_secret: 'secret',
-    redirect_uris: ['https://client.example.com/cb'],
-  },
+  clients: [
+    {
+      client_id: 'client',
+      client_secret: 'secret',
+      redirect_uris: ['https://client.example.com/cb'],
+    },
+    {
+      client_id: 'client2',
+      client_secret: 'secret',
+      redirect_uris: ['https://client2.example.com/cb'],
+    },
+  ],
 };

--- a/test/run.js
+++ b/test/run.js
@@ -1,34 +1,84 @@
 /* eslint-disable no-console */
 
 const { JWK: { createKeyStore } } = require('node-jose');
-const server = require('http').createServer().listen(0);
 const Mocha = require('mocha');
+const { createServer } = require('http');
+const { all: clearRequireCache } = require('clear-module');
+
+const FORMAT_REGEXP = /^--format=(\w+)$/;
+const formats = [];
+process.argv.forEach((arg) => {
+  if (FORMAT_REGEXP.exec(arg)) {
+    formats.push(RegExp.$1);
+  }
+});
+
+if (!formats.length) {
+  formats.push('legacy');
+  formats.push('opaque');
+  formats.push('jwt');
+}
+const passed = [];
 
 const { utils: { lookupFiles } } = Mocha;
-const mocha = new Mocha();
-const NOOP = () => {};
+global.keystore = createKeyStore();
+const files = lookupFiles('test/**/*.test.js', ['js'], true);
+class SuiteFailedError extends Error {}
 
-server.once('listening', () => {
-  global.server = server;
-  global.keystore = createKeyStore();
+const { info, warn } = console;
+console.info = function (...args) {
+  if (!args[0].includes('NOTICE: ')) info.apply(this, args);
+};
+console.warn = function (...args) {
+  if (!args[0].includes('WARNING: ')) warn.apply(this, args);
+};
 
-  Promise.all([
+async function run() {
+  clearRequireCache();
+  const DEFAULTS = require('../lib/helpers/defaults'); // eslint-disable-line global-require
+  DEFAULTS.formats.default = this.format;
+  await new Promise((resolve) => {
+    global.server = createServer().listen(0);
+    global.server.once('listening', resolve);
+  });
+  await new Promise((resolve, reject) => {
+    const mocha = new Mocha();
+    mocha.files = files;
+
+    if (process.env.CI) {
+      // mocha.retries(1);
+      mocha.forbidOnly(); // force suite fail on encountered only test
+      mocha.forbidPending(); // force suite fail on encountered skip test
+    }
+
+    mocha.run((failures) => {
+      if (!failures) {
+        passed.push(`Suite passed with ${this.format} format`);
+        global.server.close(resolve);
+      } else {
+        reject(new SuiteFailedError(`Suite failed with ${this.format} format`));
+      }
+    });
+  });
+}
+
+(async () => {
+  await Promise.all([
     global.keystore.generate('RSA', 1024),
     global.keystore.generate('EC', 'P-256'),
-  ])
-    .then(() => {
-      console.info = NOOP;
-      console.warn = NOOP;
-
-      mocha.files = lookupFiles('test/**/*.test.js', ['js'], true);
-
-      mocha.run(() => {
-        server.close();
-      });
-    })
-    .catch((error) => {
+  ]);
+  if (formats.includes('legacy')) await run.call({ format: 'legacy' });
+  if (formats.includes('opaque')) await run.call({ format: 'opaque' });
+  if (formats.includes('jwt')) await run.call({ format: 'jwt' });
+  passed.forEach(pass => console.log('\x1b[32m%s\x1b[0m', pass));
+})()
+  .catch((error) => {
+    passed.forEach(pass => console.log('\x1b[32m%s\x1b[0m', pass));
+    if (error instanceof SuiteFailedError) {
+      console.log('\x1b[31m%s\x1b[0m', error.message);
+    } else {
       console.error(error);
-      server.close();
-      process.exitCode = 1;
-    });
-});
+    }
+    global.server.close();
+    process.exitCode = 1;
+  });


### PR DESCRIPTION
Added `formats` configuration option. This option allows to configure the token storage and value formats. The different values change how a token value is generated as well as what properties get sent to the adapter for storage. Three formats are defined (see [`lib/models/formats`](https://github.com/panva/node-oidc-provider/tree/storage-formats/lib/models/formats))

- `legacy` is the current and default format until next major release. no changes in the format sent to adapter
- `opaque` formatted tokens have a different value then `legacy` and in addition store what was in
  legacy format encoded under `payload` as root properties, this makes analysing the data in your storage way easier
- `jwt` formatted tokens are issued as JWTs and stored the same as `opaque` only with additional property `jwt`. The signing algorithm for these tokens uses the client's `id_token_signed_response_alg` value and falls back to `RS256` for tokens with no relation to a client or when the client's alg is `none`

This feature uses the previously defined public token API of `[klass].prototype.getValueAndPayload, [klass].prototype.constructor.getTokenId, [klass].prototype.constructor.verify` and adds a new one `[klass].prototype.constructor.generateTokenId`. See the inline comment docs for more detail on those.

Example use, setting default opaque and access tokens as JWTs.
```js
const oidc = new Provider('...', {
  formats: { default: 'opaque', AccessToken: 'jwt' },
});
```

**Further format ideas and suggestions are welcome.**

@madarche please check and adapt `example/adapters/bookshelf_postgresql_adapter.js` for new storage formats support (opaque and jwt) if needed.