### PR TITLE
Missing sessions and id cookies refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ Yay for [SemVer](http://semver.org/).
 - fixed edge cases where client and provider signing keys would be used for encryption and vice versa
 - adjusted error_description to be more descriptive when PKCE plain value fallback is not possible
   due to the plain method not being supported
+- fixed issues with interaction sessions and the back button, assertions are now in place and both
+  resume endpoint and interaction helpers will now reject with SessionNotFound named error, which
+  is essentially just InvalidRequest with a more descriptive name.
 
 ## 4.0.x
 ### 4.0.3

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1110,17 +1110,7 @@ async frontchannelLogoutPendingSource(ctx, frames, postLogoutRedirectUri, timeou
   ctx.body = `<!DOCTYPE html>
 <head>
 <title>Logout</title>
-<style>
-  iframe {
-    visibility: hidden;
-    position: absolute;
-    left: 0;
-    top: 0;
-    height:0;
-    width:0;
-    border: none;
-  }
-</style>
+<style>/* css and html classes omitted for brevity, see lib/helpers/defaults.js */</style>
 </head>
 <body>
 ${frames.join('')}
@@ -1293,10 +1283,13 @@ async renderError(ctx, out, error) {
   ctx.body = `<!DOCTYPE html>
 <head>
 <title>oops! something went wrong</title>
+<style>/* css and html classes omitted for brevity, see lib/helpers/defaults.js */</style>
 </head>
 <body>
-<h1>oops! something went wrong</h1>
-<pre>${JSON.stringify(out, null, 4)}</pre>
+<div>
+  <h1>oops! something went wrong</h1>
+  ${Object.entries(out).map(([key, value]) => `<pre><strong>${key}</strong>: ${value}</pre>`).join('')}
+</div>
 </body>
 </html>`;
 }

--- a/docs/update-configuration.js
+++ b/docs/update-configuration.js
@@ -18,6 +18,9 @@ class Block {
       while (buffer.indexOf('*') === 0 || buffer.indexOf(' ') === 0) {
         buffer = buffer.slice(1);
       }
+      if (buffer.indexOf('-') === 0) {
+        buffer = Buffer.concat([Buffer.from('\n'), buffer]);
+      }
       this[this.active] = Buffer.concat([this[this.active], Buffer.from(' '), buffer]);
     }
   }
@@ -116,6 +119,7 @@ const props = [
           break;
         case 'function': {
           let fixIndent;
+          let mute = false;
           append(String(value).split('\n').map((line, index) => {
             if (index === 1) {
               line.match(/^(\s+)\S+/);
@@ -125,6 +129,15 @@ const props = [
             if (line.startsWith(' ')) line = line.slice(fixIndent);
             line = line.replace(/ \/\/ eslint-disable.+/, '');
             line = line.replace(/ \/\/ TODO.+/, '');
+            line = line.replace(/ class="[ \-\w]+ ?"/, '');
+            if (line.includes('<style>')) {
+              mute = true;
+              return '<style>/* css and html classes omitted for brevity, see lib/helpers/defaults.js */</style>';
+            } else if (line.includes('</style>')) {
+              mute = false;
+              return undefined;
+            }
+            if (mute) return undefined;
             return line;
           }).filter(Boolean)
             .join('\n'));

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -453,10 +453,15 @@ const DEFAULTS = {
     ctx.body = `<!DOCTYPE html>
 <head>
   <title>oops! something went wrong</title>
+  <style>
+    @import url(https://fonts.googleapis.com/css?family=Roboto:400,100);.container h1{font-weight:100;text-align:center;font-size:2.3em}body{font-family:Roboto,sans-serif;margin-top:25px;margin-bottom:25px}.container{padding:0 40px 10px;width:274px;background-color:#F7F7F7;margin:0 auto 10px;border-radius:2px;box-shadow:0 2px 2px rgba(0,0,0,.3);overflow:hidden}pre{white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space:-o-pre-wrap;word-wrap:break-word;margin:0 0 0 1em;text-indent:-1em}
+  </style>
 </head>
 <body>
-  <h1>oops! something went wrong</h1>
-  <pre>${JSON.stringify(out, null, 4)}</pre>
+  <div class="container">
+    <h1>oops! something went wrong</h1>
+    ${Object.entries(out).map(([key, value]) => `<pre><strong>${key}</strong>: ${value}</pre>`).join('')}
+  </div>
 </body>
 </html>`;
   },

--- a/lib/helpers/errors.js
+++ b/lib/helpers/errors.js
@@ -54,6 +54,8 @@ class InvalidRequest extends OIDCProviderError {
   }
 }
 
+class SessionNotFound extends InvalidRequest {}
+
 class InvalidClient extends OIDCProviderError {
   constructor(detail) {
     super(400, 'invalid_client');
@@ -123,5 +125,6 @@ module.exports.InvalidClient = InvalidClient;
 module.exports.InvalidClientMetadata = InvalidClientMetadata;
 module.exports.InvalidGrant = InvalidGrant;
 module.exports.InvalidRequest = InvalidRequest;
+module.exports.SessionNotFound = SessionNotFound;
 module.exports.InvalidScope = InvalidScope;
 module.exports.InvalidToken = InvalidToken;

--- a/lib/models/session.js
+++ b/lib/models/session.js
@@ -2,6 +2,9 @@ const uuid = require('uuid/v4');
 const epochTime = require('../helpers/epoch_time');
 const assert = require('assert');
 const instance = require('../helpers/weak_cache');
+const { deprecate } = require('util');
+
+const deprecated = deprecate(() => {}, 'Session.find returning new sessions if none is found is deprecated');
 
 module.exports = function getSession(provider) {
   let adapter;
@@ -78,7 +81,7 @@ module.exports = function getSession(provider) {
       return authorization.meta;
     }
 
-    static async find(id) {
+    static async find(id, { upsert = true } = {}) {
       assert(id, 'id must be provided to Session#find');
       const data = await getAdapter().find(id);
       if (data) {
@@ -89,16 +92,28 @@ module.exports = function getSession(provider) {
           return new Session(id, data);
         }
       }
-      return new Session(id);
+      /* istanbul ignore if */
+      if (upsert) {
+        deprecated();
+        return new Session(id);
+      }
+      return undefined;
     }
 
     static async get(ctx) {
       // is there supposed to be a session bound? generate if not
-      const sessionId = ctx.cookies.get(provider.cookieName('session'), {
+      let sessionId = ctx.cookies.get(provider.cookieName('session'), {
         signed: instance(provider).configuration('cookies.long.signed'),
-      }) || uuid();
+      });
 
-      const session = await this.find(sessionId);
+      let session;
+      if (sessionId) {
+        session = await this.find(sessionId, { upsert: false });
+      }
+      if (!session) {
+        sessionId = uuid();
+        session = new this(sessionId);
+      }
 
       // refresh the session duration
       ctx.cookies.set(provider.cookieName('session'), sessionId, instance(provider).configuration('cookies.long'));

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -22,6 +22,7 @@ const validUrl = require('./helpers/valid_url');
 const epochTime = require('./helpers/epoch_time');
 const httpWrapper = require('./helpers/http');
 const getContext = require('./helpers/oidc_context');
+const { SessionNotFound } = require('./helpers/errors');
 
 const models = require('./models');
 
@@ -58,8 +59,13 @@ async function getInteraction(req, res) {
   const id = getCookie.call(this, this.cookieName('interaction'), {
     signed: instance(this).configuration('cookies.short.signed'),
   }, cookies);
-  const interaction = await this.Session.find(id);
-  assert(interaction, 'interaction session not found');
+  if (!id) {
+    throw new SessionNotFound('interaction session id cookie not found');
+  }
+  const interaction = await this.Session.find(id, { upsert: false });
+  if (!interaction) {
+    throw new SessionNotFound('interaction session not found');
+  }
   return interaction;
 }
 
@@ -203,8 +209,7 @@ class Provider extends events.EventEmitter {
   }
 
   async interactionDetails(req) {
-    const interaction = await getInteraction.call(this, req);
-    return interaction;
+    return getInteraction.call(this, req);
   }
 
   async setProviderSession(req, res, {

--- a/lib/shared/resume.js
+++ b/lib/shared/resume.js
@@ -4,6 +4,8 @@ const _ = require('lodash');
 const { InvalidRequest } = require('../helpers/errors');
 const instance = require('../helpers/weak_cache');
 
+class SessionNotFound extends InvalidRequest {}
+
 module.exports = function getResumeAction(provider) {
   return async function resumeAction(ctx, next) {
     ctx.oidc.uuid = ctx.params.grant;
@@ -12,11 +14,13 @@ module.exports = function getResumeAction(provider) {
 
     const cookieId = ctx.cookies.get(provider.cookieName('resume'), cookieOptions);
     if (!cookieId || cookieId !== ctx.oidc.uuid) {
-      ctx.throw(new InvalidRequest('authorization request has expired'));
+      throw new SessionNotFound('authorization request has expired');
     }
 
-    const interactionSession = await provider.Session.find(cookieId);
-    ctx.assert(interactionSession, new InvalidRequest('interaction session not found'));
+    const interactionSession = await provider.Session.find(cookieId, { upsert: false });
+    if (!interactionSession) {
+      throw new SessionNotFound('interaction session not found');
+    }
 
     const { result, params = {}, signed = [] } = interactionSession;
     await interactionSession.destroy();

--- a/test/provider/provider_class.test.js
+++ b/test/provider/provider_class.test.js
@@ -19,6 +19,7 @@ describe('Provider', () => {
       'InvalidRequestUri',
       'InvalidScope',
       'InvalidToken',
+      'SessionNotFound',
       'RedirectUriMismatch',
       'RegistrationNotSupported',
       'RequestNotSupported',

--- a/test/sessions/sessions.test.js
+++ b/test/sessions/sessions.test.js
@@ -40,9 +40,10 @@ describe('session exp handling', () => {
     expect(this.TestAdapter.for('Session').destroy.called).to.be.false;
   });
 
-  it('calls delete on exp-format expired encountered sessions', async function () {
+  it('calls delete on exp-format expired encountered sessions and generates a new session id', async function () {
     await this.login();
     const session = this.getSession();
+    const oldSessionId = this.getSessionId();
     session.exp = epochTime();
 
     sinon.spy(this.TestAdapter.for('Session'), 'destroy');
@@ -58,6 +59,10 @@ describe('session exp handling', () => {
       .expect(auth.validateInteractionError('login_required', 'no_session'));
 
     expect(this.TestAdapter.for('Session').destroy.called).to.be.true;
+
+    const newSessionId = this.getSessionId();
+    expect(newSessionId).to.be.ok;
+    expect(newSessionId).not.to.equal(oldSessionId);
   });
 
   describe('clockTolerance', () => {
@@ -87,11 +92,12 @@ describe('session exp handling', () => {
       expect(this.TestAdapter.for('Session').destroy.called).to.be.false;
     });
 
-    it('calls delete on exp-format expired encountered sessions', async function () {
+    it('calls delete on exp-format expired encountered sessions and generates a new session id', async function () {
       await this.login();
       const session = this.getSession();
       i(this.provider).configuration().clockTolerance = 10;
       session.exp = epochTime() - 10;
+      const oldSessionId = this.getSessionId();
 
       sinon.spy(this.TestAdapter.for('Session'), 'destroy');
 
@@ -106,6 +112,10 @@ describe('session exp handling', () => {
         .expect(auth.validateInteractionError('login_required', 'no_session'));
 
       expect(this.TestAdapter.for('Session').destroy.called).to.be.true;
+
+      const newSessionId = this.getSessionId();
+      expect(newSessionId).to.be.ok;
+      expect(newSessionId).not.to.equal(oldSessionId);
     });
   });
 });


### PR DESCRIPTION
Fixes #299

Fixes issues with interaction sessions and the back button, assertions are now in place and both resume endpoint and interaction helpers will reject with SessionNotFound named error, which is essentially just InvalidRequest with a more descriptive name.

Note that this is not graceful and the interaction implementation still needs to handle these errors.