### PR TITLE
conform id token end-user claims feature toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,9 +32,20 @@ Yay for [SemVer](http://semver.org/).
 
 ## Unreleased
 - [DIFF](https://github.com/panva/node-oidc-provider/compare/v4.0.3...master)
+
+
+**New Features**
+Added `conformIdTokenClaims` feature toggle.
+
+This toggle makes the OP only include End-User claims in the ID Token as defined by Core 1.0 section
+5.4 - when the response_type is id_token or unless requested using the claims parameter.
+
+**Fixes**
 - fixed edge cases where client and provider signing keys would be used for encryption and vice versa
+- fixed an end_session server error in case where session.authorizations is missing - #295
 - adjusted error_description to be more descriptive when PKCE plain value fallback is not possible
   due to the plain method not being supported
+
 
 ## 4.0.x
 ### 4.0.3

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1474,7 +1474,7 @@ default value:
 
 [client-metadata]: https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
 [core-account-claims]: https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
-[core-scopes]: http://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
+[core-scopes]: https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
 [core-offline-access]: https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess
 [core-claims]: https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter
 [core-jwt-parameters]: https://openid.net/specs/openid-connect-core-1_0.html#JWTRequests

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,7 +98,7 @@ const oidc = new Provider('http://localhost:3000', {
 **Aggregated and Distributed claims**  
 Returning aggregated and distributed claims is as easy as having your Account#claims method return
 the two necessary members `_claim_sources` and `_claim_names` with the
-[expected][aggregated-distributed-claims] properties. oidc-provider will include only the
+[expected][core-aggregated-distributed-claims] properties. oidc-provider will include only the
 sources for claims that are part of the request scope, omitting the ones that the RP did not request
 and leaving out the entire `_claim_sources` and `_claim_sources` if they bear no requested claims.
 
@@ -368,6 +368,7 @@ deployment compact. The feature flags with their default values are
 | frontchannelLogout | no |
 | claimsParameter | no |
 | clientCredentials | no |
+| conformIdTokenClaims | no |
 | discovery | yes |
 | encryption | no |
 | introspection | no |
@@ -404,11 +405,37 @@ WebFinger always returns positive results and links to this issuer, it is not re
 in any way.
 
 **Authorization `claims` parameter**  
-Enables the use and validations of `claims` parameter as described in [Core 1.0][core-claims-url]
+Enables the use and validations of `claims` parameter as described in
+[Core 1.0 - 5.5. Requesting Claims using the "claims" Request Parameter][core-claims]
 and sets the discovery endpoint property `claims_parameter_supported` to true.
 ```js
 const configuration = { features: { claimsParameter: Boolean[false] } };
 ```
+
+**ID Token only contains End-User claims when response_type=id_token**  
+[Core 1.0 - 5.4. Requesting Claims using Scope Values][core-scopes]
+defines that claims requested using the `scope` parameter are returned from the UserInfo Endpoint
+unless the `response_type=id_token`.
+
+> The Claims requested by the profile, email, address, and phone scope values are returned from the
+> UserInfo Endpoint, as described in Section 5.3.2, when a response_type value is used that results
+> in an Access Token being issued. However, when no Access Token is issued (which is the case for
+> the response_type value id_token), the resulting Claims are returned in the ID Token.
+
+To enable/disable this conform behaviour
+```js
+const configuration = { features: { conformIdTokenClaims: Boolean[false] } };
+```
+
+The conform/non-conform behaviour results in the following results
+
+| flag value | request params | authorization_endpoint ID Token (if issued) | token_endpoint ID Token (if issued) |
+|---|---|---|---|
+| false | `response_type=` _any_<br/><br/> `scope=openid email` | ✅ `sub`<br/> ✅ `email`<br/> ✅ `email_verified` | ✅ `sub`<br/> ✅ `email`<br/> ✅ `email_verified` |
+| true | `response_type=` _any but_ `id_token`<br/><br/> `scope=openid email` | ✅ `sub`<br/> ❌ `email`<br/> ❌ `email_verified` | ✅ `sub`<br/> ❌ `email`<br/> ❌ `email_verified` |
+| true | `response_type=` _any but_ `id_token`<br/><br/> `scope=openid email`<br/><br/> `claims={"id_token":{"email":null}}` | ✅ `sub`<br/> ✅ `email`<br/> ❌ `email_verified` | ✅ `sub`<br/> ✅ `email`<br/> ❌ `email_verified` |
+| true | `response_type=id_token`<br/><br/> `scope=openid email` | ✅ `sub`<br/> ✅ `email`<br/> ✅ `email_verified` | _n/a_ |
+
 
 **Token endpoint `client_credentials` grant**  
 Enables `grant_type=client_credentials` to be used on the token endpoint. Note: client still has to
@@ -420,7 +447,7 @@ const configuration = { features: { clientCredentials: Boolean[false] } };
 ```
 
 **Encryption features**  
-Enables clients to receive encrypted userinfo responses, encrypted ID Tokens and to send encrypted
+Enables clients to receive encrypted UserInfo responses, encrypted ID Tokens and to send encrypted
 request parameters to authorization.
 ```js
 const configuration = { features: { encryption: Boolean[false] } };
@@ -428,14 +455,14 @@ const configuration = { features: { encryption: Boolean[false] } };
 
 
 **Offline access - Refresh Tokens**  
-The use of Refresh Tokens (offline access) as described in [Core 1.0 Offline Access][core-offline-access]
+The use of Refresh Tokens (offline access) as described in [Core 1.0 - 11. Offline Access][core-offline-access]
 does not require any feature flag as Refresh Tokens will be issued by the authorization_code grant
 automatically in case the authentication request included offline_access scope and consent prompt and
 the client in question has the refresh_token grant configured.
 
 **Refresh Tokens beyond the spec scope**  
-  > The use of Refresh Tokens is not exclusive to the offline_access use case. The Authorization
-  > Server MAY grant Refresh Tokens in other contexts that are beyond the scope of this specification.
+> The use of Refresh Tokens is not exclusive to the offline_access use case. The Authorization
+> Server MAY grant Refresh Tokens in other contexts that are beyond the scope of this specification.
 
 Provide `alwaysIssueRefresh` feature flag to have your provider instance issue Refresh Tokens even
 if offline_access scope is not requested. The client still has to have refresh_token grant
@@ -448,7 +475,7 @@ const configuration = { features: { alwaysIssueRefresh: Boolean[false] } };
 
 **Authorization `request` parameter**  
 Enables the use and validations of `request` parameter as described in
-[Core 1.0][core-jwt-parameters-url] and sets the discovery endpoint property
+[Core 1.0][core-jwt-parameters] and sets the discovery endpoint property
 `request_parameter_supported` to true.
 
 ```js
@@ -458,7 +485,7 @@ const configuration = { features: { request: Boolean[false] } };
 
 **Authorization `request_uri` parameter**  
 Enables the use and validations of `request_uri` parameter as described in
-[Core 1.0][core-jwt-parameters-url] and sets the discovery endpoint property
+[Core 1.0][core-jwt-parameters] and sets the discovery endpoint property
 `request_uri_parameter_supported` and `require_request_uri_registration` to true.
 ```js
 const configuration = { features: { requestUri: Boolean[true] } };
@@ -858,7 +885,7 @@ default value:
 
 Helper used by the OP to push additional audiences to issued ID Tokens and other signed responses. The return value should either be falsy to omit adding additional audiences or an array of strings to push.  
 
-affects: id token audiences, signed userinfo audiences  
+affects: ID Token audiences, signed UserInfo audiences  
 
 default value:
 ```js
@@ -1060,6 +1087,7 @@ default value:
   frontchannelLogout: false,
   claimsParameter: false,
   clientCredentials: false,
+  conformIdTokenClaims: false,
   encryption: false,
   introspection: false,
   alwaysIssueRefresh: false,
@@ -1074,7 +1102,7 @@ default value:
 
 Helper used by the OP to load your account and retrieve it's available claims. The return value should be a Promise and #claims() can return a Promise too  
 
-affects: authorization, authorization_code and refresh_token grants, id token claims  
+affects: authorization, authorization_code and refresh_token grants, ID Token claims  
 
 default value:
 ```js
@@ -1090,7 +1118,7 @@ async findById(ctx, sub, token) {
     // @param scope - the intended scope, while oidc-provider will mask
     //   claims depending on the scope automatically you might want to skip
     //   loading some claims from external resources etc. based on this detail
-    //   or not return them in id tokens but only userinfo and so on
+    //   or not return them in ID Tokens but only UserInfo and so on
     async claims(use, scope) {
       return { sub };
     },
@@ -1446,10 +1474,11 @@ default value:
 
 [client-metadata]: https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata
 [core-account-claims]: https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
+[core-scopes]: http://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims
 [core-offline-access]: https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess
-[core-claims-url]: https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter
-[core-jwt-parameters-url]: https://openid.net/specs/openid-connect-core-1_0.html#JWTRequests
-[aggregated-distributed-claims]: https://openid.net/specs/openid-connect-core-1_0.html#AggregatedDistributedClaims
+[core-claims]: https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter
+[core-jwt-parameters]: https://openid.net/specs/openid-connect-core-1_0.html#JWTRequests
+[core-aggregated-distributed-claims]: https://openid.net/specs/openid-connect-core-1_0.html#AggregatedDistributedClaims
 [backchannel-logout]: https://openid.net/specs/openid-connect-backchannel-1_0-04.html
 [frontchannel-logout]: https://openid.net/specs/openid-connect-frontchannel-1_0-02.html
 [pkce]: https://tools.ietf.org/html/rfc7636

--- a/example/settings.js
+++ b/example/settings.js
@@ -31,6 +31,7 @@ module.exports.config = {
 
     backchannelLogout: true, // defaults to false
     claimsParameter: true, // defaults to false
+    conformIdTokenClaims: true, // defaults to false
     encryption: true, // defaults to false
     frontchannelLogout: true, // defaults to false
     introspection: true, // defaults to false

--- a/lib/actions/authorization/process_response_types.js
+++ b/lib/actions/authorization/process_response_types.js
@@ -5,7 +5,7 @@ module.exports = (provider) => {
   const { IdToken, AccessToken, AuthorizationCode } = provider;
 
   const {
-    features: { pkce },
+    features: { pkce, conformIdTokenClaims },
     audiences,
   } = instance(provider).configuration();
 
@@ -69,7 +69,15 @@ module.exports = (provider) => {
       },
     }, ctx.oidc.client.sectorIdentifier);
 
-    token.scope = ctx.oidc.params.scope;
+    if (conformIdTokenClaims) {
+      if (ctx.oidc.params.response_type === 'id_token') {
+        token.scope = ctx.oidc.params.scope;
+      } else {
+        token.scope = 'openid';
+      }
+    } else {
+      token.scope = ctx.oidc.params.scope;
+    }
     token.mask = get(ctx.oidc.claims, 'id_token', {});
 
     token.set('nonce', ctx.oidc.params.nonce);

--- a/lib/actions/grants/authorization_code.js
+++ b/lib/actions/grants/authorization_code.js
@@ -7,7 +7,9 @@ const presence = require('../../helpers/validate_presence');
 const instance = require('../../helpers/weak_cache');
 
 module.exports.handler = function getAuthorizationCodeHandler(provider) {
-  const { features: { pkce, alwaysIssueRefresh }, audiences } = instance(provider).configuration();
+  const {
+    features: { pkce, alwaysIssueRefresh, conformIdTokenClaims }, audiences,
+  } = instance(provider).configuration();
   return async function authorizationCodeResponse(ctx, next) {
     presence(ctx, ['code', 'redirect_uri']);
 
@@ -114,7 +116,11 @@ module.exports.handler = function getAuthorizationCodeHandler(provider) {
       },
     }, ctx.oidc.client.sectorIdentifier);
 
-    token.scope = code.scope;
+    if (conformIdTokenClaims) {
+      token.scope = 'openid';
+    } else {
+      token.scope = code.scope;
+    }
     token.mask = get(code.claims, 'id_token', {});
 
     token.set('nonce', code.nonce);

--- a/lib/actions/grants/refresh_token.js
+++ b/lib/actions/grants/refresh_token.js
@@ -8,7 +8,9 @@ module.exports.handler = function getRefreshTokenHandler(provider) {
 
   return async function refreshTokenResponse(ctx, next) {
     presence(ctx, ['refresh_token']);
-    const { refreshTokenRotation, audiences } = conf;
+    const {
+      refreshTokenRotation, audiences, features: { conformIdTokenClaims },
+    } = conf;
 
     const {
       RefreshToken, Account, AccessToken, IdToken,
@@ -104,7 +106,11 @@ module.exports.handler = function getRefreshTokenHandler(provider) {
       auth_time: refreshToken.authTime,
     }), ctx.oidc.client.sectorIdentifier);
 
-    token.scope = scope;
+    if (conformIdTokenClaims) {
+      token.scope = 'openid';
+    } else {
+      token.scope = scope;
+    }
     token.mask = _.get(refreshToken.claims, 'id_token', {});
 
     token.set('nonce', refreshToken.nonce);

--- a/lib/helpers/configuration.js
+++ b/lib/helpers/configuration.js
@@ -5,6 +5,7 @@ const STABLE_FLAGS = [
   'oauthNativeApps',
   'claimsParameter',
   'clientCredentials',
+  'conformIdTokenClaims',
   'discovery',
   'encryption',
   'introspection',

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -175,6 +175,7 @@ const DEFAULTS = {
     frontchannelLogout: false,
     claimsParameter: false,
     clientCredentials: false,
+    conformIdTokenClaims: false, // TODO: true in next major
     encryption: false,
     introspection: false,
     alwaysIssueRefresh: false,
@@ -513,7 +514,7 @@ const DEFAULTS = {
    * description: Helper used by the OP to push additional audiences to issued ID Tokens and other
    *   signed responses. The return value should either be falsy to omit adding additional audiences
    *   or an array of strings to push.
-   * affects: id token audiences, signed userinfo audiences
+   * affects: ID Token audiences, signed UserInfo audiences
    */
   async audiences(ctx, sub, token, use, scope) { // eslint-disable-line no-unused-vars
     // @param ctx   - koa request context
@@ -532,7 +533,7 @@ const DEFAULTS = {
    *
    * description: Helper used by the OP to load your account and retrieve it's available claims. The
    *   return value should be a Promise and #claims() can return a Promise too
-   * affects: authorization, authorization_code and refresh_token grants, id token claims
+   * affects: authorization, authorization_code and refresh_token grants, ID Token claims
    */
   async findById(ctx, sub, token) { // eslint-disable-line no-unused-vars
     // @param ctx   - koa request context
@@ -547,7 +548,7 @@ const DEFAULTS = {
       // @param scope - the intended scope, while oidc-provider will mask
       //   claims depending on the scope automatically you might want to skip
       //   loading some claims from external resources etc. based on this detail
-      //   or not return them in id tokens but only userinfo and so on
+      //   or not return them in ID Tokens but only UserInfo and so on
       async claims(use, scope) { // eslint-disable-line no-unused-vars
         return { sub };
       },

--- a/test/claim_types/claim_types.config.js
+++ b/test/claim_types/claim_types.config.js
@@ -6,7 +6,7 @@ module.exports = {
     client_id: 'client',
     client_secret: 'secret',
     grant_types: ['implicit'],
-    response_types: ['id_token token'],
+    response_types: ['id_token token', 'id_token'],
     redirect_uris: ['https://client.example.com/cb'],
   },
 };

--- a/test/claim_types/claim_types.test.js
+++ b/test/claim_types/claim_types.test.js
@@ -36,7 +36,7 @@ describe('distributed and aggregated claims', () => {
   context('id_token', () => {
     it('should return _claim_names and _claim_sources members', function () {
       const auth = new this.AuthorizationRequest({
-        response_type: 'id_token token',
+        response_type: 'id_token',
         scope: 'openid profile',
       });
 
@@ -59,7 +59,7 @@ describe('distributed and aggregated claims', () => {
 
     it('does not return the members if these claims arent requested at all', function () {
       const auth = new this.AuthorizationRequest({
-        response_type: 'id_token token',
+        response_type: 'id_token',
         scope: 'openid',
       });
 

--- a/test/id_token_claims/conform.config.js
+++ b/test/id_token_claims/conform.config.js
@@ -1,0 +1,17 @@
+const { clone } = require('lodash');
+const config = clone(require('../default.config'));
+
+config.features = { conformIdTokenClaims: true, claimsParameter: true, alwaysIssueRefresh: true };
+
+module.exports = {
+  config,
+  clients: [{
+    client_id: 'client',
+    token_endpoint_auth_method: 'none',
+    grant_types: ['authorization_code', 'implicit', 'refresh_token'],
+    response_types: [
+      'code id_token token', 'code id_token', 'code token', 'code', 'id_token token', 'id_token',
+    ],
+    redirect_uris: ['https://client.example.com/cb'],
+  }],
+};

--- a/test/id_token_claims/conform.test.js
+++ b/test/id_token_claims/conform.test.js
@@ -1,0 +1,124 @@
+/* eslint-disable prefer-const */
+
+const { expect } = require('chai');
+const { parse: parseUrl } = require('url');
+
+const bootstrap = require('../test_helper');
+const { decode: decodeJWT } = require('../../lib/helpers/jwt');
+
+const redirect_uri = 'https://client.example.com/cb';
+const scope = 'openid email';
+const client_id = 'client';
+
+describe('features.conformIdTokenClaims=true', () => {
+  before(bootstrap(__dirname, 'conform'));
+  before(function () { return this.login(); });
+
+  [
+    'code id_token token', 'code id_token', 'code token', 'code', 'id_token token', 'id_token',
+  ].forEach((response_type) => {
+    describe(`response_type=${response_type}`, () => {
+      before(async function () {
+        const client = await this.provider.Client.find('client');
+
+        const claims = JSON.stringify({
+          id_token: { gender: null, email: null },
+          ...(response_type !== 'id_token' ? { userinfo: { gender: null } } : undefined),
+        });
+
+        const auth = new this.AuthorizationRequest({ response_type, scope, claims });
+
+        let id_token;
+        let refresh_token;
+        let code;
+        let access_token;
+
+        const { headers: { location } } = await this.agent
+          .get('/auth')
+          .query(auth)
+          .expect(302)
+          .expect((...args) => {
+            if (response_type === 'code') return;
+            auth.validateFragment(...args);
+          })
+          .expect(auth.validateClientLocation);
+
+        ({ query: { code, id_token, access_token } } = parseUrl(location, true));
+
+        this.authorization = { id_token };
+
+        if (response_type.includes('code')) {
+          ({ body: { id_token, refresh_token } } = await this.agent.post('/token')
+            .send({
+              client_id, code, grant_type: 'authorization_code', redirect_uri,
+            })
+            .type('form')
+            .expect(200));
+
+          this.token = { id_token };
+
+          ({ body: { id_token, access_token } } = await this.agent.post('/token')
+            .send({ client_id, grant_type: 'refresh_token', refresh_token })
+            .type('form')
+            .expect(200));
+
+          this.refresh = { id_token };
+        }
+
+        if (access_token) {
+          let userinfo;
+          delete client.userinfoSignedResponseAlg;
+          ({ body: userinfo } = await this.agent.get('/me')
+            .auth(access_token, { type: 'bearer' })
+            .expect(200));
+          this.userinfo = userinfo;
+
+          client.userinfoSignedResponseAlg = 'none';
+          await this.provider.Client.find('client');
+          ({ text: userinfo } = await this.agent.get('/me')
+            .auth(access_token, { type: 'bearer' })
+            .expect(200));
+          this.userinfoSigned = userinfo;
+        }
+      });
+
+      if (response_type === 'id_token') {
+        it('authorization endpoint id_token has scope requested claims', function () {
+          const { payload } = decodeJWT(this.authorization.id_token);
+          expect(payload).to.contain.keys('gender', 'email', 'email_verified');
+        });
+      } else if (response_type.includes('id_token')) {
+        it('authorization endpoint id_token does not have scope requested claims', function () {
+          const { payload } = decodeJWT(this.authorization.id_token);
+          expect(payload).to.contain.keys('gender', 'email');
+          expect(payload).not.to.contain.keys('email_verified');
+        });
+      }
+
+      if (response_type !== 'id_token') {
+        it('userinfo has scope requested claims', function () {
+          expect(this.userinfo).to.contain.keys('email', 'email_verified', 'gender');
+        });
+
+        it('signed userinfo has scope requested claims', function () {
+          const { payload } = decodeJWT(this.userinfoSigned);
+          expect(payload).to.contain.keys('email', 'email_verified', 'gender');
+        });
+      }
+
+      if (response_type.includes('code')) {
+        it('token endpoint id_token does not have scope requested claims', function () {
+          const { payload } = decodeJWT(this.token.id_token);
+          expect(payload).to.contain.keys('gender', 'email');
+          expect(payload).not.to.contain.keys('email_verified');
+        });
+
+        it('refreshed id_token does not have scope requested claims', function () {
+          const { payload } = decodeJWT(this.refresh.id_token);
+          expect(payload).to.contain.keys('gender', 'email');
+          expect(payload).not.to.contain.keys('email_verified');
+        });
+      }
+    });
+  });
+});

--- a/test/id_token_claims/non_conform.config.js
+++ b/test/id_token_claims/non_conform.config.js
@@ -1,0 +1,6 @@
+const { clone } = require('lodash');
+const setup = clone(require('./conform.config'));
+
+setup.config.features.conformIdTokenClaims = false;
+
+module.exports = setup;

--- a/test/id_token_claims/non_conform.test.js
+++ b/test/id_token_claims/non_conform.test.js
@@ -1,0 +1,110 @@
+/* eslint-disable prefer-const */
+
+const { expect } = require('chai');
+const { parse: parseUrl } = require('url');
+
+const bootstrap = require('../test_helper');
+const { decode: decodeJWT } = require('../../lib/helpers/jwt');
+
+const redirect_uri = 'https://client.example.com/cb';
+const scope = 'openid email';
+const client_id = 'client';
+
+describe('features.conformIdTokenClaims=false', () => {
+  before(bootstrap(__dirname, 'non_conform'));
+  before(function () { return this.login(); });
+
+  [
+    'code id_token token', 'code id_token', 'code token', 'code', 'id_token token', 'id_token',
+  ].forEach((response_type) => {
+    describe(`response_type=${response_type}`, () => {
+      before(async function () {
+        const client = await this.provider.Client.find('client');
+        const auth = new this.AuthorizationRequest({ response_type, scope });
+
+        let id_token;
+        let refresh_token;
+        let code;
+        let access_token;
+
+        const { headers: { location } } = await this.agent
+          .get('/auth')
+          .query(auth)
+          .expect(302)
+          .expect((...args) => {
+            if (response_type === 'code') return;
+            auth.validateFragment(...args);
+          })
+          .expect(auth.validateClientLocation);
+
+        ({ query: { code, id_token, access_token } } = parseUrl(location, true));
+
+        this.authorization = { id_token };
+
+        if (response_type.includes('code')) {
+          ({ body: { id_token, refresh_token, access_token } } = await this.agent.post('/token')
+            .send({
+              client_id, code, grant_type: 'authorization_code', redirect_uri,
+            })
+            .type('form')
+            .expect(200));
+
+          this.token = { id_token };
+
+          ({ body: { id_token } } = await this.agent.post('/token')
+            .send({ client_id, grant_type: 'refresh_token', refresh_token })
+            .type('form')
+            .expect(200));
+
+          this.refresh = { id_token };
+        }
+
+        if (access_token) {
+          let userinfo;
+          delete client.userinfoSignedResponseAlg;
+          ({ body: userinfo } = await this.agent.get('/me')
+            .auth(access_token, { type: 'bearer' })
+            .expect(200));
+          this.userinfo = userinfo;
+
+          client.userinfoSignedResponseAlg = 'none';
+          await this.provider.Client.find('client');
+          ({ text: userinfo } = await this.agent.get('/me')
+            .auth(access_token, { type: 'bearer' })
+            .expect(200));
+          this.userinfoSigned = userinfo;
+        }
+      });
+
+      if (response_type.includes('id_token')) {
+        it('authorization endpoint id_token has scope requested claims', function () {
+          const { payload } = decodeJWT(this.authorization.id_token);
+          expect(payload).to.contain.keys('email', 'email_verified');
+        });
+      }
+
+      if (response_type !== 'id_token') {
+        it('userinfo has scope requested claims', function () {
+          expect(this.userinfo).to.contain.keys('email', 'email_verified');
+        });
+
+        it('signed userinfo has scope requested claims', function () {
+          const { payload } = decodeJWT(this.userinfoSigned);
+          expect(payload).to.contain.keys('email', 'email_verified');
+        });
+      }
+
+      if (response_type.includes('code')) {
+        it('token endpoint id_token has scope requested claims', function () {
+          const { payload } = decodeJWT(this.token.id_token);
+          expect(payload).to.contain.keys('email', 'email_verified');
+        });
+
+        it('refreshed id_token has scope requested claims', function () {
+          const { payload } = decodeJWT(this.refresh.id_token);
+          expect(payload).to.contain.keys('email', 'email_verified');
+        });
+      }
+    });
+  });
+});


### PR DESCRIPTION
[Core 1.0 - 5.4. Requesting Claims using Scope Values](https://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims) defines that claims requested using the `scope` parameter are returned from the UserInfo Endpoint
unless the `response_type=id_token`.

> The Claims requested by the profile, email, address, and phone scope values are returned from the
> UserInfo Endpoint, as described in Section 5.3.2, when a response_type value is used that results
> in an Access Token being issued. However, when no Access Token is issued (which is the case for
> the response_type value id_token), the resulting Claims are returned in the ID Token.

To enable/disable this conform behaviour
```js
const configuration = { features: { conformIdTokenClaims: Boolean[false] } };
```

The conform/non-conform behaviour results in the following results

| flag value | request params | authorization_endpoint ID Token (if issued) | token_endpoint ID Token (if issued) |
|---|---|---|---|
| false | `response_type=` _any_<br/><br/> `scope=openid email` | ✅ `sub`<br/> ✅ `email`<br/> ✅ `email_verified` | ✅ `sub`<br/> ✅ `email`<br/> ✅ `email_verified` |
| true | `response_type=` _any but_ `id_token`<br/><br/> `scope=openid email` | ✅ `sub`<br/> ❌ `email`<br/> ❌ `email_verified` | ✅ `sub`<br/> ❌ `email`<br/> ❌ `email_verified` |
| true | `response_type=` _any but_ `id_token`<br/><br/> `scope=openid email`<br/><br/> `claims={"id_token":{"email":null}}` | ✅ `sub`<br/> ✅ `email`<br/> ❌ `email_verified` | ✅ `sub`<br/> ✅ `email`<br/> ❌ `email_verified` |
| true | `response_type=id_token`<br/><br/> `scope=openid email` | ✅ `sub`<br/> ✅ `email`<br/> ✅ `email_verified` | _n/a_ |
