### PR TITLE
feat: return session from setProviderSession

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -232,6 +232,7 @@ class Provider extends events.EventEmitter {
       session.sidFor(clientId, uuid());
     });
     await session.save();
+    return session;
   }
 
   httpOptions(values) {


### PR DESCRIPTION
Give the caller access to the session object
since they won't have access to the session
id using the normal cookie.

Figured a PR would be better than a "feature request" issue with no code, even if it is just a 1-liner.

We have a use case where we lose cookies on our client, but the session should still be active. We also use the node-oidc-provider session for add-on features, and since the cookies are lost we can't recover the session when processing a request. I can call `setProviderSession` to recover the session, but I can't figure out how to get access to the new session id to make the session available to my add-on features.