### PR TITLE
v4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,7 +220,7 @@ This toggle makes the OP only include End-User claims in the ID Token as defined
     ```js
     provider.use(async function introspectionTokenType(ctx, next) {
       await next();
-      if (ctx._matchedRouteName === 'introspection') {
+      if (ctx.oidc.route === 'introspection') {
         const token = ctx.oidc.entities.AccessToken || ctx.oidc.entities.ClientCredentials || ctx.oidc.entities.RefreshToken;
 
         switch (token && token.kind) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -652,6 +652,7 @@ provider.registerGrantType('password', function passwordGrantTypeFactory(provide
     if ((account = await Account.authenticate(ctx.oidc.params.username, ctx.oidc.params.password))) {
       const AccessToken = providerInstance.AccessToken;
       const at = new AccessToken({
+				gty: 'password',
         accountId: account.id,
         clientId: ctx.oidc.client.clientId,
         grantId: ctx.oidc.uuid,
@@ -1211,8 +1212,8 @@ async findById(ctx, sub, token) {
 ### formats
 
 This option allows to configure the token storage and value formats. The different values change how a token value is generated as well as what properties get sent to the adapter for storage. Three formats are defined, see the expected [Adapter API](/example/my_adapter.js) for each format's specifics.  
-- `legacy` is the current and default format until next major release. No changes in the format sent to adapter. 
-- `opaque` formatted tokens have a different value then `legacy` and in addition store what was in legacy format encoded under `payload` as root properties, this makes analysing the data in your storage way easier 
+- `legacy` is the current and default format until next major release. No changes in the format sent to adapter.
+- `opaque` formatted tokens have a different value then `legacy` and in addition store what was in legacy format encoded under `payload` as root properties, this makes analysing the data in your storage way easier
 - `jwt` formatted tokens are issued as JWTs and stored the same as `opaque` only with additional property `jwt`. The signing algorithm for these tokens uses the client's `id_token_signed_response_alg` value and falls back to `RS256` for tokens with no relation to a client or when the client's alg is `none`  
 
 affects: properties passed to adapters for token types, issued token formats  
@@ -1403,8 +1404,8 @@ default value:
 
 ### refreshTokenRotation
 
-Configures if and how the OP rotates refresh tokens after they are used. Supported values are 
-- `none` when refresh tokens are not rotated and their initial expiration date is final or 
+Configures if and how the OP rotates refresh tokens after they are used. Supported values are
+- `none` when refresh tokens are not rotated and their initial expiration date is final or
 - `rotateAndConsume` when refresh tokens are rotated when used, current token is marked as consumed and new one is issued with new TTL, when a consumed refresh token is encountered an error is returned instead and the whole token chain (grant) is revoked  
 
 affects: refresh token rotation and adjacent revocation  
@@ -1505,8 +1506,8 @@ default value:
 
 ### subjectTypes
 
-List of the Subject Identifier types that this OP supports. Valid types are 
-- `public` 
+List of the Subject Identifier types that this OP supports. Valid types are
+- `public`
 - `pairwise`  
 
 affects: discovery, registration, registration management, ID Token and Userinfo sub claim values  

--- a/docs/update-configuration.js
+++ b/docs/update-configuration.js
@@ -1,10 +1,12 @@
 /* eslint-disable no-param-reassign */
 
 const { createInterface: readline } = require('readline');
-const { createReadStream, writeFileSync, readFileSync } = require('fs');
-const values = require('../lib/helpers/defaults');
-const { get } = require('lodash');
 const { inspect } = require('util');
+const { createReadStream, writeFileSync, readFileSync } = require('fs');
+
+const { get } = require('lodash');
+
+const values = require('../lib/helpers/defaults');
 
 function capitalizeSentences(copy) {
   return copy.replace(/\. [a-z]/g, match => `. ${match.slice(-1).toUpperCase()}`);

--- a/docs/update-configuration.js
+++ b/docs/update-configuration.js
@@ -135,7 +135,8 @@ const props = [
             if (line.includes('<style>')) {
               mute = true;
               return '<style>/* css and html classes omitted for brevity, see lib/helpers/defaults.js */</style>';
-            } else if (line.includes('</style>')) {
+            }
+            if (line.includes('</style>')) {
               mute = false;
               return undefined;
             }

--- a/example/adapters/bookshelf_postgresql_adapter.js
+++ b/example/adapters/bookshelf_postgresql_adapter.js
@@ -25,7 +25,7 @@
 //   expires_at timestamp
 // );
 
-// TODO: @madarche adapt for new storage formats support (opaque and jwt)
+// TODO: @madarche adapt for new storage formats and deviceCode support (opaque and jwt)
 
 const knexCreate = require('knex'); // eslint-disable-line import/no-unresolved
 const bookshelfCreate = require('bookshelf'); // eslint-disable-line import/no-unresolved

--- a/example/adapters/google_cloud_datastore.js
+++ b/example/adapters/google_cloud_datastore.js
@@ -11,11 +11,12 @@ const Datastore = require('@google-cloud/datastore'); // eslint-disable-line imp
 
 let DB;
 
-const grantable = [
+const grantable = new Set([
   'AccessToken',
   'AuthorizationCode',
   'RefreshToken',
-];
+  'DeviceCode',
+]);
 
 class Adapter {
   constructor(name) {
@@ -56,7 +57,7 @@ class Adapter {
   }
 
   async destroy(id) {
-    if (grantable.includes(this.name)) {
+    if (grantable.has(this.name)) {
       await this.find(id).then(({ grantId }) => (
         Promise.all(grantable.map((name) => {
           const query = DB.createQuery(name).filter('grantId', '=', grantId);

--- a/example/my_adapter.js
+++ b/example/my_adapter.js
@@ -67,6 +67,9 @@ class MyAdapter {
      * - redirectUri {string} - redirect_uri value from an authorization request
      * - scope {string} - scope value from on authorization request
      * - sid {string} - session identifier the token comes from
+     * - gty {string} - [AccessToken, RefreshToken only] space delimited grant values, indicating
+     *     the grant type(s) they originate from (implicit, authorization_code, refresh_token or
+     *     device_code) the original one is always first, second is refresh_token if refreshed
      * - params {object} - [DeviceCode only] an object with the authorization request parameters
      *     as requested by the client with device_authorization_endpoint
      * - deviceInfo {object} - [DeviceCode only] an object with details about the

--- a/example/my_adapter.js
+++ b/example/my_adapter.js
@@ -10,7 +10,7 @@ class MyAdapter {
    * @constructor
    * @param {string} name Name of the oidc-provider model. One of "Session", "AccessToken",
    * "AuthorizationCode", "RefreshToken", "ClientCredentials", "Client", "InitialAccessToken",
-   * "RegistrationAccessToken"
+   * "RegistrationAccessToken", "DeviceCode"
    *
    */
   constructor(name) {
@@ -67,6 +67,13 @@ class MyAdapter {
      * - redirectUri {string} - redirect_uri value from an authorization request
      * - scope {string} - scope value from on authorization request
      * - sid {string} - session identifier the token comes from
+     * - params {object} - [DeviceCode only] an object with the authorization request parameters
+     *     as requested by the client with device_authorization_endpoint
+     * - deviceInfo {object} - [DeviceCode only] an object with details about the
+     *     device_authorization_endpoint request
+     * - error {string} - [DeviceCode only] - error from authnz to be returned to the polling client
+     * - errorDescription {string} - [DeviceCode only] - error_description from authnz to be returned
+     *     to the polling client
      *
      *
      * when `jwt`
@@ -110,6 +117,20 @@ class MyAdapter {
    *
    */
   async find(id) {
+
+  }
+
+  /**
+   *
+   * Return previously stored instance of DeviceCode. You only need this method for the deviceCode
+   * feature
+   *
+   * @return {Promise} Promise fulfilled with either Object (when found and not dropped yet due to
+   * expiration) or falsy value when not found anymore. Rejected with error when encountered.
+   * @param {string} userCode the user_code value associated with a DeviceCode instance
+   *
+   */
+  async findByUserCode(userCode) {
 
   }
 

--- a/example/views/_layout.html
+++ b/example/views/_layout.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8">
     <title>Sign-in</title>
-    <style type="text/css">
+    <style>
       @import url(https://fonts.googleapis.com/css?family=Roboto:400,100);
 
       body {
@@ -51,14 +51,6 @@
         -moz-box-sizing: border-box;
       }
 
-      .login-card input[type=text]:hover, input[type=email]:hover, input[type=password]:hover {
-        border: 1px solid #b9b9b9;
-        border-top: 1px solid #a0a0a0;
-        -moz-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
-        -webkit-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
-        box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
-      }
-
       .login {
         text-align: center;
         font-size: 14px;
@@ -75,12 +67,6 @@
         background-color: #4d90fe;
       }
 
-      .login-submit:hover {
-        border: 0px;
-        text-shadow: 0 1px rgba(0,0,0,0.3);
-        background-color: #357ae8;
-      }
-
       .login-card a {
         text-decoration: none;
         color: #666;
@@ -88,11 +74,6 @@
         text-align: center;
         display: inline-block;
         opacity: 0.6;
-        transition: opacity ease 0.5s;
-      }
-
-      .login-card a:hover {
-        opacity: 1;
       }
 
       .login-help {

--- a/lib/actions/authorization/assign_claims.js
+++ b/lib/actions/authorization/assign_claims.js
@@ -1,0 +1,36 @@
+const { merge } = require('lodash');
+
+const instance = require('../../helpers/weak_cache');
+
+/*
+ * If claims parameter is provided and supported handles it's validation
+ * - should not be combined with rt none
+ * - should be JSON serialized object with id_token or userinfo properties as objects
+ * - claims.userinfo should not be used if authorization result is not access_token
+ *
+ * Merges requested claims with auth_time as requested if max_age is provided or require_auth_time
+ * is configured for the client.
+ *
+ * Merges requested claims with acr as requested if acr_values is provided
+ *
+ * @throws: invalid_request
+ */
+module.exports = provider => async function assignClaims(ctx, next) {
+  const { params } = ctx.oidc;
+
+  if (params.claims !== undefined && instance(provider).configuration('features.claimsParameter')) {
+    ctx.oidc.claims = JSON.parse(params.claims);
+  }
+
+  if (params.max_age || ctx.oidc.client.requireAuthTime || ctx.oidc.prompts.includes('login')) {
+    merge(ctx.oidc.claims, { id_token: { auth_time: { essential: true } } });
+  }
+
+  const acrValues = params.acr_values;
+
+  if (acrValues) {
+    merge(ctx.oidc.claims, { id_token: { acr: { values: acrValues.split(' ') } } });
+  }
+
+  await next();
+};

--- a/lib/actions/authorization/authorization_emit.js
+++ b/lib/actions/authorization/authorization_emit.js
@@ -3,13 +3,15 @@ const Debug = require('debug');
 const accepted = new Debug('oidc-provider:authentication:accepted');
 const resumed = new Debug('oidc-provider:authentication:resumed');
 
+const authorizationRoutes = new Set(['authorization', 'code_verification']);
+
 module.exports = provider => async function authorizationEmit(ctx, next) {
-  if (ctx.oidc.result) {
-    resumed('uuid=%s %o', ctx.oidc.uuid, ctx.oidc.result);
-    provider.emit('interaction.ended', ctx);
-  } else {
+  if (authorizationRoutes.has(ctx.oidc.route)) {
     accepted('uuid=%s %o', ctx.oidc.uuid, ctx.oidc.params);
     provider.emit('authorization.accepted', ctx);
+  } else {
+    resumed('uuid=%s %o', ctx.oidc.uuid, ctx.oidc.result);
+    provider.emit('interaction.ended', ctx);
   }
   await next();
 };

--- a/lib/actions/authorization/check_claims.js
+++ b/lib/actions/authorization/check_claims.js
@@ -1,4 +1,4 @@
-const { isPlainObject, merge } = require('lodash');
+const { isPlainObject } = require('lodash');
 
 const { InvalidRequest } = require('../../helpers/errors');
 const instance = require('../../helpers/weak_cache');
@@ -51,18 +51,6 @@ module.exports = provider => async function checkClaims(ctx, next) {
     if (params.response_type === 'id_token' && claims.userinfo) {
       throw new InvalidRequest('claims.userinfo should not be used if access_token is not issued');
     }
-
-    ctx.oidc.claims = claims;
-  }
-
-  if (params.max_age || ctx.oidc.client.requireAuthTime || ctx.oidc.prompts.includes('login')) {
-    merge(ctx.oidc.claims, { id_token: { auth_time: { essential: true } } });
-  }
-
-  const acrValues = params.acr_values;
-
-  if (acrValues) {
-    merge(ctx.oidc.claims, { id_token: { acr: { values: acrValues.split(' ') } } });
   }
 
   await next();

--- a/lib/actions/authorization/check_client.js
+++ b/lib/actions/authorization/check_client.js
@@ -1,4 +1,5 @@
-const { InvalidRequest, InvalidClient } = require('../../helpers/errors');
+const { InvalidClient } = require('../../helpers/errors');
+const presence = require('../../helpers/validate_presence');
 
 /*
  * Checks client_id
@@ -9,13 +10,9 @@ const { InvalidRequest, InvalidClient } = require('../../helpers/errors');
  * @throws: invalid_client
  */
 module.exports = ({ Client }) => async function checkClient(ctx, next) {
-  const { client_id: clientId } = ctx.oidc.params;
+  presence(ctx, 'client_id');
 
-  if (!clientId) {
-    throw new InvalidRequest('missing required parameter client_id');
-  }
-
-  const client = await Client.find(String(clientId));
+  const client = await Client.find(ctx.oidc.params.client_id);
 
   if (!client) {
     throw new InvalidClient();

--- a/lib/actions/authorization/check_client_grant_type.js
+++ b/lib/actions/authorization/check_client_grant_type.js
@@ -1,0 +1,8 @@
+const { UnauthorizedClient } = require('../../helpers/errors');
+
+module.exports = function checkClientGrantType({ oidc: { client: { grantTypes } } }, next) {
+  if (!grantTypes.includes('urn:ietf:params:oauth:grant-type:device_code')) {
+    throw new UnauthorizedClient('device flow not allowed for this client');
+  }
+  return next();
+};

--- a/lib/actions/authorization/check_pixy.js
+++ b/lib/actions/authorization/check_pixy.js
@@ -31,7 +31,7 @@ module.exports = (provider) => {
 
     const forced = pkce
       && pkce.forcedForNative
-      && params.response_type.includes('code')
+      && (ctx.oidc.route === 'device_authorization' || params.response_type.includes('code'))
       && ctx.oidc.client.applicationType === 'native';
 
     if (forced && !params.code_challenge) {

--- a/lib/actions/authorization/check_prompt.js
+++ b/lib/actions/authorization/check_prompt.js
@@ -15,7 +15,7 @@ module.exports = provider => async function checkPrompt(ctx, next) {
     const unsupported = difference(prompts, instance(provider).configuration('prompts'));
 
     if (!isEmpty(unsupported)) {
-      throw new InvalidRequest(`invalid prompt value(s) provided. (${unsupported.join(',')})`);
+      throw new InvalidRequest('invalid prompt value provided');
     }
 
     if (prompts.includes('none') && prompts.length !== 1) {

--- a/lib/actions/authorization/decode_request.js
+++ b/lib/actions/authorization/decode_request.js
@@ -61,7 +61,7 @@ module.exports = (provider, PARAM_LIST) => {
       throw new InvalidRequestObject('request object must not contain request or request_uri properties');
     }
 
-    if (payload.response_type !== undefined && payload.response_type !== params.response_type) {
+    if (PARAM_LIST.has('response_type') && payload.response_type !== undefined && payload.response_type !== params.response_type) {
       throw new InvalidRequestObject('request response_type must equal the one in request parameters');
     }
 

--- a/lib/actions/authorization/device_authorization_response.js
+++ b/lib/actions/authorization/device_authorization_response.js
@@ -1,0 +1,42 @@
+const debug = require('debug')('oidc-provider:device_authorization');
+
+const generate = require('../../helpers/generate_user_code');
+const instance = require('../../helpers/weak_cache');
+
+module.exports = function getDeviceAuthorizationResponse(provider) {
+  const { DeviceCode } = provider;
+  const {
+    pkce, deviceCode: { charset, mask, deviceInfo },
+  } = instance(provider).configuration('features');
+
+  return async function deviceAuthorizationResponse(ctx, next) {
+    const userCode = generate(charset, mask);
+
+    const dc = new DeviceCode({
+      grantId: ctx.oidc.uuid,
+      clientId: ctx.oidc.client.clientId,
+      params: ctx.oidc.params.toPlainObject(),
+      userCode,
+      deviceInfo: deviceInfo(ctx),
+    });
+
+    if (pkce) {
+      dc.codeChallenge = ctx.oidc.params.code_challenge;
+      dc.codeChallengeMethod = ctx.oidc.params.code_challenge_method;
+    }
+
+    ctx.oidc.entity('DeviceCode', dc);
+    ctx.body = {
+      device_code: await dc.save(),
+      user_code: userCode,
+      verification_uri: ctx.oidc.urlFor('code_verification'),
+      verification_uri_complete: ctx.oidc.urlFor('code_verification', {
+        query: { user_code: userCode },
+      }),
+      expires_in: dc.expiration,
+    };
+    await next();
+    provider.emit('device_authorization.success', ctx);
+    debug('response uuid=%s %o', ctx.oidc.uuid, ctx.body);
+  };
+};

--- a/lib/actions/authorization/device_check_params.js
+++ b/lib/actions/authorization/device_check_params.js
@@ -1,0 +1,13 @@
+const { InvalidRequest } = require('../../helpers/errors');
+const presence = require('../../helpers/validate_presence');
+
+module.exports = async function checkParams(ctx, next) {
+  presence(ctx, 'scope');
+
+  const scopes = ctx.oidc.params.scope.split(' ');
+  if (!scopes.includes('openid')) {
+    ctx.throw(new InvalidRequest('openid is required scope'));
+  }
+
+  await next();
+};

--- a/lib/actions/authorization/device_user_flow.js
+++ b/lib/actions/authorization/device_user_flow.js
@@ -1,0 +1,68 @@
+const Debug = require('debug');
+
+const getParams = require('../../helpers/params');
+const { InvalidRequest } = require('../../helpers/errors');
+const {
+  NotFoundError, ReRenderError, ExpiredError, AlreadyUsedError,
+} = require('../../helpers/re_render_errors');
+const errOut = require('../../helpers/err_out');
+
+const debug = new Debug('oidc-provider:authentication:error');
+
+module.exports = function getDeviceVerification(provider, whitelist) {
+  const Params = getParams(whitelist);
+
+  return async function deviceUserFlow(ctx, next) {
+    let code;
+    try {
+      if (ctx.oidc.route === 'device_resume') { // TODO
+        code = await provider.DeviceCode.findByUserCode(ctx.params.user_code, {
+          ignoreExpiration: true,
+        });
+
+        if (!code) {
+          throw new NotFoundError();
+        }
+
+        if (code.grantId !== ctx.params.grant) {
+          throw new InvalidRequest('grantId mismatch');
+        }
+
+        if (code.isExpired) {
+          throw new ExpiredError();
+        }
+
+        if (code.error || code.accountId) {
+          throw new AlreadyUsedError();
+        }
+
+        ctx.oidc.entity('DeviceCode', code);
+      } else {
+        code = ctx.oidc.deviceCode;
+
+        if (code) ctx.oidc.uuid = code.grantId;
+        ctx.oidc.params = new Params(code.params);
+      }
+
+      ctx.oidc.uuid = code.grantId;
+
+      await next();
+    } catch (err) {
+      if (!(err instanceof ReRenderError)) {
+        const out = errOut(err);
+
+        if (code) {
+          Object.assign(code, {
+            error: out.error,
+            errorDescription: out.error_description,
+          });
+          await code.save();
+        }
+
+        debug('uuid=%s %o', ctx.oidc.uuid, out);
+      }
+
+      throw err;
+    }
+  };
+};

--- a/lib/actions/authorization/device_user_flow_response.js
+++ b/lib/actions/authorization/device_user_flow_response.js
@@ -1,0 +1,31 @@
+const { get } = require('lodash');
+const debug = require('debug')('oidc-provider:authentication:success');
+
+const instance = require('../../helpers/weak_cache');
+
+module.exports = provider => async function deviceVerificationResponse(ctx, next) {
+  const { deviceCodeSuccess } = instance(provider).configuration();
+  const code = ctx.oidc.deviceCode;
+
+  Object.assign(code, {
+    accountId: ctx.oidc.session.accountId(),
+    acr: ctx.oidc.acr,
+    amr: ctx.oidc.amr,
+    authTime: ctx.oidc.session.authTime(),
+    claims: ctx.oidc.claims,
+    scope: ctx.oidc.params.scope,
+  });
+
+  if (ctx.oidc.client.includeSid() || get(ctx.oidc.claims, 'id_token.sid')) {
+    code.sid = ctx.oidc.session.sidFor(ctx.oidc.client.clientId);
+  }
+
+  await code.save();
+
+  await deviceCodeSuccess(ctx);
+
+  provider.emit('authorization.success', ctx);
+  debug('uuid=%s %o', ctx.oidc.uuid, {});
+
+  await next();
+};

--- a/lib/actions/authorization/index.js
+++ b/lib/actions/authorization/index.js
@@ -1,7 +1,8 @@
 const noCache = require('../../shared/no_cache');
 const bodyParser = require('../../shared/conditional_body');
 const rejectDupes = require('../../shared/reject_dupes');
-const paramsMiddleware = require('../../shared/get_params');
+const paramsMiddleware = require('../../shared/assemble_params');
+const sessionMiddleware = require('../../shared/session');
 const instance = require('../../helpers/weak_cache');
 const { PARAM_LIST } = require('../../consts');
 
@@ -21,48 +22,85 @@ const checkRedirectUri = require('./check_redirect_uri');
 const checkWebMessageUri = require('./check_web_message_uri');
 const assignDefaults = require('./assign_defaults');
 const checkClaims = require('./check_claims');
+const assignClaims = require('./assign_claims');
 const loadAccount = require('./load_account');
 const interactions = require('./interactions');
 const respond = require('./respond');
 const checkPixy = require('./check_pixy');
 const processResponseTypes = require('./process_response_types');
 const authorizationEmit = require('./authorization_emit');
+const getResume = require('./resume');
+const checkClientGrantType = require('./check_client_grant_type');
+const deviceCheckParams = require('./device_check_params');
+const deviceAuthorizationResponse = require('./device_authorization_response');
+const deviceUserFlow = require('./device_user_flow');
+const deviceUserFlowResponse = require('./device_user_flow_response');
 
 const parseBody = bodyParser('application/x-www-form-urlencoded');
 
-module.exports = function authorizationAction(provider) {
+const A = 'authorization';
+const R = 'resume';
+const DA = 'device_authorization';
+const CV = 'code_verification';
+const DR = 'device_resume';
+
+module.exports = function authorizationAction(provider, endpoint) {
   const whitelist = new Set(PARAM_LIST);
   const extras = instance(provider).configuration('extraParams');
   extras.forEach(whitelist.add.bind(whitelist));
+  if ([DA, CV, DR].includes(endpoint)) {
+    whitelist.delete('response_type');
+    whitelist.delete('response_mode');
+    whitelist.delete('state');
+    whitelist.delete('redirect_uri');
+  }
 
-  const getParams = paramsMiddleware(whitelist);
+  const stack = [];
 
-  return [
-    noCache,
-    parseBody,
-    getParams,
-    checkClient(provider),
-    oneRedirectUriClients,
-    rejectDupes,
-    checkResponseMode(provider),
-    throwNotSupported(provider),
-    oauthRequired,
-    checkOpenidPresent,
-    fetchRequestUri(provider),
-    decodeRequest(provider, whitelist),
-    oidcRequired,
-    checkPrompt(provider),
-    checkResponseType(provider),
-    checkScope(provider),
-    checkRedirectUri,
-    checkWebMessageUri(provider),
-    checkPixy(provider),
-    assignDefaults,
-    authorizationEmit(provider),
-    checkClaims(provider),
-    loadAccount(provider),
-    interactions(provider),
-    respond(provider),
-    processResponseTypes(provider),
-  ];
+  const use = (middleware, ...only) => {
+    if (only.includes(endpoint)) {
+      stack.push(middleware());
+    }
+  };
+  const returnTo = endpoint.match(/^(code|device)_/) ? 'device_resume' : 'resume';
+
+  /* eslint-disable no-multi-spaces, space-in-parens */
+  use(() => noCache,                                    A, DA, R, CV, DR);
+  use(() => sessionMiddleware(provider),                A,     R,     DR);
+  use(() => getResume(provider, whitelist, returnTo),          R,     DR);
+  use(() => deviceUserFlow(provider, whitelist),                  CV, DR);
+  use(() => parseBody,                                  A, DA           );
+  use(() => paramsMiddleware(whitelist),                A, DA           );
+  use(() => rejectDupes.only('client_id'),              A, DA, R, CV, DR);
+  use(() => checkClient(provider),                      A, DA, R, CV, DR);
+  use(() => oneRedirectUriClients,                      A               );
+  use(() => rejectDupes,                                A, DA           );
+  use(() => checkClientGrantType,                          DA           );
+  use(() => checkResponseMode(provider),                A               );
+  use(() => throwNotSupported(provider),                A, DA           );
+  use(() => deviceCheckParams,                             DA           );
+  use(() => oauthRequired,                              A               );
+  use(() => checkOpenidPresent,                         A               );
+  use(() => fetchRequestUri(provider),                  A, DA           );
+  use(() => decodeRequest(provider, whitelist),         A, DA           );
+  use(() => oidcRequired,                               A               );
+  use(() => checkPrompt(provider),                      A, DA           );
+  use(() => checkResponseType(provider),                A               );
+  use(() => checkScope(provider),                       A, DA           );
+  use(() => checkRedirectUri,                           A               );
+  use(() => checkWebMessageUri(provider),               A               );
+  use(() => checkPixy(provider),                        A, DA           );
+  use(() => assignDefaults,                             A, DA           );
+  use(() => checkClaims(provider),                      A, DA           );
+  use(() => authorizationEmit(provider),                A,     R, CV, DR);
+  use(() => assignClaims(provider),                     A,     R, CV, DR);
+  use(() => loadAccount(provider),                      A,     R, CV, DR);
+  use(() => interactions(provider, returnTo),           A,     R, CV, DR);
+  use(() => respond(provider),                          A,     R        );
+  use(() => processResponseTypes(provider),             A,     R        );
+  use(() => deviceAuthorizationResponse(provider),         DA           );
+  use(() => deviceUserFlowResponse(provider),                     CV, DR);
+  /* eslint-enable no-multi-spaces, space-in-parens */
+
+  return stack;
 };

--- a/lib/actions/authorization/interactions.js
+++ b/lib/actions/authorization/interactions.js
@@ -7,7 +7,7 @@ const { InvalidRequest } = require('../../helpers/errors');
 const mask = require('../../helpers/claims');
 const instance = require('../../helpers/weak_cache');
 
-module.exports = (provider) => {
+module.exports = (provider, resumeRouteName) => {
   const Claims = mask(instance(provider).configuration());
   const interactionCheck = instance(provider).configuration('interactionCheck');
 
@@ -169,15 +169,19 @@ module.exports = (provider) => {
           });
         }
       } catch (err) {
-        err.status = 302;
-        err.statusCode = 302;
+        const code = ctx.oidc.route.match(/^(code|device)_/) ? 400 : 302;
+        err.status = code;
+        err.statusCode = code;
         err.expose = true;
         throw err;
       }
 
       const destination = await instance(provider).configuration('interactionUrl')(ctx, interaction);
       const cookieOptions = instance(provider).configuration('cookies.short');
-      const returnTo = ctx.oidc.urlFor('resume', { grant: ctx.oidc.uuid });
+      const returnTo = ctx.oidc.urlFor(resumeRouteName, {
+        grant: ctx.oidc.uuid,
+        ...(ctx.oidc.deviceCode ? { user_code: ctx.oidc.deviceCode.userCode } : undefined),
+      });
 
       const interactionSession = new provider.Session(ctx.oidc.uuid, {
         returnTo,

--- a/lib/actions/authorization/oauth_required.js
+++ b/lib/actions/authorization/oauth_required.js
@@ -1,7 +1,7 @@
 const presence = require('../../helpers/validate_presence');
 
 const REQUIRED = [
-  'response_type', 'client_id', 'scope',
+  'response_type', 'scope',
 ];
 
 /*

--- a/lib/actions/authorization/process_response_types.js
+++ b/lib/actions/authorization/process_response_types.js
@@ -19,6 +19,7 @@ module.exports = (provider) => {
       grantId: ctx.oidc.uuid,
       scope: ctx.oidc.params.scope,
       sid: ctx.oidc.session.sidFor(ctx.oidc.client.clientId),
+      gty: 'implicit',
     });
 
     at.setAudiences(await audiences(ctx, accountId, at, 'access_token', ctx.oidc.params.scope));

--- a/lib/actions/authorization/resume.js
+++ b/lib/actions/authorization/resume.js
@@ -3,13 +3,13 @@ const url = require('url');
 const uuid = require('uuid/v4');
 const _ = require('lodash');
 
-const { SessionNotFound } = require('../helpers/errors');
-const instance = require('../helpers/weak_cache');
+const { SessionNotFound } = require('../../helpers/errors');
+const instance = require('../../helpers/weak_cache');
+const getParams = require('../../helpers/params');
 
-module.exports = function getResumeAction(provider) {
+module.exports = function getResumeAction(provider, whitelist, resumeRouteName) {
+  const Params = getParams(whitelist);
   return async function resumeAction(ctx, next) {
-    ctx.oidc.uuid = ctx.params.grant;
-
     const cookieOptions = _.omit(instance(provider).configuration('cookies.short'), 'maxAge', 'expires');
 
     const cookieId = ctx.cookies.get(provider.cookieName('resume'), cookieOptions);
@@ -22,14 +22,23 @@ module.exports = function getResumeAction(provider) {
       throw new SessionNotFound('interaction session not found');
     }
 
-    const { result, params = {}, signed = [] } = interactionSession;
+    const {
+      result,
+      params = {},
+      signed = [],
+    } = interactionSession;
+
     await interactionSession.destroy();
 
-    ctx.query = params;
+    ctx.oidc.params = new Params(params);
     ctx.oidc.signed = signed;
+    ctx.oidc.redirectUriCheckPerformed = true;
 
     const clearOpts = _.defaults({}, cookieOptions, {
-      path: url.parse(ctx.oidc.urlFor('resume', { grant: ctx.oidc.uuid })).pathname,
+      path: url.parse(ctx.oidc.urlFor(resumeRouteName, {
+        grant: ctx.oidc.uuid,
+        ...(ctx.params.user_code ? { user_code: ctx.params.user_code } : undefined),
+      })).pathname,
     });
     ctx.cookies.set(provider.cookieName('resume'), null, clearOpts);
 
@@ -51,15 +60,15 @@ module.exports = function getResumeAction(provider) {
     }
 
     if (result && result.consent && result.consent.scope !== undefined) {
-      ctx.query.scope = String(result.consent.scope);
+      ctx.oidc.params.scope = String(result.consent.scope);
     }
 
-    if (!_.isEmpty(result) && !ctx.oidc.session.sidFor(ctx.query.client_id)) {
-      ctx.oidc.session.sidFor(ctx.query.client_id, uuid());
+    if (!_.isEmpty(result) && !ctx.oidc.session.sidFor(ctx.oidc.params.client_id)) {
+      ctx.oidc.session.sidFor(ctx.oidc.params.client_id, uuid());
     }
 
     if (!_.isEmpty(result) && _.isObjectLike(result.meta)) {
-      ctx.oidc.session.metaFor(ctx.query.client_id, result.meta);
+      ctx.oidc.session.metaFor(ctx.oidc.params.client_id, result.meta);
     }
 
     ctx.oidc.result = result;

--- a/lib/actions/code_verification.js
+++ b/lib/actions/code_verification.js
@@ -1,0 +1,107 @@
+const crypto = require('crypto');
+
+const sessionMiddleware = require('../shared/session');
+const paramsMiddleware = require('../shared/assemble_params');
+const bodyParser = require('../shared/conditional_body');
+const rejectDupes = require('../shared/reject_dupes');
+const instance = require('../helpers/weak_cache');
+const { InvalidClient, InvalidRequest } = require('../helpers/errors');
+const {
+  NoCodeError, NotFoundError, ExpiredError, AlreadyUsedError,
+} = require('../helpers/re_render_errors');
+const formHtml = require('../helpers/user_code_form');
+const formPost = require('../response_modes/form_post');
+
+const parseBody = bodyParser('application/x-www-form-urlencoded');
+
+module.exports = function getCodeVerification(provider) {
+  return {
+    get: [
+      sessionMiddleware(provider),
+      paramsMiddleware(['user_code']),
+      async function renderCodeVerification(ctx, next) {
+        const { userCodeInputSource } = instance(provider).configuration();
+
+        // TODO: generic xsrf middleware to remove this
+        const secret = crypto.randomBytes(24).toString('hex');
+        ctx.oidc.session.device = { secret };
+
+        const action = provider.pathFor('code_verification');
+        if (ctx.oidc.params.user_code) {
+          await formPost(ctx, action, {
+            xsrf: secret,
+            user_code: ctx.oidc.params.user_code,
+          });
+        } else {
+          await userCodeInputSource(ctx, formHtml.input(action, secret));
+        }
+
+        await next();
+      },
+    ],
+    post: [
+      sessionMiddleware(provider),
+      parseBody,
+      paramsMiddleware(['xsrf', 'user_code', 'confirm']),
+      rejectDupes,
+
+      async function codeVerificationCSRF(ctx, next) {
+        if (!ctx.oidc.session.device) {
+          throw new InvalidRequest('could not find device form details');
+        }
+        if (ctx.oidc.session.device.secret !== ctx.oidc.params.xsrf) {
+          throw new InvalidRequest('xsrf token invalid');
+        }
+        await next();
+      },
+
+      async function loadDeviceCodeByUserInput(ctx, next) {
+        const { userCodeConfirmSource } = instance(provider).configuration();
+        const { user_code: userCode, confirm } = ctx.oidc.params;
+
+        if (!userCode) {
+          throw new NoCodeError();
+        }
+
+        const code = await provider.DeviceCode.findByUserCode(userCode, { ignoreExpiration: true });
+
+        if (!code) {
+          throw new NotFoundError(userCode);
+        }
+
+        if (code.isExpired) {
+          throw new ExpiredError(userCode);
+        }
+        if (code.error || code.accountId) {
+          throw new AlreadyUsedError(userCode);
+        }
+
+        ctx.oidc.entity('DeviceCode', code);
+
+        if (!confirm) {
+          const client = await provider.Client.find(code.clientId);
+          if (!client) {
+            throw new InvalidClient();
+          }
+          ctx.oidc.entity('Client', client);
+
+          const action = provider.pathFor('code_verification');
+          await userCodeConfirmSource(
+            ctx,
+            formHtml.confirm(action, ctx.oidc.session.device.secret, userCode),
+            client,
+            code.deviceInfo,
+          );
+          return;
+        }
+
+        await next();
+      },
+
+      async function cleanup(ctx, next) {
+        delete ctx.oidc.session.device;
+        await next();
+      },
+    ],
+  };
+};

--- a/lib/actions/discovery.js
+++ b/lib/actions/discovery.js
@@ -86,6 +86,9 @@ module.exports = function discoveryAction(provider) {
         ctx.body.frontchannel_logout_session_supported = true;
       }
     }
+    if (config.features.deviceCode) {
+      ctx.body.device_authorization_endpoint = ctx.oidc.urlFor('device_authorization');
+    }
 
     defaults(ctx.body, config.discovery);
 

--- a/lib/actions/end_session.js
+++ b/lib/actions/end_session.js
@@ -9,7 +9,8 @@ const redirectUri = require('../helpers/redirect_uri');
 const instance = require('../helpers/weak_cache');
 const rejectDupes = require('../shared/reject_dupes');
 const bodyParser = require('../shared/conditional_body');
-const paramsMiddleware = require('../shared/get_params');
+const paramsMiddleware = require('../shared/assemble_params');
+const getSessionMiddleware = require('../shared/session');
 
 const parseBody = bodyParser('application/x-www-form-urlencoded');
 
@@ -18,6 +19,7 @@ function frameFor(target) {
 }
 
 module.exports = function endSessionAction(provider) {
+  const loadSession = getSessionMiddleware(provider);
   const STATES = new RegExp(`${provider.cookieName('state')}\\.[^=]+=`, 'g');
   const { Client } = provider;
 
@@ -40,8 +42,8 @@ module.exports = function endSessionAction(provider) {
 
   return {
     get: [
+      loadSession,
       paramsMiddleware(['id_token_hint', 'post_logout_redirect_uri', 'state', 'ui_locales']),
-
       rejectDupes,
 
       async function endSessionChecks(ctx, next) {
@@ -79,6 +81,7 @@ module.exports = function endSessionAction(provider) {
       },
 
       async function renderLogout(ctx, next) {
+        // TODO: generic xsrf middleware to remove this
         const secret = crypto.randomBytes(24).toString('hex');
 
         ctx.oidc.session.logout = {
@@ -92,18 +95,17 @@ module.exports = function endSessionAction(provider) {
         ctx.type = 'html';
         ctx.status = 200;
 
-        const formhtml = `<form id="op.logoutForm" method="post" action="${ctx.oidc.urlFor('end_session')}"><input type="hidden" name="xsrf" value="${secret}"/></form>`;
-        await logoutSource(ctx, formhtml);
+        const formHtml = `<form id="op.logoutForm" method="post" action="${ctx.oidc.urlFor('end_session')}"><input type="hidden" name="xsrf" value="${secret}"/></form>`;
+        await logoutSource(ctx, formHtml);
 
         await next();
       },
     ],
 
     post: [
+      loadSession,
       parseBody,
-
       paramsMiddleware(['xsrf', 'logout']),
-
       rejectDupes,
 
       async function checkLogoutToken(ctx, next) {
@@ -165,7 +167,6 @@ module.exports = function endSessionAction(provider) {
 
         if (params.logout) {
           await session.destroy();
-          session.destroyed = true;
 
           // get all cookies matching _state.[clientId](.sig) and drop them
           const cookies = ctx.get('cookie').match(STATES);

--- a/lib/actions/grants/authorization_code.js
+++ b/lib/actions/grants/authorization_code.js
@@ -1,4 +1,5 @@
 const { get } = require('lodash');
+const uuidToGrantId = require('debug')('oidc-provider:uuid');
 
 const { InvalidGrant } = require('../../helpers/errors');
 const presence = require('../../helpers/validate_presence');
@@ -21,6 +22,8 @@ module.exports.handler = function getAuthorizationCodeHandler(provider) {
     if (!code) {
       throw new InvalidGrant('authorization code not found');
     }
+    uuidToGrantId('switched from uuid=%s to value of grantId=%s', ctx.oidc.uuid, code.grantId);
+    ctx.oidc.uuid = code.grantId;
 
     if (code.isExpired) {
       throw new InvalidGrant('authorization code is expired');

--- a/lib/actions/grants/authorization_code.js
+++ b/lib/actions/grants/authorization_code.js
@@ -1,17 +1,16 @@
-const crypto = require('crypto');
-const assert = require('assert');
-
 const { get } = require('lodash');
-const base64url = require('base64url');
 
 const { InvalidGrant } = require('../../helpers/errors');
 const presence = require('../../helpers/validate_presence');
 const instance = require('../../helpers/weak_cache');
+const getCheckPKCE = require('../../helpers/pkce');
 
 module.exports.handler = function getAuthorizationCodeHandler(provider) {
   const {
-    features: { pkce, alwaysIssueRefresh, conformIdTokenClaims }, audiences,
+    features: { alwaysIssueRefresh, conformIdTokenClaims }, audiences,
   } = instance(provider).configuration();
+  const checkPKCE = getCheckPKCE(provider);
+
   return async function authorizationCodeResponse(ctx, next) {
     presence(ctx, 'code', 'redirect_uri');
 
@@ -27,20 +26,10 @@ module.exports.handler = function getAuthorizationCodeHandler(provider) {
       throw new InvalidGrant('authorization code is expired');
     }
 
-    // PKCE check
-    if (pkce && (ctx.oidc.params.code_verifier || code.codeChallenge)) {
-      try {
-        let expected = ctx.oidc.params.code_verifier;
-        assert(expected);
+    checkPKCE(ctx.oidc.params.code_verifier, code.codeChallenge, code.codeChallengeMethod);
 
-        if (code.codeChallengeMethod === 'S256') {
-          expected = base64url.encode(crypto.createHash('sha256').update(expected).digest());
-        }
-
-        assert.equal(code.codeChallenge, expected);
-      } catch (err) {
-        throw new InvalidGrant('PKCE verification failed');
-      }
+    if (code.clientId !== ctx.oidc.client.clientId) {
+      ctx.throw(new InvalidGrant('authorization code client mismatch'));
     }
 
     try {
@@ -52,10 +41,6 @@ module.exports.handler = function getAuthorizationCodeHandler(provider) {
     } catch (err) {
       await code.destroy();
       throw err;
-    }
-
-    if (code.clientId !== ctx.oidc.client.clientId) {
-      throw new InvalidGrant('authorization code client mismatch');
     }
 
     if (code.redirectUri !== ctx.oidc.params.redirect_uri) {

--- a/lib/actions/grants/authorization_code.js
+++ b/lib/actions/grants/authorization_code.js
@@ -6,6 +6,8 @@ const presence = require('../../helpers/validate_presence');
 const instance = require('../../helpers/weak_cache');
 const getCheckPKCE = require('../../helpers/pkce');
 
+const gty = 'authorization_code';
+
 module.exports.handler = function getAuthorizationCodeHandler(provider) {
   const {
     features: { alwaysIssueRefresh, conformIdTokenClaims }, audiences,
@@ -61,6 +63,7 @@ module.exports.handler = function getAuthorizationCodeHandler(provider) {
 
     const { AccessToken, IdToken, RefreshToken } = provider;
     const at = new AccessToken({
+      gty,
       accountId: account.accountId,
       claims: code.claims,
       clientId: ctx.oidc.client.clientId,
@@ -81,6 +84,7 @@ module.exports.handler = function getAuthorizationCodeHandler(provider) {
 
     if (grantPresent && (alwaysIssueRefresh || code.scope.split(' ').includes('offline_access'))) {
       const rt = new RefreshToken({
+        gty,
         accountId: account.accountId,
         acr: code.acr,
         amr: code.amr,

--- a/lib/actions/grants/device_code.js
+++ b/lib/actions/grants/device_code.js
@@ -1,0 +1,150 @@
+const { get, upperFirst, camelCase } = require('lodash');
+
+const errors = require('../../helpers/errors');
+const presence = require('../../helpers/validate_presence');
+const instance = require('../../helpers/weak_cache');
+const getCheckPKCE = require('../../helpers/pkce');
+
+const { InvalidGrant, ExpiredToken, AuthorizationPending } = errors;
+
+module.exports.handler = function getDeviceCodeHandler(provider) {
+  const {
+    features: { alwaysIssueRefresh, conformIdTokenClaims }, audiences,
+  } = instance(provider).configuration();
+  const checkPKCE = getCheckPKCE(provider);
+
+  return async function authorizationCodeResponse(ctx, next) {
+    presence(ctx, 'device_code');
+
+    const code = await provider.DeviceCode.find(ctx.oidc.params.device_code, {
+      ignoreExpiration: true,
+    });
+
+    if (!code) {
+      ctx.throw(new InvalidGrant('device code not found'));
+    }
+
+    checkPKCE(ctx.oidc.params.code_verifier, code.codeChallenge, code.codeChallengeMethod);
+
+    if (code.clientId !== ctx.oidc.client.clientId) {
+      ctx.throw(new InvalidGrant('device code client mismatch'));
+    }
+
+    if (code.isExpired) {
+      ctx.throw(new ExpiredToken('device code is expired'));
+    }
+
+    if (!code.accountId && !code.error) {
+      ctx.throw(new AuthorizationPending());
+    }
+
+    try {
+      if (code.consumed) {
+        ctx.throw(new InvalidGrant('device code already consumed'));
+      }
+
+      await code.consume();
+    } catch (err) {
+      await code.destroy();
+      throw err;
+    }
+
+    if (code.error) {
+      const className = upperFirst(camelCase(code.error));
+      if (errors[className]) {
+        ctx.throw(new errors[className](code.errorDescription));
+      } else {
+        ctx.status = 400;
+        ctx.body = {
+          error: code.error,
+          error_description: code.errorDescription,
+        };
+        return next();
+      }
+    }
+
+    ctx.oidc.entity('DeviceCode', code);
+
+    const account = await provider.Account.findById(ctx, code.accountId, code);
+
+    if (!account) {
+      ctx.throw(new InvalidGrant('device code invalid (referenced account not found)'));
+    }
+    ctx.oidc.entity('Account', account);
+
+    const { AccessToken, IdToken, RefreshToken } = provider;
+    const at = new AccessToken({
+      accountId: account.accountId,
+      claims: code.claims,
+      clientId: ctx.oidc.client.clientId,
+      grantId: code.grantId,
+      scope: code.scope,
+      sid: code.sid,
+    });
+
+    at.setAudiences(await audiences(ctx, account.accountId, at, 'access_token', code.scope));
+
+    const accessToken = await at.save();
+    ctx.oidc.entity('AccessToken', at);
+
+    const { expiresIn } = AccessToken;
+
+    let refreshToken;
+    const grantPresent = ctx.oidc.client.grantTypes.includes('refresh_token');
+
+    if (grantPresent && (alwaysIssueRefresh || code.scope.split(' ').includes('offline_access'))) {
+      const rt = new RefreshToken({
+        accountId: account.accountId,
+        acr: code.acr,
+        amr: code.amr,
+        authTime: code.authTime,
+        claims: code.claims,
+        clientId: ctx.oidc.client.clientId,
+        grantId: code.grantId,
+        nonce: code.nonce,
+        scope: code.scope,
+        sid: code.sid,
+      });
+
+      refreshToken = await rt.save();
+      ctx.oidc.entity('RefreshToken', rt);
+    }
+
+    const token = new IdToken({
+      ...await account.claims('id_token', code.scope),
+      ...{
+        acr: code.acr,
+        amr: code.amr,
+        auth_time: code.authTime,
+      },
+    }, ctx.oidc.client.sectorIdentifier);
+
+    if (conformIdTokenClaims) {
+      token.scope = 'openid';
+    } else {
+      token.scope = code.scope;
+    }
+    token.mask = get(code.claims, 'id_token', {});
+
+    token.set('nonce', code.nonce);
+    token.set('at_hash', accessToken);
+    token.set('sid', code.sid);
+
+    const idToken = await token.sign(ctx.oidc.client, {
+      audiences: await audiences(ctx, code.accountId, code, 'id_token', code.scope),
+    });
+
+    ctx.body = {
+      access_token: accessToken,
+      expires_in: expiresIn,
+      id_token: idToken,
+      refresh_token: refreshToken,
+      scope: code.scope,
+      token_type: 'Bearer',
+    };
+
+    return next();
+  };
+};
+
+module.exports.parameters = ['device_code', 'code_verifier'];

--- a/lib/actions/grants/device_code.js
+++ b/lib/actions/grants/device_code.js
@@ -8,6 +8,8 @@ const getCheckPKCE = require('../../helpers/pkce');
 
 const { InvalidGrant, ExpiredToken, AuthorizationPending } = errors;
 
+const gty = 'device_code';
+
 module.exports.handler = function getDeviceCodeHandler(provider) {
   const {
     features: { alwaysIssueRefresh, conformIdTokenClaims }, audiences,
@@ -77,6 +79,7 @@ module.exports.handler = function getDeviceCodeHandler(provider) {
 
     const { AccessToken, IdToken, RefreshToken } = provider;
     const at = new AccessToken({
+      gty,
       accountId: account.accountId,
       claims: code.claims,
       clientId: ctx.oidc.client.clientId,
@@ -97,6 +100,7 @@ module.exports.handler = function getDeviceCodeHandler(provider) {
 
     if (grantPresent && (alwaysIssueRefresh || code.scope.split(' ').includes('offline_access'))) {
       const rt = new RefreshToken({
+        gty,
         accountId: account.accountId,
         acr: code.acr,
         amr: code.amr,

--- a/lib/actions/grants/device_code.js
+++ b/lib/actions/grants/device_code.js
@@ -1,4 +1,5 @@
 const { get, upperFirst, camelCase } = require('lodash');
+const uuidToGrantId = require('debug')('oidc-provider:uuid');
 
 const errors = require('../../helpers/errors');
 const presence = require('../../helpers/validate_presence');
@@ -23,6 +24,8 @@ module.exports.handler = function getDeviceCodeHandler(provider) {
     if (!code) {
       ctx.throw(new InvalidGrant('device code not found'));
     }
+    uuidToGrantId('switched from uuid=%s to value of grantId=%s', ctx.oidc.uuid, code.grantId);
+    ctx.oidc.uuid = code.grantId;
 
     checkPKCE(ctx.oidc.params.code_verifier, code.codeChallenge, code.codeChallengeMethod);
 

--- a/lib/actions/grants/index.js
+++ b/lib/actions/grants/index.js
@@ -3,9 +3,11 @@
 const authorization_code = require('./authorization_code');
 const client_credentials = require('./client_credentials');
 const refresh_token = require('./refresh_token');
+const device_code = require('./device_code');
 
 module.exports = {
   authorization_code,
   client_credentials,
   refresh_token,
+  'urn:ietf:params:oauth:grant-type:device_code': device_code,
 };

--- a/lib/actions/grants/refresh_token.js
+++ b/lib/actions/grants/refresh_token.js
@@ -1,4 +1,5 @@
 const _ = require('lodash');
+const uuidToGrantId = require('debug')('oidc-provider:uuid');
 
 const { InvalidGrant, InvalidScope } = require('../../helpers/errors');
 const presence = require('../../helpers/validate_presence');
@@ -23,6 +24,8 @@ module.exports.handler = function getRefreshTokenHandler(provider) {
     if (!refreshToken) {
       throw new InvalidGrant('refresh token not found');
     }
+    uuidToGrantId('switched from uuid=%s to value of grantId=%s', ctx.oidc.uuid, refreshToken.grantId);
+    ctx.oidc.uuid = refreshToken.grantId;
 
     if (refreshToken.isExpired) {
       throw new InvalidGrant('refresh token is expired');

--- a/lib/actions/grants/refresh_token.js
+++ b/lib/actions/grants/refresh_token.js
@@ -5,6 +5,8 @@ const { InvalidGrant, InvalidScope } = require('../../helpers/errors');
 const presence = require('../../helpers/validate_presence');
 const instance = require('../../helpers/weak_cache');
 
+const gty = 'refresh_token';
+
 module.exports.handler = function getRefreshTokenHandler(provider) {
   const conf = instance(provider).configuration();
 
@@ -79,7 +81,12 @@ module.exports.handler = function getRefreshTokenHandler(provider) {
           grantId: refreshToken.grantId,
           nonce: refreshToken.nonce,
           sid: refreshToken.sid,
+          gty: refreshToken.gty,
         });
+
+        if (!refreshToken.gty.endsWith(gty)) {
+          refreshToken.gty = `${refreshToken.gty} ${gty}`;
+        }
 
         refreshTokenValue = await refreshToken.save();
         ctx.oidc.entity('RefreshToken', refreshToken);
@@ -96,7 +103,12 @@ module.exports.handler = function getRefreshTokenHandler(provider) {
       clientId: ctx.oidc.client.clientId,
       grantId: refreshToken.grantId,
       sid: refreshToken.sid,
+      gty: refreshToken.gty,
     });
+
+    if (!at.gty.endsWith(gty)) {
+      at.gty = `${at.gty} ${gty}`;
+    }
 
     at.setAudiences(await audiences(ctx, account.accountId, at, 'access_token', scope));
 

--- a/lib/actions/introspection.js
+++ b/lib/actions/introspection.js
@@ -1,4 +1,7 @@
-const debug = require('debug')('oidc-provider:introspection');
+const Debug = require('debug');
+
+const debug = new Debug('oidc-provider:introspection');
+const uuidToGrantId = new Debug('oidc-provider:uuid');
 
 const presence = require('../helpers/validate_presence');
 const tokenAuth = require('../shared/token_auth');
@@ -108,6 +111,10 @@ module.exports = function introspectionAction(provider) {
 
       if (!token || !token.isValid) {
         return;
+      }
+      if (token.grantId) {
+        uuidToGrantId('switched from uuid=%s to value of grantId=%s', ctx.oidc.uuid, token.grantId);
+        ctx.oidc.uuid = token.grantId;
       }
 
       if (ctx.oidc.client.introspectionEndpointAuthMethod === 'none') {

--- a/lib/actions/introspection.js
+++ b/lib/actions/introspection.js
@@ -9,7 +9,7 @@ const bodyParser = require('../shared/selective_body');
 const rejectDupes = require('../shared/reject_dupes');
 const getParams = require('../shared/assemble_params');
 
-const introspectable = ['AccessToken', 'ClientCredentials', 'RefreshToken'];
+const introspectable = new Set(['AccessToken', 'ClientCredentials', 'RefreshToken']);
 const PARAM_LIST = new Set(['token', 'token_type_hint', ...tokenAuth.AUTH_PARAMS]);
 
 module.exports = function introspectionAction(provider) {
@@ -116,7 +116,7 @@ module.exports = function introspectionAction(provider) {
         }
       }
 
-      if (introspectable.includes(token.kind)) {
+      if (introspectable.has(token.kind)) {
         ctx.oidc.entity(token.kind, token);
       } else {
         return;

--- a/lib/actions/introspection.js
+++ b/lib/actions/introspection.js
@@ -7,7 +7,7 @@ const mask = require('../helpers/claims');
 const instance = require('../helpers/weak_cache');
 const bodyParser = require('../shared/selective_body');
 const rejectDupes = require('../shared/reject_dupes');
-const getParams = require('../shared/get_params');
+const getParams = require('../shared/assemble_params');
 
 const introspectable = ['AccessToken', 'ClientCredentials', 'RefreshToken'];
 const PARAM_LIST = new Set(['token', 'token_type_hint', ...tokenAuth.AUTH_PARAMS]);

--- a/lib/actions/revocation.js
+++ b/lib/actions/revocation.js
@@ -6,7 +6,7 @@ const instance = require('../helpers/weak_cache');
 const tokenAuth = require('../shared/token_auth');
 const bodyParser = require('../shared/selective_body');
 const rejectDupes = require('../shared/reject_dupes');
-const getParams = require('../shared/get_params');
+const getParams = require('../shared/assemble_params');
 
 const revokeable = ['AccessToken', 'ClientCredentials', 'RefreshToken'];
 const PARAM_LIST = new Set(['token', 'token_type_hint', ...tokenAuth.AUTH_PARAMS]);

--- a/lib/actions/revocation.js
+++ b/lib/actions/revocation.js
@@ -1,4 +1,7 @@
-const debug = require('debug')('oidc-provider:revocation');
+const Debug = require('debug');
+
+const debug = new Debug('oidc-provider:revocation');
+const uuidToGrantId = new Debug('oidc-provider:uuid');
 
 const { InvalidRequest } = require('../helpers/errors');
 const presence = require('../helpers/validate_presence');
@@ -108,6 +111,11 @@ module.exports = function revocationAction(provider) {
         ctx.oidc.entity(token.kind, token);
       } else {
         return;
+      }
+
+      if (token.grantId) {
+        uuidToGrantId('switched from uuid=%s to value of grantId=%s', ctx.oidc.uuid, token.grantId);
+        ctx.oidc.uuid = token.grantId;
       }
 
       if (token.clientId !== ctx.oidc.client.clientId) {

--- a/lib/actions/revocation.js
+++ b/lib/actions/revocation.js
@@ -50,13 +50,13 @@ module.exports = function revocationAction(provider) {
     async function renderTokenResponse(ctx, next) {
       ctx.status = 200;
       ctx.body = '';
+      await next();
       debug(
         'uuid=%s client=%s token=%s',
         ctx.oidc.uuid,
         ctx.oidc.client.clientId,
         ctx.oidc.params.token,
       );
-      await next();
     },
 
     async function revokeToken(ctx, next) {

--- a/lib/actions/revocation.js
+++ b/lib/actions/revocation.js
@@ -8,7 +8,7 @@ const bodyParser = require('../shared/selective_body');
 const rejectDupes = require('../shared/reject_dupes');
 const getParams = require('../shared/assemble_params');
 
-const revokeable = ['AccessToken', 'ClientCredentials', 'RefreshToken'];
+const revokeable = new Set(['AccessToken', 'ClientCredentials', 'RefreshToken']);
 const PARAM_LIST = new Set(['token', 'token_type_hint', ...tokenAuth.AUTH_PARAMS]);
 
 module.exports = function revocationAction(provider) {
@@ -104,7 +104,7 @@ module.exports = function revocationAction(provider) {
 
       if (!token) return;
 
-      if (revokeable.includes(token.kind)) {
+      if (revokeable.has(token.kind)) {
         ctx.oidc.entity(token.kind, token);
       } else {
         return;

--- a/lib/actions/token.js
+++ b/lib/actions/token.js
@@ -9,7 +9,7 @@ const noCache = require('../shared/no_cache');
 const tokenAuth = require('../shared/token_auth');
 const bodyParser = require('../shared/selective_body');
 const rejectDupes = require('../shared/reject_dupes');
-const getParams = require('../shared/get_params');
+const getParams = require('../shared/assemble_params');
 
 module.exports = function tokenAction(provider) {
   const parseBody = bodyParser('application/x-www-form-urlencoded');

--- a/lib/actions/userinfo.js
+++ b/lib/actions/userinfo.js
@@ -7,8 +7,7 @@ const instance = require('../helpers/weak_cache');
 const setWWWAuthenticate = require('../helpers/set_www_authenticate');
 const bodyParser = require('../shared/conditional_body');
 const rejectDupes = require('../shared/reject_dupes');
-const params = require('../shared/get_params');
-const errorHandler = require('../shared/error_handler');
+const params = require('../shared/assemble_params');
 const noCache = require('../shared/no_cache');
 
 const PARAM_LIST = [
@@ -31,7 +30,6 @@ module.exports = function userinfoAction(provider) {
 
   return [
     noCache,
-    errorHandler(provider, 'userinfo.error'),
 
     async function setWWWAuthenticateHeader(ctx, next) {
       try {

--- a/lib/actions/userinfo.js
+++ b/lib/actions/userinfo.js
@@ -1,5 +1,8 @@
 const _ = require('lodash');
-const debug = require('debug')('oidc-provider:userinfo');
+const Debug = require('debug');
+
+const debug = new Debug('oidc-provider:userinfo');
+const uuidToGrantId = new Debug('oidc-provider:uuid');
 
 const { InvalidToken, InvalidScope } = require('../helpers/errors');
 const getMask = require('../helpers/claims');
@@ -56,6 +59,9 @@ module.exports = function userinfoAction(provider) {
     async function validateBearer(ctx, next) {
       const accessToken = await provider.AccessToken.find(ctx.oidc.bearer);
       ctx.assert(accessToken, new InvalidToken());
+
+      uuidToGrantId('switched from uuid=%s to value of grantId=%s', ctx.oidc.uuid, accessToken.grantId);
+      ctx.oidc.uuid = accessToken.grantId;
 
       ctx.oidc.accessToken = accessToken;
       ctx.oidc.entity('AccessToken', accessToken);

--- a/lib/adapter_test.js
+++ b/lib/adapter_test.js
@@ -4,6 +4,7 @@ const { isMatch, pick } = require('lodash');
 const uuid = require('uuid/v4');
 
 const epochTime = require('./helpers/epoch_time');
+const instance = require('./helpers/weak_cache');
 
 module.exports = class AdapterTest {
   constructor(provider, accountId = uuid, clientId = uuid) {
@@ -30,13 +31,29 @@ module.exports = class AdapterTest {
     };
   }
 
-  execute() {
-    return this.authorizationCodeInsert()
+  async execute() {
+    await this.authorizationCodeInsert()
       .then(this.authorizationCodeFind.bind(this))
       .then(this.authorizationCodeConsume.bind(this))
       .then(this.accessTokenSave.bind(this))
       .then(this.accessTokenFind.bind(this))
       .then(this.accessTokenDestroy.bind(this));
+
+    if (instance(this.provider).configuration('features.deviceCode')) {
+      const dc = new (this.provider.DeviceCode)({
+        clientId: this.data.clientId,
+        grantId: this.data.grantId,
+        userCode: '123-456-789',
+        params: {
+          client_id: 'client',
+          scope: 'openid',
+        },
+      });
+
+      await dc.save();
+      const found = await this.provider.DeviceCode.findByUserCode('123-456-789', { ignoreExpiration: true });
+      assert(found, 'expected device code to be found by user code');
+    }
   }
 
   authorizationCodeInsert() {

--- a/lib/adapters/memory_adapter.js
+++ b/lib/adapters/memory_adapter.js
@@ -8,6 +8,10 @@ function grantKeyFor(id) {
   return `grant:${id}`;
 }
 
+function userCodeKeyFor(userCode) {
+  return `userCode:${userCode}`;
+}
+
 class MemoryAdapter {
   constructor(name) {
     this.name = name;
@@ -43,10 +47,15 @@ class MemoryAdapter {
     return Promise.resolve(storage.get(this.key(id)));
   }
 
+  findByUserCode(userCode) {
+    const id = storage.get(userCodeKeyFor(userCode));
+    return this.find(id);
+  }
+
   upsert(id, payload, expiresIn) {
     const key = this.key(id);
 
-    const { grantId } = payload;
+    const { grantId, userCode } = payload;
     if (grantId) {
       const grantKey = grantKeyFor(grantId);
       const grant = storage.get(grantKey);
@@ -55,6 +64,10 @@ class MemoryAdapter {
       } else {
         grant.push(key);
       }
+    }
+
+    if (userCode) {
+      storage.set(userCodeKeyFor(userCode), id, expiresIn * 1000);
     }
 
     storage.set(key, payload, expiresIn * 1000);

--- a/lib/helpers/configuration_schema.js
+++ b/lib/helpers/configuration_schema.js
@@ -1,5 +1,6 @@
-const _ = require('lodash');
-const { get, set } = require('lodash');
+const {
+  get, set, chain, ..._
+} = require('lodash');
 
 const defaults = require('./defaults');
 
@@ -63,8 +64,8 @@ function authEndpointDefaults(config) {
     'unsupported.tokenEndpointAuthSigningAlgValues',
   ].forEach((prop) => {
     ['introspection', 'revocation'].forEach((endpoint) => {
-      if (_.get(config, prop) && !_.get(config, prop.replace('token', endpoint))) {
-        _.set(config, prop.replace('token', endpoint), _.get(config, prop));
+      if (get(config, prop) && !get(config, prop.replace('token', endpoint))) {
+        set(config, prop.replace('token', endpoint), get(config, prop));
       }
     });
   });
@@ -92,6 +93,21 @@ module.exports = class ConfigurationSchema {
 
     if (get(this, 'features.requestUri') === true) {
       set(this, 'features.requestUri', { requireRequestUriRegistration: true });
+    }
+
+    if (get(this, 'features.deviceCode')) {
+      if (!this.features.deviceCode.charset) {
+        set(this, 'features.deviceCode.charset', 'BCDFGHJKLMNPQRSTVWXZ');
+      }
+      if (!this.features.deviceCode.mask) {
+        set(this, 'features.deviceCode.mask', '****-****');
+      }
+      if (!this.features.deviceCode.deviceInfo) {
+        set(this, 'features.deviceCode.deviceInfo', ctx => ({
+          ip: ctx.ip,
+          userAgent: ctx.get('user-agent'),
+        }));
+      }
     }
 
     this.collectScopes();
@@ -123,6 +139,10 @@ module.exports = class ConfigurationSchema {
 
     if (this.features.clientCredentials) {
       this.grantTypes.add('client_credentials');
+    }
+
+    if (this.features.deviceCode) {
+      this.grantTypes.add('urn:ietf:params:oauth:grant-type:device_code');
     }
   }
 
@@ -212,7 +232,7 @@ module.exports = class ConfigurationSchema {
   }
 
   omitUnsupported(property) {
-    _.pullAll(this[property], _.get(this, `unsupported.${property}`, []));
+    _.pullAll(this[property], get(this, `unsupported.${property}`, []));
   }
 
   removeSigAlg() {

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -154,9 +154,9 @@ const DEFAULTS = {
    * extraParams
    *
    * description: Pass an iterable object (i.e. array or set of strings) to extend the parameters
-   *   recognised by the authorization endpoint. These parameters are then available in
-   *   `ctx.oidc.params` as well as passed to interaction session details
-   * affects: authorization, interaction
+   *   recognised by the authorization and device authorization endpoints. These parameters are then
+   *   available in `ctx.oidc.params` as well as passed to interaction session details
+   * affects: authorization, device_authorization, interaction
    */
   extraParams: [],
 
@@ -178,6 +178,7 @@ const DEFAULTS = {
     claimsParameter: false,
     clientCredentials: false,
     conformIdTokenClaims: false, // TODO: true in next major
+    deviceCode: false,
     encryption: false,
     frontchannelLogout: false,
     introspection: false,
@@ -217,6 +218,7 @@ const DEFAULTS = {
     AccessToken: undefined,
     AuthorizationCode: undefined,
     RefreshToken: undefined,
+    DeviceCode: undefined,
     ClientCredentials: undefined,
     InitialAccessToken: undefined,
     RegistrationAccessToken: undefined,
@@ -259,12 +261,14 @@ const DEFAULTS = {
     authorization: '/auth',
     certificates: '/certs',
     check_session: '/session/check',
+    device_authorization: '/device/auth',
     end_session: '/session/end',
     introspection: '/token/introspection',
     registration: '/reg',
     revocation: '/token/revocation',
     token: '/token',
     userinfo: '/me',
+    code_verification: '/device',
   },
 
 
@@ -325,6 +329,7 @@ const DEFAULTS = {
     AccessToken: 60 * 60, // 1 hour in seconds
     AuthorizationCode: 10 * 60, // 10 minutes in seconds
     ClientCredentials: 10 * 60, // 10 minutes in seconds
+    DeviceCode: 10 * 60, // 10 minutes in seconds
     IdToken: 60 * 60, // 1 hour in seconds
     RefreshToken: 14 * 24 * 60 * 60, // 14 days in seconds
   },
@@ -384,17 +389,20 @@ const DEFAULTS = {
   /*
    * logoutSource
    *
-   * description: HTML source to which a logout form source is passed when session management
-   *   renders a confirmation prompt for the User-Agent.
+   * description: HTML source rendered when when session management feature renders a confirmation
+   *   prompt for the User-Agent.
    * affects: session management
    */
   async logoutSource(ctx, form) {
+    // @param ctx - koa request context
+    // @param form - form source (id="op.logoutForm") to be embedded in the page and submitted by
+    //   the End-User
     changeme('logoutSource', 'customize the look of the logout page');
     ctx.body = `<!DOCTYPE html>
 <head>
   <title>Logout Request</title>
   <style>
-    @import url(https://fonts.googleapis.com/css?family=Roboto:400,100);.container h1{font-weight:100;text-align:center;font-size:1.3em}body{font-family:Roboto,sans-serif;margin-top:25px;margin-bottom:25px}.container{padding:0 40px 10px;width:274px;background-color:#F7F7F7;margin:0 auto 10px;border-radius:2px;box-shadow:0 2px 2px rgba(0,0,0,.3);overflow:hidden}.btn{text-align:center;font-size:14px;font-family:Arial,sans-serif;font-weight:700;height:36px;padding:0 8px;width:100%;display:block;margin-bottom:10px;position:relative;border:0;color:#fff;text-shadow:0 1px rgba(0,0,0,.1);background-color:#4d90fe}.btn:hover{border:0;text-shadow:0 1px rgba(0,0,0,.3);background-color:#357ae8}button{cursor:pointer}
+  @import url(https://fonts.googleapis.com/css?family=Roboto:400,100);button,h1{text-align:center}h1{font-weight:100;font-size:1.3em}body{font-family:Roboto,sans-serif;margin-top:25px;margin-bottom:25px}.container{padding:0 40px 10px;width:274px;background-color:#F7F7F7;margin:0 auto 10px;border-radius:2px;box-shadow:0 2px 2px rgba(0,0,0,.3);overflow:hidden}button{font-size:14px;font-family:Arial,sans-serif;font-weight:700;height:36px;padding:0 8px;width:100%;display:block;margin-bottom:10px;position:relative;border:0;color:#fff;text-shadow:0 1px rgba(0,0,0,.1);background-color:#4d90fe;cursor:pointer}button:hover{border:0;text-shadow:0 1px rgba(0,0,0,.3);background-color:#357ae8}
   </style>
 </head>
 <body>
@@ -416,8 +424,121 @@ const DEFAULTS = {
       }
     </script>
     ${form}
-    <button class="btn" onclick="logout()">Yes, sign me out</button>
-    <button class="btn" onclick="rpLogoutOnly()">No, stay signed in</button>
+    <button onclick="logout()">Yes, sign me out</button>
+    <button onclick="rpLogoutOnly()">No, stay signed in</button>
+  </div>
+</body>
+</html>`;
+  },
+
+
+  /*
+   * userCodeInputSource
+   *
+   * description: HTML source rendered when device code feature renders an input prompt for the
+   *   User-Agent.
+   * affects: device code input
+   */
+  async userCodeInputSource(ctx, form, out, err) {
+    // @param ctx - koa request context
+    // @param form - form source (id="op.deviceInputForm") to be embedded in the page and submitted
+    //   by the End-User.
+    // @param out - if an error is returned the out object contains details that are fit to be
+    //   rendered, i.e. does not include internal error messages
+    // @param err - error object with an optional userCode property passed when the form is being
+    //   re-rendered due to code missing/invalid/expired
+    changeme('userCodeInputSource', 'customize the look of the user code input page');
+    let msg;
+    if (err && (err.userCode || err.name === 'NoCodeError')) {
+      msg = '<p class="red">The code you entered is incorrect. Try again</p>';
+    } else if (err) {
+      msg = '<p class="red">There was an error processing your request</p>';
+    }
+    ctx.body = `<!DOCTYPE html>
+<head>
+  <title>Sign-in</title>
+  <style>
+    @import url(https://fonts.googleapis.com/css?family=Roboto:400,100);h1,h1+p{font-weight:100;text-align:center}body{font-family:Roboto,sans-serif;margin-top:25px;margin-bottom:25px}.container{padding:0 40px 10px;width:274px;background-color:#F7F7F7;margin:0 auto 10px;border-radius:2px;box-shadow:0 2px 2px rgba(0,0,0,.3);overflow:hidden}h1{font-size:2.3em}p.red{color:#d50000}input[type=email],input[type=password],input[type=text]{height:44px;font-size:16px;width:100%;margin-bottom:10px;-webkit-appearance:none;background:#fff;border:1px solid #d9d9d9;border-top:1px solid silver;padding:0 8px;box-sizing:border-box;-moz-box-sizing:border-box}[type=submit]{width:100%;display:block;margin-bottom:10px;position:relative;text-align:center;font-size:14px;font-family:Arial,sans-serif;font-weight:700;height:36px;padding:0 8px;border:0;color:#fff;text-shadow:0 1px rgba(0,0,0,.1);background-color:#4d90fe;cursor:pointer}[type=submit]:hover{border:0;text-shadow:0 1px rgba(0,0,0,.3);background-color:#357ae8}
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Sign-in</h1>
+    ${msg}
+    ${form}
+    <button type="submit" form="op.deviceInputForm">Continue</button>
+  </div>
+</body>
+</html>`;
+  },
+
+
+  /*
+   * userCodeConfirmSource
+   *
+   * description: HTML source rendered when device code feature renders an a confirmation prompt for
+   *   ther User-Agent.
+   * affects: device code authorization confirmation
+   */
+  async userCodeConfirmSource(ctx, form, client, deviceInfo) {
+    // @param ctx - koa request context
+    // @param form - form source (id="op.deviceConfirmForm") to be embedded in the page and
+    //   submitted by the End-User.
+    // @param deviceInfo - device information from the device_authorization_endpoint call
+    changeme('userCodeConfirmSource', 'customize the look of the user code confirmation page');
+    const {
+      clientId, clientName, clientUri, logoUri, policyUri, tosUri, // eslint-disable-line no-unused-vars, max-len
+    } = ctx.oidc.client;
+    ctx.body = `<!DOCTYPE html>
+<head>
+  <title>Device Login Confirmation</title>
+  <style>
+    @import url(https://fonts.googleapis.com/css?family=Roboto:400,100);.help,h1,h1+p{text-align:center}h1,h1+p{font-weight:100}body{font-family:Roboto,sans-serif;margin-top:25px;margin-bottom:25px}.container{padding:0 40px 10px;width:274px;background-color:#F7F7F7;margin:0 auto 10px;border-radius:2px;box-shadow:0 2px 2px rgba(0,0,0,.3);overflow:hidden}h1{font-size:2.3em}[type=submit]{width:100%;display:block;margin-bottom:10px;position:relative;font-size:14px;font-family:Arial,sans-serif;font-weight:700;height:36px;padding:0 8px;border:0;color:#fff;text-shadow:0 1px rgba(0,0,0,.1);background-color:#4d90fe;cursor:pointer}button:hover{border:0;text-shadow:0 1px rgba(0,0,0,.3);background-color:#357ae8}a{text-decoration:none;color:#666;font-weight:400;display:inline-block;opacity:.6}.help{width:100%;font-size:12px}
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Confirm Device</h1>
+    <p>
+      You are about to authorize a <code>${clientName || clientId}</code> device client on IP <code>${deviceInfo.ip}</code>, identified by <code>${deviceInfo.userAgent}</code>
+      <br/><br/>
+      If you did not initiate this action and/or are unaware of such device in your possession please close this window.
+    </p>
+    ${form}
+    <button autofocus type="submit" form="op.deviceConfirmForm">Continue</button>
+    <div class="help">
+      <a href="">[ Cancel ]</a>
+    </div>
+  </div>
+</body>
+</html>`;
+  },
+
+
+  /*
+   * deviceCodeSuccess
+   *
+   * description: HTML source rendered when device code feature renders a success page for the
+   *   User-Agent.
+   * affects: device code success page
+   */
+  async deviceCodeSuccess(ctx) {
+    // @param ctx - koa request context
+    changeme('deviceCodeSuccess', 'customize the look of the device code success page');
+    const {
+      clientId, clientName, clientUri, initiateLoginUri, logoUri, policyUri, tosUri, // eslint-disable-line no-unused-vars, max-len
+    } = ctx.oidc.client;
+    ctx.body = `<!DOCTYPE html>
+<head>
+  <title>Sign-in Success</title>
+  <style>
+    @import url(https://fonts.googleapis.com/css?family=Roboto:400,100);h1,h1+p{font-weight:100;text-align:center}body{font-family:Roboto,sans-serif;margin-top:25px;margin-bottom:25px}.container{padding:0 40px 10px;width:274px;background-color:#F7F7F7;margin:0 auto 10px;border-radius:2px;box-shadow:0 2px 2px rgba(0,0,0,.3);overflow:hidden}h1{font-size:2.3em}
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Sign-in Success</h1>
+    <p>Your login ${clientName ? `with ${clientName}` : ''} was successful, you can now close this page.</p>
   </div>
 </body>
 </html>`;
@@ -432,6 +553,7 @@ const DEFAULTS = {
    *   as have a timeout mechanism in it.
    * affects: session management
    */
+  // TODO: check escaping of client entered url values
   async frontchannelLogoutPendingSource(ctx, frames, postLogoutRedirectUri, timeout) {
     changeme('frontchannelLogoutPendingSource', 'customize the front-channel logout pending page');
     ctx.body = `<!DOCTYPE html>
@@ -501,7 +623,7 @@ const DEFAULTS = {
 <head>
   <title>oops! something went wrong</title>
   <style>
-    @import url(https://fonts.googleapis.com/css?family=Roboto:400,100);.container h1{font-weight:100;text-align:center;font-size:2.3em}body{font-family:Roboto,sans-serif;margin-top:25px;margin-bottom:25px}.container{padding:0 40px 10px;width:274px;background-color:#F7F7F7;margin:0 auto 10px;border-radius:2px;box-shadow:0 2px 2px rgba(0,0,0,.3);overflow:hidden}pre{white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space:-o-pre-wrap;word-wrap:break-word;margin:0 0 0 1em;text-indent:-1em}
+    @import url(https://fonts.googleapis.com/css?family=Roboto:400,100);h1{font-weight:100;text-align:center;font-size:2.3em}body{font-family:Roboto,sans-serif;margin-top:25px;margin-bottom:25px}.container{padding:0 40px 10px;width:274px;background-color:#F7F7F7;margin:0 auto 10px;border-radius:2px;box-shadow:0 2px 2px rgba(0,0,0,.3);overflow:hidden}pre{white-space:pre-wrap;white-space:-moz-pre-wrap;white-space:-pre-wrap;white-space:-o-pre-wrap;word-wrap:break-word;margin:0 0 0 1em;text-indent:-1em}
   </style>
 </head>
 <body>

--- a/lib/helpers/err_out.js
+++ b/lib/helpers/err_out.js
@@ -1,0 +1,17 @@
+module.exports = ({
+  expose, message, error_description: description, scope,
+}, state) => {
+  if (expose) {
+    return {
+      error: message,
+      error_description: description,
+      ...(scope !== undefined ? { scope } : undefined),
+      ...(state !== undefined ? { state } : undefined),
+    };
+  }
+  return {
+    error: 'server_error',
+    error_description: 'oops something went wrong',
+    ...(state ? { state } : undefined),
+  };
+};

--- a/lib/helpers/errors.js
+++ b/lib/helpers/errors.js
@@ -90,8 +90,9 @@ class InvalidGrant extends OIDCProviderError {
 }
 
 const classes = [
-  ['temporarily_unavailable'],
   ['access_denied'],
+  ['authorization_pending', 'authorization request is still pending as the end-user hasn\'t yet completed the user interaction steps'],
+  ['expired_token'],
   ['invalid_request_object'],
   ['invalid_request_uri'],
   ['redirect_uri_mismatch', 'redirect_uri did not match any client\'s registered redirect_uris'],
@@ -99,8 +100,10 @@ const classes = [
   ['registration_not_supported', 'registration parameter provided but not supported'],
   ['request_not_supported', 'request parameter provided but not supported'],
   ['request_uri_not_supported', 'request_uri parameter provided but not supported'],
-  ['restricted_grant_type', 'requested grant type is restricted to this client'], // TODO: Deprecated Error
-  ['restricted_response_type', 'response_type not allowed for this client'], // TODO: Deprecated Error
+  ['restricted_grant_type', 'requested grant type is restricted to this client'], // TODO: Deprecated Error, delete in 5.x
+  ['restricted_response_type', 'response_type not allowed for this client'], // TODO: Deprecated Error, delete in 5.x
+  ['slow_down', 'you are polling too quickly and should back off at a reasonable rate'],
+  ['temporarily_unavailable'],
   ['unauthorized_client'],
   ['unsupported_grant_type', 'unsupported grant_type requested'],
   ['unsupported_response_mode', 'unsupported response_mode requested'],

--- a/lib/helpers/generate_user_code.js
+++ b/lib/helpers/generate_user_code.js
@@ -1,0 +1,13 @@
+const generate = require('nanoid/generate');
+
+module.exports = (charset, mask) => {
+  const length = mask.split('*').length - 1;
+  const generated = generate(charset, length);
+  let at = 0;
+  return mask.split('').map((p) => {
+    if (p === '*') {
+      return generated[at++]; // eslint-disable-line no-plusplus
+    }
+    return p;
+  }).join('');
+};

--- a/lib/helpers/initialize_app.js
+++ b/lib/helpers/initialize_app.js
@@ -1,3 +1,5 @@
+const assert = require('assert');
+
 const Router = require('koa-router');
 const getCors = require('@koa/cors');
 
@@ -15,9 +17,8 @@ const getCheckSession = require('../actions/check_session');
 const getEndSession = require('../actions/end_session');
 const getInteraction = require('../actions/interaction');
 const grants = require('../actions/grants');
+const getCodeVerification = require('../actions/code_verification');
 const responseModes = require('../response_modes');
-const getResumeMiddleware = require('../shared/resume');
-const getSessionMiddleware = require('../shared/session');
 const error = require('../shared/error_handler');
 const getAuthError = require('../shared/authorization_error_handler');
 const invalidRoute = require('../shared/invalid_route');
@@ -37,11 +38,43 @@ module.exports = function initializeApp() {
   const router = new Router();
   instance(this).router = router;
 
-  const get = router.get.bind(router);
-  const post = router.post.bind(router);
-  const del = router.del.bind(router);
-  const put = router.put.bind(router);
-  const options = router.options.bind(router);
+  const ensureOIDC = contextEnsureOidc(this);
+
+  function routerAssert(name, route, ...stack) {
+    assert(typeof name === 'string' && name.charAt(0) !== '/', `invalid route name ${name}`);
+    assert(typeof route === 'string' && route.charAt(0) === '/', `invalid route ${route}`);
+    stack.forEach(middleware => assert.equal(typeof middleware, 'function'), 'invalid middleware');
+  }
+  async function ensureSessionSave(ctx, next) {
+    try {
+      await next();
+      if (ctx.oidc.session && ctx.oidc.session.touched) {
+        await ctx.oidc.session.save();
+      }
+    } catch (err) {
+      // TODO
+    }
+  }
+  const get = (name, route, ...stack) => {
+    routerAssert(name, route, ...stack);
+    router.get(name, route, ensureOIDC, ensureSessionSave, ...stack);
+  };
+  const post = (name, route, ...stack) => {
+    routerAssert(name, route, ...stack);
+    router.post(name, route, ensureOIDC, ensureSessionSave, ...stack);
+  };
+  const del = (name, route, ...stack) => {
+    routerAssert(name, route, ...stack);
+    router.del(name, route, ensureOIDC, ...stack);
+  };
+  const put = (name, route, ...stack) => {
+    routerAssert(name, route, ...stack);
+    router.put(name, route, ensureOIDC, ...stack);
+  };
+  const options = (name, route, ...stack) => {
+    routerAssert(name, route, ...stack);
+    router.options(name, route, ensureOIDC, ...stack);
+  };
 
   const { routes } = configuration;
   const onlyGetCors = getCors({ allowedMethods: 'GET' });
@@ -60,22 +93,20 @@ module.exports = function initializeApp() {
     this.registerResponseMode('web_message', responseModes.webMessage);
   }
 
-  const session = getSessionMiddleware(this);
+  const authorization = getAuthorization(this, 'authorization');
   const authError = getAuthError(this);
+  get('authorization', routes.authorization, authError, ...authorization);
+  post('authorization', routes.authorization, authError, ...authorization);
 
-  const authorization = getAuthorization(this);
-  get('authorization', routes.authorization, authError, session, ...authorization);
-  post('authorization', routes.authorization, authError, session, ...authorization);
-
-  const resume = getResumeMiddleware(this);
-  get('resume', `${routes.authorization}/:grant`, authError, session, resume, ...authorization);
+  const resume = getAuthorization(this, 'resume');
+  get('resume', `${routes.authorization}/:grant`, authError, ...resume);
 
   const userinfo = getUserinfo(this);
   const userInfoCors = getCors({
     allowedMethods: 'GET,POST', exposeHeaders: 'WWW-Authenticate', allowHeaders: 'Authorization',
   });
-  get('userinfo', routes.userinfo, userInfoCors, ...userinfo);
-  post('userinfo', routes.userinfo, userInfoCors, ...userinfo);
+  get('userinfo', routes.userinfo, userInfoCors, error(this, 'userinfo.error'), ...userinfo);
+  post('userinfo', routes.userinfo, userInfoCors, error(this, 'userinfo.error'), ...userinfo);
   options('userinfo', routes.userinfo, userInfoCors);
 
   const token = getToken(this);
@@ -123,8 +154,21 @@ module.exports = function initializeApp() {
     get('check_session', routes.check_session, error(this, 'check_session.error'), checkFrame);
 
     const endSession = getEndSession(this);
-    get('end_session', routes.end_session, error(this, 'end_session.error'), session, ...endSession.get);
-    post('end_session', routes.end_session, error(this, 'end_session.error'), session, ...endSession.post);
+    get('end_session', routes.end_session, error(this, 'end_session.error'), ...endSession.get);
+    post('end_session', routes.end_session, error(this, 'end_session.error'), ...endSession.post);
+  }
+
+  if (configuration.features.deviceCode) {
+    const deviceAuthorization = getAuthorization(this, 'device_authorization');
+    post('device_authorization', routes.device_authorization, error(this, 'device_authorization.error'), ...deviceAuthorization);
+
+    const codeVerification = getCodeVerification(this);
+    const postCodeVerification = getAuthorization(this, 'code_verification');
+    get('code_verification', routes.code_verification, error(this, 'code_verification.error'), ...codeVerification.get);
+    post('code_verification', routes.code_verification, error(this, 'code_verification.error'), ...codeVerification.post, ...postCodeVerification);
+
+    const deviceResume = getAuthorization(this, 'device_resume');
+    get('device_resume', `${routes.code_verification}/:user_code/:grant/`, error(this, 'device_resume.error'), ...deviceResume);
   }
 
   if (configuration.features.devInteractions) {
@@ -151,7 +195,6 @@ module.exports = function initializeApp() {
   proxyWarning.firstInternal = true;
 
   app.use(proxyWarning);
-  app.use(contextEnsureOidc(this));
   app.use(router.routes());
   app.use(error(this));
   app.use(invalidRoute);

--- a/lib/helpers/jwt.js
+++ b/lib/helpers/jwt.js
@@ -25,12 +25,12 @@ class JWT {
     const timestamp = epochTime();
 
     Object.assign(payload, {
-      aud: options.audience ? options.audience : payload.aud,
-      azp: options.authorizedParty ? options.authorizedParty : payload.azp,
-      exp: options.expiresIn ? timestamp + options.expiresIn : payload.exp,
-      iat: payload.iat ? payload.iat : timestamp,
-      iss: options.issuer ? options.issuer : payload.iss,
-      sub: options.subject ? options.subject : payload.sub,
+      aud: options.audience !== undefined ? options.audience : payload.aud,
+      azp: options.authorizedParty !== undefined ? options.authorizedParty : payload.azp,
+      exp: options.expiresIn !== undefined ? timestamp + options.expiresIn : payload.exp,
+      iat: payload.iat !== undefined ? payload.iat : timestamp,
+      iss: options.issuer !== undefined ? options.issuer : payload.iss,
+      sub: options.subject !== undefined ? options.subject : payload.sub,
     });
 
     if (alg === 'none') {

--- a/lib/helpers/oidc_context.js
+++ b/lib/helpers/oidc_context.js
@@ -17,11 +17,14 @@ module.exports = function getContext(provider) {
   class OIDCContext {
     constructor(ctx) {
       this.ctx = ctx;
+      this.route = ctx._matchedRouteName;
       this.authorization = {};
       this.redirectUriCheckPerformed = false;
       this.webMessageUriCheckPerformed = false;
-      this.uuid = uuid();
+      this.uuid = (ctx.params && ctx.params.grant) || uuid();
       this.entities = {};
+      this.claims = {};
+      this.issuer = provider.issuer;
     }
 
     entity(key, value) {
@@ -41,15 +44,16 @@ module.exports = function getContext(provider) {
     }
 
     promptPending(name) {
-      if (this.ctx._matchedRouteName === 'authorization') { // first pass
-        return this.prompts && this.prompts.includes(name);
+      // result pass
+      if (this.ctx.oidc.route.endsWith('resume')) {
+        if (name === 'none') return true;
+
+        const should = _.difference(this.prompts, Object.keys(this.result || {}));
+        return should.includes(name);
       }
 
-      // result pass
-      if (name === 'none') return true;
-
-      const should = _.difference(this.prompts, Object.keys(this.result || {}));
-      return should.includes(name);
+      // first pass
+      return this.prompts && this.prompts.includes(name);
     }
 
     get acr() {
@@ -60,11 +64,7 @@ module.exports = function getContext(provider) {
       return _.get(this, 'result.login.amr');
     }
 
-    set claims(value) { instance(this).claims = value; }
-
     get prompts() { return this.params.prompt ? this.params.prompt.split(' ') : []; }
-
-    get claims() { return instance(this).claims; }
 
     get bearer() {
       if ('bearer' in instance(this)) {
@@ -116,6 +116,10 @@ module.exports = function getContext(provider) {
 
     get registrationAccessToken() {
       return this.entities.RegistrationAccessToken;
+    }
+
+    get deviceCode() {
+      return this.entities.DeviceCode;
     }
 
     get account() {

--- a/lib/helpers/params.js
+++ b/lib/helpers/params.js
@@ -5,20 +5,13 @@ const { omitBy, isUndefined } = require('lodash');
 module.exports = function getParams(whitelist) {
   assert(whitelist, 'whitelist must be present');
 
-  class Params {
+  return class Params {
     constructor(params) {
       whitelist.forEach((prop) => { this[prop] = params[prop]; });
-      Object.seal(this);
     }
 
     toPlainObject() {
       return omitBy(this, isUndefined);
     }
-  }
-
-  return async function assembleParams(ctx, next) {
-    const params = ctx.method === 'POST' ? ctx.oidc.body : ctx.query;
-    ctx.oidc.params = new Params(params);
-    await next();
   };
 };

--- a/lib/helpers/pkce.js
+++ b/lib/helpers/pkce.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const crypto = require('crypto');
+
+const base64url = require('base64url');
+
+const { InvalidGrant } = require('../helpers/errors');
+const instance = require('../helpers/weak_cache');
+
+module.exports = provider => function checkPKCE(verifier, challenge, method) {
+  const pkce = instance(provider).configuration('features.pkce');
+  if (pkce && (verifier || challenge)) {
+    try {
+      let expected = verifier;
+      assert(expected);
+
+      if (method === 'S256') {
+        expected = base64url(crypto.createHash('sha256').update(expected).digest());
+      }
+
+      assert.equal(challenge, expected);
+    } catch (err) {
+      throw new InvalidGrant('PKCE verification failed');
+    }
+  }
+};

--- a/lib/helpers/re_render_errors.js
+++ b/lib/helpers/re_render_errors.js
@@ -1,0 +1,40 @@
+class ReRenderError extends Error {
+  constructor(message, userCode) {
+    super(message);
+    if (userCode) this.userCode = userCode;
+    this.message = message;
+    this.name = this.constructor.name;
+    this.status = 200;
+    this.statusCode = 200;
+    this.expose = true;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+class NotFoundError extends ReRenderError {
+  constructor(userCode) {
+    super('the code was not found', userCode);
+  }
+}
+class ExpiredError extends ReRenderError {
+  constructor(userCode) {
+    super('the code has expired', userCode);
+  }
+}
+class AlreadyUsedError extends ReRenderError {
+  constructor(userCode) {
+    super('code has already been used', userCode);
+  }
+}
+class NoCodeError extends ReRenderError {
+  constructor() {
+    super('no code submitted');
+  }
+}
+
+module.exports = {
+  ReRenderError,
+  NotFoundError,
+  ExpiredError,
+  AlreadyUsedError,
+  NoCodeError,
+};

--- a/lib/helpers/sector_identifier.js
+++ b/lib/helpers/sector_identifier.js
@@ -4,15 +4,15 @@ const { InvalidClientMetadata } = require('./errors');
 
 module.exports = ({ sectorIdentifierUri, redirectUris, subjectType }) => {
   if (subjectType === 'pairwise' && !sectorIdentifierUri) {
-    const hosts = redirectUris
+    const { 0: host, length } = redirectUris
       .map(uri => new URL(uri).host)
       .filter((value, index, self) => self.indexOf(value) === index);
 
-    if (hosts.length !== 1) {
+    if (length !== 1) {
       throw new InvalidClientMetadata('sector_identifier_uri is required when using multiple hosts in your redirect_uris');
     }
 
-    return hosts[0];
+    return host;
   }
 
   if (sectorIdentifierUri) {

--- a/lib/helpers/user_code_form.js
+++ b/lib/helpers/user_code_form.js
@@ -1,0 +1,17 @@
+const htmlEscape = require('./html_escape');
+
+module.exports = {
+  input(action, csrfToken, code) {
+    return `<form id="op.deviceInputForm" method="post" action="${action}">
+  <input type="hidden" name="xsrf" value="${csrfToken}"/>
+  <input onfocus="this.select(); this.onfocus = undefined;" autofocus required ${code ? `value="${htmlEscape(code)}" ` : ''}type="text" name="user_code" placeholder="Enter code"></input>
+  </form>`;
+  },
+  confirm(action, csrfToken, code) {
+    return `<form id="op.deviceConfirmForm" method="post" action="${action}">
+<input type="hidden" name="xsrf" value="${csrfToken}"/>
+<input type="hidden" name="user_code" value="${htmlEscape(code)}"/>
+<input type="hidden" name="confirm" value="yes"/>
+</form>`;
+  },
+};

--- a/lib/models/access_token.js
+++ b/lib/models/access_token.js
@@ -1,9 +1,11 @@
 const setAudiences = require('./mixins/set_audiences');
 const hasFormat = require('./mixins/has_format');
+const hasGrantType = require('./mixins/has_grant_type');
 const apply = require('./mixins/apply');
 
 module.exports = provider => class AccessToken extends apply([
   setAudiences,
+  hasGrantType,
   hasFormat(provider, 'AccessToken', provider.BaseToken),
 ]) {
   static get IN_PAYLOAD() {

--- a/lib/models/base_token.js
+++ b/lib/models/base_token.js
@@ -53,6 +53,7 @@ module.exports = function getBaseToken(provider) {
       if (this.constructor.format === 'legacy') {
         if (this.constructor.IN_PAYLOAD.includes('grantId') && !upsert.grantId) upsert.grantId = this.grantId;
         if (this.constructor.IN_PAYLOAD.includes('consumed') && !upsert.consumed) upsert.consumed = this.consumed;
+        if (this.constructor.IN_PAYLOAD.includes('userCode') && !upsert.userCode) upsert.userCode = this.userCode;
       }
       await this.adapter.upsert(this.jti, upsert, this.remainingTTL);
       provider.emit('token.issued', this);

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -333,6 +333,7 @@ module.exports = function getClient(provider) {
     /* eslint-disable class-methods-use-this */
     includeSid() {
       return true; // TODO: deprecated
+      // return this.frontchannelLogoutSessionRequired || this.backchannelLogoutSessionRequired;
       // return this.frontchannelLogoutUri || this.backchannelLogoutUri;
     }
     /* eslint-enable class-methods-use-this */

--- a/lib/models/device_code.js
+++ b/lib/models/device_code.js
@@ -4,12 +4,14 @@ const storesAuth = require('./mixins/stores_auth');
 const hasFormat = require('./mixins/has_format');
 const consumable = require('./mixins/consumable');
 const storesPKCE = require('./mixins/stores_pkce');
+const hasGrantType = require('./mixins/has_grant_type');
 const apply = require('./mixins/apply');
 
 module.exports = provider => class DeviceCode extends apply([
   storesPKCE,
   storesAuth,
   consumable(provider),
+  hasGrantType,
   hasFormat(provider, 'DeviceCode', provider.BaseToken),
 ]) {
   static async findByUserCode(userCode, { ignoreExpiration = false } = {}) {

--- a/lib/models/device_code.js
+++ b/lib/models/device_code.js
@@ -1,0 +1,46 @@
+const assert = require('assert');
+
+const storesAuth = require('./mixins/stores_auth');
+const hasFormat = require('./mixins/has_format');
+const consumable = require('./mixins/consumable');
+const storesPKCE = require('./mixins/stores_pkce');
+const apply = require('./mixins/apply');
+
+module.exports = provider => class DeviceCode extends apply([
+  storesPKCE,
+  storesAuth,
+  consumable(provider),
+  hasFormat(provider, 'DeviceCode', provider.BaseToken),
+]) {
+  static async findByUserCode(userCode, { ignoreExpiration = false } = {}) {
+    let rethrow;
+    try {
+      const stored = await this.adapter.findByUserCode(userCode).catch((err) => {
+        rethrow = true;
+        throw err;
+      });
+      assert(stored);
+      assert.equal(userCode, stored.userCode);
+      const payload = await this.verify(undefined, stored, {
+        ignoreExpiration, foundByUserCode: true,
+      });
+      const inst = new this(payload);
+
+      return inst;
+    } catch (err) {
+      if (rethrow) throw err;
+      return undefined;
+    }
+  }
+
+  static get IN_PAYLOAD() {
+    return [
+      ...super.IN_PAYLOAD,
+      'error',
+      'errorDescription',
+      'params',
+      'userCode',
+      'deviceInfo',
+    ];
+  }
+};

--- a/lib/models/formats/jwt.js
+++ b/lib/models/formats/jwt.js
@@ -61,10 +61,13 @@ module.exports = (provider) => {
     getTokenId(token) {
       return getClaim(token, 'jti');
     },
-    async verify(token, stored, { ignoreExpiration }) {
-      assert.equal(token, stored.jwt);
-      const jti = this.getTokenId(token);
-      return opaque.verify.call(this, jti, stored, { ignoreExpiration });
+    async verify(token, stored, { ignoreExpiration, foundByUserCode }) {
+      let jti;
+      if (!foundByUserCode) {
+        assert.equal(token, stored.jwt);
+        jti = this.getTokenId(token);
+      }
+      return opaque.verify.call(this, jti, stored, { ignoreExpiration, foundByUserCode });
     },
   };
 };

--- a/lib/models/formats/legacy.js
+++ b/lib/models/formats/legacy.js
@@ -40,15 +40,17 @@ module.exports = provider => ({
   getTokenId(token) {
     return token.substring(0, 48);
   },
-  async verify(token, stored, { ignoreExpiration } = {}) {
-    assert.equal(token.substring(48), stored.signature);
+  async verify(token, stored, { ignoreExpiration, foundByUserCode } = {}) {
+    if (!foundByUserCode) {
+      assert.equal(token.substring(48), stored.signature);
+    }
     const { payload } = decode([stored.header, stored.payload, stored.signature].join('.'));
     payload.signature = stored.signature;
     assertPayload(payload, {
       ignoreExpiration,
       issuer: provider.issuer,
       clockTolerance: instance(provider).configuration('clockTolerance'),
-      jti: this.getTokenId(token),
+      ...(foundByUserCode ? undefined : { jti: this.getTokenId(token) }),
     });
     return payload;
   },

--- a/lib/models/formats/opaque.js
+++ b/lib/models/formats/opaque.js
@@ -24,8 +24,10 @@ module.exports = provider => ({
   // >= 160 bits
   //   RefreshToken
   //   AuthorizationCode
+  //   DeviceCode
   generateTokenId() {
     switch (this.name) {
+      case 'DeviceCode':
       case 'RefreshToken':
       case 'AuthorizationCode':
         return nanoid(27);
@@ -51,12 +53,12 @@ module.exports = provider => ({
   getTokenId(token) {
     return token;
   },
-  async verify(token, stored, { ignoreExpiration }) {
+  async verify(token, stored, { ignoreExpiration, foundByUserCode }) {
     assertPayload(stored, {
       ignoreExpiration,
       issuer: provider.issuer,
       clockTolerance: instance(provider).configuration('clockTolerance'),
-      jti: token,
+      ...(foundByUserCode ? undefined : { jti: token }),
     });
 
     return stored;

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -8,6 +8,7 @@ const getClientCredentials = require('./client_credentials');
 const getRefreshToken = require('./refresh_token');
 const getRegistrationAccessToken = require('./registration_access_token');
 const getInitialAccessToken = require('./initial_access_token');
+const getDeviceCode = require('./device_code');
 
 module.exports = {
   getAccessToken,
@@ -20,4 +21,5 @@ module.exports = {
   getRefreshToken,
   getRegistrationAccessToken,
   getSession,
+  getDeviceCode,
 };

--- a/lib/models/mixins/has_grant_type.js
+++ b/lib/models/mixins/has_grant_type.js
@@ -1,0 +1,8 @@
+module.exports = superclass => class extends superclass {
+  static get IN_PAYLOAD() {
+    return [
+      ...super.IN_PAYLOAD,
+      'gty',
+    ];
+  }
+};

--- a/lib/models/refresh_token.js
+++ b/lib/models/refresh_token.js
@@ -1,10 +1,12 @@
 const storesAuth = require('./mixins/stores_auth');
 const hasFormat = require('./mixins/has_format');
 const consumable = require('./mixins/consumable');
+const hasGrantType = require('./mixins/has_grant_type');
 const apply = require('./mixins/apply');
 
 module.exports = provider => class RefreshToken extends apply([
   consumable(provider),
   storesAuth,
+  hasGrantType,
   hasFormat(provider, 'RefreshToken', provider.BaseToken),
 ]) {};

--- a/lib/models/session.js
+++ b/lib/models/session.js
@@ -50,15 +50,16 @@ module.exports = function getSession(provider) {
       return false;
     }
 
-    save(ttl = instance(provider).configuration('cookies.long.maxAge') / 1000) {
+    async save(ttl = instance(provider).configuration('cookies.long.maxAge') / 1000) {
       const payload = { ...this, ...(ttl ? { exp: epochTime() + ttl } : {}) };
       delete payload.id;
-
-      return getAdapter().upsert(this.id, payload, ttl);
+      await getAdapter().upsert(this.id, payload, ttl);
+      this.touched = false; // TODO:
     }
 
-    destroy() {
-      return getAdapter().destroy(this.id);
+    async destroy() {
+      await getAdapter().destroy(this.id);
+      this.destroyed = true; // TODO:
     }
 
     sidFor(clientId, value) {

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -128,6 +128,7 @@ class Provider extends events.EventEmitter {
     instance(this).ClientCredentials = models.getClientCredentials(this);
     instance(this).InitialAccessToken = models.getInitialAccessToken(this);
     instance(this).RegistrationAccessToken = models.getRegistrationAccessToken(this);
+    instance(this).DeviceCode = models.getDeviceCode(this);
     instance(this).OIDCContext = getContext(this);
     const { pathname } = url.parse(this.issuer);
     instance(this).mountPath = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
@@ -292,6 +293,8 @@ class Provider extends events.EventEmitter {
   get InitialAccessToken() { return instance(this).InitialAccessToken; }
 
   get RegistrationAccessToken() { return instance(this).RegistrationAccessToken; }
+
+  get DeviceCode() { return instance(this).DeviceCode; }
 
   get initialized() { return !!instance(this).initialized; }
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -26,7 +26,7 @@ const { SessionNotFound } = require('./helpers/errors');
 const models = require('./models');
 
 function checkInit(provider) {
-  assert(provider.initialized, 'provider must be initialized first, see provider#initialize');
+  assert(instance(provider).initialized, 'provider must be initialized first, see provider#initialize');
 }
 
 function getCookie(name, opts, cookies) {
@@ -135,7 +135,7 @@ class Provider extends events.EventEmitter {
   }
 
   initialize({ adapter, clients = [], keystore } = {}) {
-    if (this.initialized) throw new Error('already initialized');
+    if (instance(this).initialized) throw new Error('already initialized');
     if (instance(this).initializing) {
       throw new Error('already initializing');
     } else {
@@ -242,7 +242,7 @@ class Provider extends events.EventEmitter {
 
   use(fn) {
     instance(this).app.use(fn);
-    if (this.initialized) {
+    if (instance(this).initialized) {
       // note: get the fn back since it might've been changed from generator to fn by koa-convert
       const newMw = instance(this).app.middleware.pop();
       const internalIndex = this.app.middleware.findIndex(mw => !!mw.firstInternal);
@@ -295,8 +295,6 @@ class Provider extends events.EventEmitter {
   get RegistrationAccessToken() { return instance(this).RegistrationAccessToken; }
 
   get DeviceCode() { return instance(this).DeviceCode; }
-
-  get initialized() { return !!instance(this).initialized; }
 
   static useGot() { // eslint-disable-line class-methods-use-this
     httpWrapper.useGot();

--- a/lib/shared/assemble_params.js
+++ b/lib/shared/assemble_params.js
@@ -1,0 +1,11 @@
+const getParams = require('../helpers/params');
+
+module.exports = function getAssembleParams(whitelist) {
+  const Params = getParams(whitelist);
+
+  return async function assembleParams(ctx, next) {
+    const params = ctx.method === 'POST' ? ctx.oidc.body : ctx.query;
+    ctx.oidc.params = new Params(params);
+    await next();
+  };
+};

--- a/lib/shared/authorization_error_handler.js
+++ b/lib/shared/authorization_error_handler.js
@@ -2,6 +2,7 @@ const Debug = require('debug');
 
 const { RedirectUriMismatch, WebMessageUriMismatch } = require('../helpers/errors');
 const instance = require('../helpers/weak_cache');
+const errOut = require('../helpers/err_out');
 
 const debug = new Debug('oidc-provider:authentication:error');
 const serverError = new Debug('oidc-provider:server_error');
@@ -24,11 +25,7 @@ module.exports = (provider) => {
   });
 
   function getOutAndEmit(ctx, err, state) {
-    const out = err.expose
-      ? { error: err.message, error_description: err.error_description }
-      : { error: 'server_error', error_description: 'oops something went wrong' };
-
-    if (state !== undefined) out.state = state;
+    const out = errOut(err, state);
 
     if (err.expose) {
       provider.emit('authorization.error', err, ctx);

--- a/lib/shared/error_handler.js
+++ b/lib/shared/error_handler.js
@@ -1,40 +1,43 @@
+const crypto = require('crypto');
+
 const Debug = require('debug');
 
 const instance = require('../helpers/weak_cache');
+const formHtml = require('../helpers/user_code_form');
+const { ReRenderError } = require('../helpers/re_render_errors');
+const errOut = require('../helpers/err_out');
 
 const debug = new Debug('oidc-provider:error');
 const serverError = new Debug('oidc-provider:server_error');
 const serverErrorTrace = new Debug('oidc-provider:server_error:trace');
 
+const userInputRoutes = new Set(['code_verification', 'device_resume']);
+
 module.exports = function getErrorHandler(provider, eventName) {
-  return async function apiErrorHandler(ctx, next) {
+  return async function errorHandler(ctx, next) {
+    const { userCodeInputSource } = instance(provider).configuration();
     try {
       await next();
     } catch (err) {
-      const out = {};
+      const out = errOut(err);
       ctx.status = err.statusCode || 500;
 
-      if (err.expose) {
-        Object.assign(
-          out,
-          { error: err.message, error_description: err.error_description },
-        );
-
-        if (err.scope) out.scope = err.scope;
-
-        debug('uuid=%s path=%s method=%s error=%o detail=%s', ctx.oidc.uuid, ctx.path, ctx.method, out, err.error_detail);
-      } else {
-        serverError('uuid=%s path=%s method=%s error=%o', ctx.oidc.uuid, ctx.path, ctx.method, err);
+      if (err.expose && !(err instanceof ReRenderError)) {
+        debug('uuid=%s path=%s method=%s error=%o detail=%s', ctx.oidc && ctx.oidc.uuid, ctx.path, ctx.method, out, err.error_detail);
+      } else if (!(err instanceof ReRenderError)) {
+        serverError('uuid=%s path=%s method=%s error=%o', ctx.oidc && ctx.oidc.uuid, ctx.path, ctx.method, err);
         serverErrorTrace(err);
-        Object.assign(
-          out,
-          { error: 'server_error', error_description: 'oops something went wrong' },
-        );
       }
 
-      // this makes */* requests respond with json (curl, xhr, request libraries), while in
-      // browser requests end up rendering the html error instead
-      if (ctx.accepts('json', 'html') === 'html') {
+      if (ctx.oidc && ctx.oidc.session && userInputRoutes.has(ctx.oidc.route)) {
+        // TODO: generic xsrf middleware to remove this
+        const secret = crypto.randomBytes(24).toString('hex');
+        ctx.oidc.session.device = { secret };
+        await userCodeInputSource(ctx, formHtml.input(provider.pathFor('code_verification'), secret, err.userCode), out, err);
+        if (err instanceof ReRenderError) return; // render without emit
+      } else if (ctx.accepts('json', 'html') === 'html') {
+        // this ^^ makes */* requests respond with json (curl, xhr, request libraries), while in
+        // browser requests end up rendering the html error instead
         const renderError = instance(provider).configuration('renderError');
         await renderError(ctx, out, err);
       } else {

--- a/lib/shared/selective_body.js
+++ b/lib/shared/selective_body.js
@@ -52,7 +52,7 @@ is not recommended, resolving to use req.body or request.body instead');
 
       await next();
     } else {
-      throw new InvalidRequest(`only ${only} content-type ${ctx.method} bodies are supported`);
+      throw new InvalidRequest(`only ${only} content-type bodies are supported on ${ctx.method} ${ctx.path}`);
     }
   };
 };

--- a/lib/shared/session.js
+++ b/lib/shared/session.js
@@ -1,21 +1,38 @@
 module.exports = function getSessionHandler(provider) {
   return async function sessionHandler(ctx, next) {
-    ctx.oidc.session = await provider.Session.get(ctx);
-
-    await next();
-
-    if (ctx.oidc.session.transient) {
-      const sessionCookieName = provider.cookieName('session');
-      const stateCookieName = provider.cookieName('state');
-
-      ctx.response.get('set-cookie').forEach((cookie, index, ary) => {
-        const isLong = cookie.startsWith(sessionCookieName) || cookie.startsWith(stateCookieName);
-        if (isLong && !cookie.includes('expires=Thu, 01 Jan 1970')) {
-          ary[index] = cookie.replace(/(; ?expires=([\w\d:, ]+))/, ''); // eslint-disable-line no-param-reassign
+    ctx.oidc.session = new Proxy(await provider.Session.get(ctx), {
+      set(obj, prop, value) {
+        if (prop === 'touched') {
+          Reflect.defineProperty(obj, 'touched', { writable: true, value });
+        } else if (prop === 'destroyed') {
+          Reflect.defineProperty(obj, 'destroyed', { writable: true, value });
+          Reflect.defineProperty(obj, 'touched', { writable: true, value: false });
+        } else {
+          Reflect.set(obj, prop, value);
+          Reflect.defineProperty(obj, 'touched', { writable: true, value: true });
         }
-      });
-    }
+        return true;
+      },
+    });
 
-    if (!ctx.oidc.session.destroyed) await ctx.oidc.session.save();
+    try {
+      await next();
+    } catch (err) {
+      throw err;
+    } finally {
+      if (ctx.oidc.session.transient) {
+        const sessionCookieName = provider.cookieName('session');
+        const stateCookieName = provider.cookieName('state');
+
+        ctx.response.get('set-cookie').forEach((cookie, index, ary) => {
+          const isLong = cookie.startsWith(sessionCookieName) || cookie.startsWith(stateCookieName);
+          if (isLong && !cookie.includes('expires=Thu, 01 Jan 1970')) {
+            ary[index] = cookie.replace(/(; ?expires=([\w\d:, ]+))/, ''); // eslint-disable-line no-param-reassign
+          }
+        });
+      }
+
+      if (!ctx.oidc.session.destroyed) await ctx.oidc.session.save();
+    }
   };
 };

--- a/lib/views/layout.js
+++ b/lib/views/layout.js
@@ -3,7 +3,7 @@ module.exports = `<!DOCTYPE html>
   <head>
     <meta charset="UTF-8">
     <title><%= title %></title>
-    <style type="text/css">
+    <style>
       @import url(https://fonts.googleapis.com/css?family=Roboto:400,100);
 
       body {
@@ -51,14 +51,6 @@ module.exports = `<!DOCTYPE html>
         -moz-box-sizing: border-box;
       }
 
-      .login-card input[type=text]:hover, input[type=email]:hover, input[type=password]:hover {
-        border: 1px solid #b9b9b9;
-        border-top: 1px solid #a0a0a0;
-        -moz-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
-        -webkit-box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
-        box-shadow: inset 0 1px 2px rgba(0,0,0,0.1);
-      }
-
       .login {
         text-align: center;
         font-size: 14px;
@@ -88,7 +80,6 @@ module.exports = `<!DOCTYPE html>
         text-align: center;
         display: inline-block;
         opacity: 0.6;
-        transition: opacity ease 0.5s;
       }
 
       .login-card a:hover {

--- a/test/base_token/base_token.test.js
+++ b/test/base_token/base_token.test.js
@@ -117,11 +117,23 @@ describe('BaseToken', () => {
     expect(token.consumed).to.be.true;
   });
 
-  it('rethrows adapter#find errors', async function () {
+  it('rethrows adapter#find errors (any token)', async function () {
     this.adapter.find.restore();
     const adapterThrow = new Error('adapter throw!');
     sinon.stub(this.adapter, 'find').callsFake(async () => { throw adapterThrow; });
     await this.provider.AccessToken.find('.eyJqdGkiOiJ6d1FXa2pBUzhQZks1WEUyTTEyTTcifQ.').then(fail, (err) => {
+      expect(err).to.equal(adapterThrow);
+    });
+  });
+
+  it('rethrows adapter#findByUserCode errors (Device Code)', async function () {
+    const adapterThrow = new Error('adapter throw!');
+    sinon.stub(this.TestAdapter.for('DeviceCode'), 'findByUserCode').callsFake(async () => { throw adapterThrow; });
+    await this.provider.DeviceCode.findByUserCode('123-456-789').then(() => {
+      this.TestAdapter.for('DeviceCode').findByUserCode.restore();
+      fail();
+    }, (err) => {
+      this.TestAdapter.for('DeviceCode').findByUserCode.restore();
       expect(err).to.equal(adapterThrow);
     });
   });

--- a/test/claims/claims.test.js
+++ b/test/claims/claims.test.js
@@ -242,6 +242,7 @@ expire.setDate(expire.getDate() + 1);
           it('none of multiple authentication context class references requested are met', function () {
             const auth = new this.AuthorizationRequest({
               response_type: 'id_token',
+              response_mode: 'fragment',
               scope: 'openid',
               prompt: 'none',
               claims: j({
@@ -272,6 +273,7 @@ expire.setDate(expire.getDate() + 1);
           it('single requested authentication context class reference is not met', function () {
             const auth = new this.AuthorizationRequest({
               response_type: 'id_token',
+              response_mode: 'fragment',
               scope: 'openid',
               prompt: 'none',
               claims: j({

--- a/test/configuration/adapter_test.test.js
+++ b/test/configuration/adapter_test.test.js
@@ -11,7 +11,7 @@ const client = {
 
 describe('AdapterTest', () => {
   it('passes with the default MemoryAdapter', async () => {
-    const provider = new Provider('http://localhost');
+    const provider = new Provider('http://localhost', { features: { deviceCode: true } });
     await provider.initialize({
       clients: [client],
     });
@@ -20,7 +20,7 @@ describe('AdapterTest', () => {
   });
 
   it('passes with the TestAdapter', async () => {
-    const provider = new Provider('http://localhost');
+    const provider = new Provider('http://localhost', { features: { deviceCode: true } });
     await provider.initialize({
       clients: [client],
       adapter: TestAdapter,

--- a/test/core/basic/code.authorization.test.js
+++ b/test/core/basic/code.authorization.test.js
@@ -375,7 +375,7 @@ describe('BASIC code', () => {
           .expect(auth.validateState)
           .expect(auth.validateClientLocation)
           .expect(auth.validateError('invalid_request'))
-          .expect(auth.validateErrorDescription('invalid prompt value(s) provided. (unsupported)'));
+          .expect(auth.validateErrorDescription('invalid prompt value provided'));
       });
 
       it('bad prompt combination', function () {
@@ -438,7 +438,7 @@ describe('BASIC code', () => {
             expect(renderSpy.calledOnce).to.be.true;
             const renderArgs = renderSpy.args[0];
             expect(renderArgs[1]).to.have.property('error', 'invalid_request');
-            expect(renderArgs[1]).to.have.property('error_description', 'missing required parameter client_id');
+            expect(renderArgs[1]).to.have.property('error_description', 'missing required parameter(s) (client_id)');
             expect(renderArgs[2]).to.be.an.instanceof(InvalidRequest);
           });
       });
@@ -568,7 +568,7 @@ describe('BASIC code', () => {
           return this.wrap({ route, verb, auth })
             .type('json')
             .expect(400)
-            .expect(/only application\/x-www-form-urlencoded content-type POST bodies are supported/)
+            .expect(/only application\/x-www-form-urlencoded content-type bodies are supported on POST \/auth/)
             .expect(/invalid_request/)
             .expect(() => {
               expect(spy.calledOnce).to.be.true;

--- a/test/core/hybrid/code+id_token+token.authorization.test.js
+++ b/test/core/hybrid/code+id_token+token.authorization.test.js
@@ -14,18 +14,20 @@ describe('HYBRID code+id_token+token', () => {
     describe(`${verb} ${route} with session`, () => {
       before(function () { return this.login(); });
 
-      it('responds with a access_token and code in fragment', function () {
+      it('responds with a id_token, access_token and code in fragment', async function () {
         const auth = new this.AuthorizationRequest({
           response_type,
           scope,
         });
 
-        return this.wrap({ route, verb, auth })
+        await this.wrap({ route, verb, auth })
           .expect(302)
           .expect(auth.validateFragment)
           .expect(auth.validatePresence(['code', 'id_token', 'state', 'access_token', 'expires_in', 'token_type']))
           .expect(auth.validateState)
           .expect(auth.validateClientLocation);
+
+        expect(await this.provider.AccessToken.find(auth.res.access_token)).to.have.property('gty', 'implicit');
       });
 
       it('populates ctx.oidc.entities', function (done) {

--- a/test/core/implicit/id_token+token.authorization.test.js
+++ b/test/core/implicit/id_token+token.authorization.test.js
@@ -16,18 +16,20 @@ describe('IMPLICIT id_token+token', () => {
     describe(`${verb} ${route} with session`, () => {
       before(function () { return this.login(); });
 
-      it('responds with a id_token in fragment', function () {
+      it('responds with a id_token and access_token in fragment', async function () {
         const auth = new this.AuthorizationRequest({
           response_type,
           scope,
         });
 
-        return this.wrap({ route, verb, auth })
+        await this.wrap({ route, verb, auth })
           .expect(302)
           .expect(auth.validateFragment)
           .expect(auth.validatePresence(['id_token', 'state', 'access_token', 'expires_in', 'token_type']))
           .expect(auth.validateState)
           .expect(auth.validateClientLocation);
+
+        expect(await this.provider.AccessToken.find(auth.res.access_token)).to.have.property('gty', 'implicit');
       });
 
       it('populates ctx.oidc.entities', function (done) {

--- a/test/device_code/code_verification_endpoint.test.js
+++ b/test/device_code/code_verification_endpoint.test.js
@@ -1,0 +1,335 @@
+const sinon = require('sinon');
+const { expect } = require('chai');
+const timekeeper = require('timekeeper');
+
+const bootstrap = require('../test_helper');
+
+const { any } = sinon.match;
+const route = '/device';
+
+describe('GET code_verification endpoint', () => {
+  before(bootstrap(__dirname)); // agent
+
+  describe('when accessed without user_code in query (verification_uri)', () => {
+    it('renders 200 OK end-user form with csrf', function () {
+      return this.agent.get(route)
+        .expect(200)
+        .expect('content-type', 'text/html; charset=utf-8')
+        .expect(() => {
+          const { device: { secret } } = this.getSession();
+          expect(secret).to.be.a('string');
+        })
+        .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/);
+    });
+  });
+
+  describe('when accessed with user_code in query (verification_uri_complete)', () => {
+    it('renders 200 OK self-submitting form with csrf and the value from uri', function () {
+      let secret;
+
+      return this.agent.get(route)
+        .query({ user_code: '123-456-789' })
+        .expect(200)
+        .expect('content-type', 'text/html; charset=utf-8')
+        .expect(/<body onload="javascript:document\.forms\[0]\.submit\(\)"/)
+        .expect(({ text }) => {
+          ({ device: { secret } } = this.getSession());
+          expect(text).to.match(new RegExp(`input type="hidden" name="xsrf" value="${secret}"`));
+        })
+        .expect(/<form method="post" action="\/device">/)
+        .expect(/<input type="hidden" name="user_code" value="123-456-789"\/>/);
+    });
+
+    it('escapes the user_code values', function () {
+      return this.agent.get(route)
+        .query({ user_code: '&<>"\'123-456-789' })
+        .expect(200)
+        .expect('content-type', 'text/html; charset=utf-8')
+        .expect(/<input type="hidden" name="user_code" value="&amp;&lt;&gt;&quot;&#39;123-456-789"\/>/);
+    });
+  });
+});
+
+describe('POST code_verification endpoint w/o verification', () => {
+  before(bootstrap(__dirname)); // agent
+  before(function () { return this.login(); });
+  afterEach(() => timekeeper.reset());
+
+  const xsrf = 'foo';
+
+  beforeEach(function () {
+    this.getSession().device = { secret: xsrf };
+  });
+  afterEach(function () {
+    this.provider.removeAllListeners('code_verification.error');
+    try {
+      i(this.provider).configuration().userCodeInputSource.restore();
+    } catch (err) {}
+    try {
+      i(this.provider).configuration().userCodeConfirmSource.restore();
+    } catch (err) {}
+    try {
+      this.provider.Client.find.restore();
+    } catch (err) {}
+  });
+
+  it('renders a confirmation page', async function () {
+    const spy = sinon.spy(i(this.provider).configuration(), 'userCodeConfirmSource');
+    const deviceInfo = {
+      ip: '127.0.0.1',
+      userAgent: 'foo',
+    };
+
+    await new this.provider.DeviceCode({
+      clientId: 'client',
+      userCode: 'foo-code',
+      deviceInfo,
+    }).save();
+
+    await this.agent.post(route)
+      .send({
+        xsrf,
+        user_code: 'foo-code',
+      })
+      .type('form')
+      .expect(200)
+      .expect(/<form id="op\.deviceConfirmForm" method="post" action="\/device">/);
+
+    expect(spy.calledOnce).to.be.true;
+    sinon.assert.calledWithMatch(spy, any, any, sinon.match((client) => {
+      expect(client.clientId).to.equal('client');
+      return true;
+    }), deviceInfo);
+  });
+
+  it('re-renders on no submitted code', async function () {
+    const errSpy = sinon.spy();
+    this.provider.once('code_verification.error', errSpy);
+    const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+
+    await this.agent.post(route)
+      .send({ xsrf })
+      .type('form')
+      .expect(200)
+      .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+      .expect(/<p class="red">The code you entered is incorrect\. Try again<\/p>/);
+
+    expect(spy.calledOnce).to.be.true;
+    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+      expect(err.name).to.equal('NoCodeError');
+      return true;
+    }));
+
+    expect(errSpy).to.have.property('called', false);
+  });
+
+  it('re-renders on not found code', async function () {
+    const errSpy = sinon.spy();
+    this.provider.once('code_verification.error', errSpy);
+    const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+
+    await this.agent.post(route)
+      .send({
+        xsrf,
+        user_code: 'foo-not-found',
+      })
+      .type('form')
+      .expect(200)
+      .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+      .expect(/<p class="red">The code you entered is incorrect\. Try again<\/p>/);
+
+    expect(spy.calledOnce).to.be.true;
+    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+      expect(err.name).to.equal('NotFoundError');
+      return true;
+    }));
+
+    expect(errSpy).to.have.property('called', false);
+  });
+
+  it('re-renders on found but expired code', async function () {
+    const errSpy = sinon.spy();
+    this.provider.once('code_verification.error', errSpy);
+    const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+    await new this.provider.DeviceCode({
+      userCode: 'foo-expired',
+    }).save();
+
+    timekeeper.travel(Date.now() + (((10 * 60) + 10) * 1000));
+    await this.agent.post(route)
+      .send({
+        xsrf,
+        user_code: 'foo-expired',
+      })
+      .type('form')
+      .expect(200)
+      .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+      .expect(/<p class="red">The code you entered is incorrect\. Try again<\/p>/);
+
+    expect(spy.calledOnce).to.be.true;
+    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+      expect(err.name).to.equal('ExpiredError');
+      return true;
+    }));
+
+    expect(errSpy).to.have.property('called', false);
+  });
+
+  it('re-renders on found but already user code', async function () {
+    const errSpy = sinon.spy();
+    this.provider.once('code_verification.error', errSpy);
+    const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+    await new this.provider.DeviceCode({
+      userCode: 'foo-consumed',
+      accountId: 'account',
+    }).save();
+
+    await this.agent.post(route)
+      .send({
+        xsrf,
+        user_code: 'foo-consumed',
+      })
+      .type('form')
+      .expect(200)
+      .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+      .expect(/<p class="red">The code you entered is incorrect\. Try again<\/p>/);
+
+    expect(spy.calledOnce).to.be.true;
+    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+      expect(err.name).to.equal('AlreadyUsedError');
+      return true;
+    }));
+
+    expect(errSpy).to.have.property('called', false);
+  });
+
+  it('re-renders on invalid client', async function () {
+    const errSpy = sinon.spy();
+    this.provider.once('code_verification.error', errSpy);
+    const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+    await new this.provider.DeviceCode({
+      userCode: 'foo-not-found-client',
+      clientId: 'client',
+    }).save();
+
+    sinon.stub(this.provider.Client, 'find').callsFake(async () => { });
+    await this.agent.post(route)
+      .send({
+        xsrf,
+        user_code: 'foo-not-found-client',
+      })
+      .type('form')
+      .expect(400)
+      .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+      .expect(/<p class="red">There was an error processing your request<\/p>/);
+
+    expect(spy.calledOnce).to.be.true;
+    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+      expect(err.name).to.equal('InvalidClient');
+      return true;
+    }));
+
+    expect(errSpy.calledOnce).to.be.true;
+  });
+
+  it('re-renders on !ctx.oidc.session.device', async function () {
+    const errSpy = sinon.spy();
+    this.provider.once('code_verification.error', errSpy);
+    const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+    await new this.provider.DeviceCode({
+      userCode: 'foo-csrf-1',
+    }).save();
+
+    delete this.getSession().device;
+    await this.agent.post(route)
+      .send({
+        xsrf,
+        user_code: 'foo-csrf-1',
+      })
+      .type('form')
+      .expect(400)
+      .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+      .expect(/<p class="red">There was an error processing your request<\/p>/);
+
+    expect(spy.calledOnce).to.be.true;
+    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+      expect(err.name).to.equal('InvalidRequest');
+      expect(err.error_description).to.equal('could not find device form details');
+      return true;
+    }));
+
+    expect(errSpy.calledOnce).to.be.true;
+  });
+
+  it('re-renders on invalid csrf', async function () {
+    const errSpy = sinon.spy();
+    this.provider.once('code_verification.error', errSpy);
+    const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+    await new this.provider.DeviceCode({
+      userCode: 'foo-csrf-2',
+    }).save();
+
+    await this.agent.post(route)
+      .send({
+        xsrf: 'invalid-csrf',
+        user_code: 'foo-csrf-foo',
+      })
+      .type('form')
+      .expect(400)
+      .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+      .expect(/<p class="red">There was an error processing your request<\/p>/);
+
+    expect(spy.calledOnce).to.be.true;
+    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+      expect(err.name).to.equal('InvalidRequest');
+      expect(err.error_description).to.equal('xsrf token invalid');
+      return true;
+    }));
+
+    expect(errSpy.calledOnce).to.be.true;
+  });
+});
+
+describe('POST code_verification endpoint w/ verification', () => {
+  before(bootstrap(__dirname)); // agent
+  before(function () { return this.login(); });
+  afterEach(() => timekeeper.reset());
+
+  const xsrf = 'foo';
+
+  beforeEach(function () {
+    this.getSession().device = { secret: xsrf };
+  });
+
+  it('renders a confirmation and assigns ', async function () {
+    const spy = sinon.spy(i(this.provider).configuration(), 'deviceCodeSuccess');
+
+    let code = await new this.provider.DeviceCode({
+      clientId: 'client',
+      userCode: 'foo',
+      params: {
+        client_id: 'client',
+        claims: JSON.stringify({ userinfo: { email: null } }),
+      },
+    }).save();
+
+    await this.agent.post(route)
+      .send({
+        xsrf,
+        confirm: 'yes',
+        user_code: 'foo',
+      })
+      .type('form')
+      .expect(200);
+
+    code = await this.provider.DeviceCode.find(code);
+
+    const session = this.getSession();
+
+    expect(code).to.have.property('accountId', session.account);
+    expect(code).to.have.property('authTime', session.loginTs);
+    expect(code).to.have.property('claims').that.eqls({ userinfo: { email: null } });
+
+    expect(spy.calledOnce).to.be.true;
+  });
+});

--- a/test/device_code/device_authorization_endpoint.test.js
+++ b/test/device_code/device_authorization_endpoint.test.js
@@ -1,0 +1,357 @@
+const sinon = require('sinon');
+const { expect } = require('chai');
+
+const bootstrap = require('../test_helper');
+
+const route = '/device/auth';
+
+describe('device_authorization_endpoint', () => {
+  before(bootstrap(__dirname)); // agent
+
+  it('rejects other than application/x-www-form-urlencoded', function () {
+    const spy = sinon.spy();
+    this.provider.once('device_authorization.error', spy);
+
+    return this.agent.post(route)
+      .send({
+        client_id: 'client',
+        scope: 'openid',
+      })
+      .expect(400)
+      .expect('content-type', /application\/json/)
+      .expect(() => {
+        expect(spy.calledOnce).to.be.true;
+      })
+      .expect({
+        error: 'invalid_request',
+        error_description: 'only application/x-www-form-urlencoded content-type bodies are supported on POST /device/auth',
+      });
+  });
+
+  describe('client validation', () => {
+    it('only responds to clients with urn:ietf:params:oauth:grant-type:device_code enabled', function () {
+      const spy = sinon.spy();
+      this.provider.once('device_authorization.error', spy);
+
+      return this.agent.post(route)
+        .send({
+          client_id: 'client-not-allowed',
+        })
+        .type('form')
+        .expect(400)
+        .expect('content-type', /application\/json/)
+        .expect({
+          error: 'unauthorized_client',
+          error_description: 'device flow not allowed for this client',
+        })
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+        });
+    });
+
+    it('rejects invalid clients', function () {
+      const spy = sinon.spy();
+      this.provider.once('device_authorization.error', spy);
+
+      return this.agent.post(route)
+        .send({
+          client_id: 'not-found-client',
+        })
+        .type('form')
+        .expect(400)
+        .expect('content-type', /application\/json/)
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+        })
+        .expect({
+          error: 'invalid_client',
+          error_description: 'client is invalid',
+        });
+    });
+  });
+
+  describe('param validation', () => {
+    ['request', 'request_uri', 'registration'].forEach((param) => {
+      it(`check for not supported parameter ${param}`, function () {
+        const spy = sinon.spy();
+        this.provider.once('device_authorization.error', spy);
+
+        return this.agent.post(route)
+          .send({
+            client_id: 'client',
+            scope: 'openid',
+            [param]: 'some',
+          })
+          .type('form')
+          .expect(400)
+          .expect('content-type', /application\/json/)
+          .expect(() => {
+            expect(spy.calledOnce).to.be.true;
+          })
+          .expect({
+            error: `${param}_not_supported`,
+            error_description: `${param} parameter provided but not supported`,
+          });
+      });
+    });
+
+    it('checks prompt values', function () {
+      const spy = sinon.spy();
+      this.provider.once('device_authorization.error', spy);
+
+      return this.agent.post(route)
+        .send({
+          client_id: 'client',
+          scope: 'openid',
+          prompt: 'unsupported',
+        })
+        .type('form')
+        .expect(400)
+        .expect('content-type', /application\/json/)
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+        })
+        .expect({
+          error: 'invalid_request',
+          error_description: 'invalid prompt value provided',
+        });
+    });
+
+    it('checks for bad prompt combination', function () {
+      const spy = sinon.spy();
+      this.provider.once('device_authorization.error', spy);
+
+      return this.agent.post(route)
+        .send({
+          client_id: 'client',
+          scope: 'openid',
+          prompt: 'none login',
+        })
+        .type('form')
+        .expect(400)
+        .expect('content-type', /application\/json/)
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+        })
+        .expect({
+          error: 'invalid_request',
+          error_description: 'prompt none must only be used alone',
+        });
+    });
+
+    it('unsupported prompt', function () {
+      const spy = sinon.spy();
+      this.provider.once('device_authorization.error', spy);
+
+      return this.agent.post(route)
+        .send('scope=openid&scope=openid&client_id=client')
+        .type('form')
+        .expect(400)
+        .expect('content-type', /application\/json/)
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+        })
+        .expect({
+          error: 'invalid_request',
+          error_description: 'parameters must not be provided twice. (scope)',
+        });
+    });
+
+    it('makes sure scope is provided', function () {
+      const spy = sinon.spy();
+      this.provider.once('device_authorization.error', spy);
+
+      return this.agent.post(route)
+        .send({
+          client_id: 'client',
+        })
+        .type('form')
+        .expect(400)
+        .expect('content-type', /application\/json/)
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+        })
+        .expect({
+          error: 'invalid_request',
+          error_description: 'missing required parameter(s) (scope)',
+        });
+    });
+
+    it('makes sure openid is provided as a scope', function () {
+      const spy = sinon.spy();
+      this.provider.once('device_authorization.error', spy);
+
+      return this.agent.post(route)
+        .send({
+          client_id: 'client',
+          scope: 'profile',
+        })
+        .type('form')
+        .expect(400)
+        .expect('content-type', /application\/json/)
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+        })
+        .expect({
+          error: 'invalid_request',
+          error_description: 'openid is required scope',
+        });
+    });
+  });
+
+  describe('pkce', () => {
+    it('checks for PKCE methods', function () {
+      const spy = sinon.spy();
+      this.provider.once('device_authorization.error', spy);
+
+      return this.agent.post(route)
+        .send({
+          client_id: 'client',
+          scope: 'openid',
+          code_challenge: 'foobar',
+          code_challenge_method: 'bar',
+        })
+        .type('form')
+        .expect(400)
+        .expect('content-type', /application\/json/)
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+        })
+        .expect({
+          error: 'invalid_request',
+          error_description: 'not supported value of code_challenge_method',
+        });
+    });
+
+    it('checks that codeChallenge is provided if codeChallengeMethod was', function () {
+      const spy = sinon.spy();
+      this.provider.once('device_authorization.error', spy);
+
+      return this.agent.post(route)
+        .send({
+          client_id: 'client',
+          scope: 'openid',
+          code_challenge_method: 'S256',
+        })
+        .type('form')
+        .expect(400)
+        .expect('content-type', /application\/json/)
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+        })
+        .expect({
+          error: 'invalid_request',
+          error_description: 'code_challenge must be provided with code_challenge_method',
+        });
+    });
+
+    describe('forcedForNative flag', () => {
+      afterEach(function () {
+        i(this.provider).configuration('features.pkce').forcedForNative = false;
+      });
+
+      it('forces native clients using code flow to use pkce', function () {
+        const spy = sinon.spy();
+        this.provider.once('device_authorization.error', spy);
+
+        return this.agent.post(route)
+          .send({
+            client_id: 'client',
+            scope: 'openid',
+          })
+          .type('form')
+          .expect(400)
+          .expect('content-type', /application\/json/)
+          .expect(() => {
+            expect(spy.calledOnce).to.be.true;
+          })
+          .expect({
+            error: 'invalid_request',
+            error_description: 'PKCE must be provided for native clients',
+          });
+      });
+
+      it('when false pkce is optional', function () {
+        i(this.provider).configuration('features.pkce').forcedForNative = false;
+
+        return this.agent.post(route)
+          .send({
+            client_id: 'client',
+            scope: 'openid',
+          })
+          .type('form')
+          .expect(200)
+          .expect('content-type', /application\/json/);
+      });
+    });
+  });
+
+  it('responds with json 200', async function () {
+    const spy = sinon.spy();
+    this.provider.once('device_authorization.success', spy);
+    let response;
+
+    await this.agent.post(route)
+      .send({
+        client_id: 'client',
+        scope: 'openid',
+        extra: 'included',
+        claims: JSON.stringify({ userinfo: { email: null } }),
+        redirect_uri: 'https://rp.example.com/cb/not/included',
+        response_mode: 'not included',
+        state: 'not included',
+        response_type: 'not included',
+        code_challenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+        code_challenge_method: 'S256',
+      })
+      .type('form')
+      .expect(200)
+      .expect('content-type', /application\/json/)
+      .expect(() => {
+        expect(spy.calledOnce).to.be.true;
+      })
+      .expect(({ body }) => {
+        expect(body).to.have.keys([
+          'device_code',
+          'user_code',
+          'verification_uri',
+          'verification_uri_complete',
+          'expires_in',
+        ]);
+        expect(body.verification_uri_complete).to.equal(`${body.verification_uri}?user_code=${body.user_code}`);
+        expect(body).to.have.property('verification_uri').that.matches(/\/device$/);
+        expect(body).to.have.property('expires_in', this.provider.DeviceCode.expiresIn);
+        response = body;
+      });
+
+    const dc = await this.provider.DeviceCode.find(response.device_code);
+    expect(dc).to.be.ok;
+    expect(dc).to.have.property('clientId', 'client');
+    expect(dc).to.have.property('userCode').that.is.a('string').and.equals(response.user_code);
+    expect(dc).to.have.property('params').that.is.an('object');
+    expect(dc.params).to.have.property('client_id', 'client');
+    expect(dc.params).to.have.property('scope', 'openid');
+    expect(dc.params).to.have.property('extra', 'included');
+    expect(dc.params).to.have.property('claims').that.equals(JSON.stringify({ userinfo: { email: null } }));
+    expect(dc.params).not.to.have.property('redirect_uri');
+    expect(dc.params).not.to.have.property('response_type');
+    expect(dc.params).not.to.have.property('state');
+    expect(dc.params).not.to.have.property('response_mode');
+  });
+
+  it('populates ctx.oidc.entities', function (done) {
+    this.provider.use(this.assertOnce((ctx) => {
+      expect(ctx.oidc.entities).to.have.keys('Client', 'DeviceCode');
+    }, done));
+
+    this.agent.post(route)
+      .send({
+        client_id: 'client',
+        scope: 'openid',
+        code_challenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+        code_challenge_method: 'S256',
+      })
+      .type('form')
+      .end(() => {});
+  });
+});

--- a/test/device_code/device_code.config.js
+++ b/test/device_code/device_code.config.js
@@ -1,0 +1,43 @@
+const { clone } = require('lodash');
+
+const config = clone(require('../default.config'));
+
+config.features = {
+  deviceCode: true,
+  request: false,
+  claimsParameter: true,
+  requestUri: false,
+};
+
+config.extraParams = [
+  'extra',
+];
+
+config.interactionCheck = () => {};
+
+module.exports = {
+  config,
+  clients: [
+    {
+      client_id: 'client',
+      grant_types: ['urn:ietf:params:oauth:grant-type:device_code', 'refresh_token'],
+      response_types: [],
+      redirect_uris: [],
+      token_endpoint_auth_method: 'none',
+      application_type: 'native',
+    }, {
+      client_id: 'client-other',
+      grant_types: ['urn:ietf:params:oauth:grant-type:device_code', 'refresh_token'],
+      response_types: [],
+      redirect_uris: [],
+      token_endpoint_auth_method: 'none',
+      application_type: 'native',
+    }, {
+      client_id: 'client-not-allowed',
+      token_endpoint_auth_method: 'none',
+      grant_types: [],
+      redirect_uris: [],
+      response_types: [],
+    },
+  ],
+};

--- a/test/device_code/device_code.test.js
+++ b/test/device_code/device_code.test.js
@@ -1,0 +1,15 @@
+const { expect } = require('chai');
+
+const bootstrap = require('../test_helper');
+
+describe('configuration features.deviceCode', () => {
+  before(bootstrap(__dirname)); // agent
+
+  it('extends discovery', function () {
+    return this.agent.get('/.well-known/openid-configuration')
+      .expect(200)
+      .expect((response) => {
+        expect(response.body).to.contain.keys('device_authorization_endpoint');
+      });
+  });
+});

--- a/test/device_code/device_code_conform.config.js
+++ b/test/device_code/device_code_conform.config.js
@@ -1,0 +1,7 @@
+const { cloneDeep } = require('lodash');
+
+const config = cloneDeep(require('./device_code.config'));
+
+config.config.features.conformIdTokenClaims = true;
+
+module.exports = config;

--- a/test/device_code/device_code_grant.test.js
+++ b/test/device_code/device_code_grant.test.js
@@ -79,6 +79,7 @@ describe('grant_type=urn:ietf:params:oauth:grant-type:device_code', () => {
     this.provider.use(this.assertOnce((ctx) => {
       expect(ctx.body.refresh_token).to.be.undefined;
       expect(ctx.oidc.entities).to.have.keys('Account', 'Client', 'DeviceCode', 'AccessToken');
+      expect(ctx.oidc.entities.AccessToken).to.have.property('gty', 'device_code');
     }, done));
 
     const deviceCode = new this.provider.DeviceCode({
@@ -101,6 +102,8 @@ describe('grant_type=urn:ietf:params:oauth:grant-type:device_code', () => {
   it('populates ctx.oidc.entities (w/ offline_access)', function (done) {
     this.provider.use(this.assertOnce((ctx) => {
       expect(ctx.oidc.entities).to.have.keys('Account', 'Client', 'DeviceCode', 'AccessToken', 'RefreshToken');
+      expect(ctx.oidc.entities.AccessToken).to.have.property('gty', 'device_code');
+      expect(ctx.oidc.entities.RefreshToken).to.have.property('gty', 'device_code');
     }, done));
 
     const deviceCode = new this.provider.DeviceCode({

--- a/test/device_code/device_code_grant.test.js
+++ b/test/device_code/device_code_grant.test.js
@@ -1,0 +1,525 @@
+const { expect } = require('chai');
+const sinon = require('sinon');
+const base64url = require('base64url');
+
+const bootstrap = require('../test_helper');
+const epochTime = require('../../lib/helpers/epoch_time');
+
+const route = '/token';
+const grant_type = 'urn:ietf:params:oauth:grant-type:device_code';
+
+function errorDetail(spy) {
+  return spy.args[0][0].error_detail;
+}
+
+describe('grant_type=urn:ietf:params:oauth:grant-type:device_code w/ conformIdTokenClaims', () => {
+  before(bootstrap(__dirname, { config: 'device_code_conform' })); // agent
+
+  it('returns the right stuff', async function () {
+    const spy = sinon.spy();
+    this.provider.once('grant.success', spy);
+
+    const deviceCode = new this.provider.DeviceCode({
+      accountId: 'sub',
+      scope: 'openid profile offline_access',
+      clientId: 'client',
+    });
+    const code = await deviceCode.save();
+
+    return this.agent.post('/token')
+      .type('form')
+      .send({
+        client_id: 'client',
+        device_code: code,
+        grant_type,
+      })
+      .expect(200)
+      .expect(() => {
+        expect(spy.calledOnce).to.be.true;
+      })
+      .expect((response) => {
+        expect(response.body).to.have.keys('access_token', 'id_token', 'expires_in', 'token_type', 'scope', 'refresh_token');
+        expect(JSON.parse(base64url.decode(response.body.id_token.split('.')[1]))).not.to.have.property('given_name');
+      });
+  });
+});
+
+describe('grant_type=urn:ietf:params:oauth:grant-type:device_code', () => {
+  before(bootstrap(__dirname)); // agent
+
+  it('returns the right stuff', async function () {
+    const spy = sinon.spy();
+    this.provider.once('grant.success', spy);
+
+    const deviceCode = new this.provider.DeviceCode({
+      accountId: 'sub',
+      scope: 'openid profile offline_access',
+      clientId: 'client',
+    });
+    const code = await deviceCode.save();
+
+    return this.agent.post('/token')
+      .type('form')
+      .send({
+        client_id: 'client',
+        device_code: code,
+        grant_type,
+      })
+      .expect(200)
+      .expect(() => {
+        expect(spy.calledOnce).to.be.true;
+      })
+      .expect((response) => {
+        expect(response.body).to.have.keys('access_token', 'id_token', 'expires_in', 'token_type', 'scope', 'refresh_token');
+        expect(JSON.parse(base64url.decode(response.body.id_token.split('.')[1]))).to.have.property('given_name');
+      });
+  });
+
+  it('populates ctx.oidc.entities (no offline_access)', function (done) {
+    this.provider.use(this.assertOnce((ctx) => {
+      expect(ctx.body.refresh_token).to.be.undefined;
+      expect(ctx.oidc.entities).to.have.keys('Account', 'Client', 'DeviceCode', 'AccessToken');
+    }, done));
+
+    const deviceCode = new this.provider.DeviceCode({
+      accountId: 'sub',
+      scope: 'openid',
+      clientId: 'client',
+    });
+    deviceCode.save().then((code) => {
+      this.agent.post(route)
+        .type('form')
+        .send({
+          client_id: 'client',
+          device_code: code,
+          grant_type,
+        })
+        .end(() => {});
+    });
+  });
+
+  it('populates ctx.oidc.entities (w/ offline_access)', function (done) {
+    this.provider.use(this.assertOnce((ctx) => {
+      expect(ctx.oidc.entities).to.have.keys('Account', 'Client', 'DeviceCode', 'AccessToken', 'RefreshToken');
+    }, done));
+
+    const deviceCode = new this.provider.DeviceCode({
+      accountId: 'sub',
+      scope: 'openid offline_access',
+      clientId: 'client',
+    });
+    deviceCode.save().then((code) => {
+      this.agent.post(route)
+        .type('form')
+        .send({
+          client_id: 'client',
+          device_code: code,
+          grant_type,
+        })
+        .end(() => {});
+    });
+  });
+
+  describe('validates', () => {
+    it('device_code param presence', function () {
+      return this.agent.post(route)
+        .send({
+          client_id: 'client',
+          grant_type,
+        })
+        .type('form')
+        .expect(400)
+        .expect('content-type', /application\/json/)
+        .expect({
+          error: 'invalid_request',
+          error_description: 'missing required parameter(s) (device_code)',
+        });
+    });
+
+    it('code being "found"', function () {
+      const spy = sinon.spy();
+      this.provider.once('grant.error', spy);
+      return this.agent.post(route)
+        .send({
+          client_id: 'client',
+          grant_type,
+          device_code: 'eyJraW5kIjoiQXV0aG9yaXphdGlvbkNvZGUiLCJqdGkiOiIxNTU0M2RiYS0zYThmLTRiZWEtYmRjNi04NDQ2N2MwOWZjYTYiLCJpYXQiOjE0NjM2NTk2OTgsImV4cCI6MTQ2MzY1OTc1OCwiaXNzIjoiaHR0cHM6Ly9ndWFyZGVkLWNsaWZmcy04NjM1Lmhlcm9rdWFwcC5jb20vb3AifQ.qUTaR48lavULtmDWBcpwhcF9NXhP8xzc-643h3yWLEgIyxPzKINT-upNn-byflH7P7rQlzZ-9SJKSs72ZVqWWMNikUGgJo-XmLyersONQ8sVx7v0quo4CRXamwyXfz2gq76gFlv5mtsrWwCij1kUnSaFm_HhAcoDPzGtSqhsHNoz36KjdmC3R-m84reQk_LEGizUeV-OmsBWJs3gedPGYcRCvsnW9qa21B0yZO2-HT9VQYY68UIGucDKNvizFRmIgepDZ5PUtsvyPD0PQQ9UHiEZvICeArxPLE8t1xz-lukpTMn8vA_YJ0s7kD9HYJUwxiYIuLXwDUNpGhsegxdvbw',
+        })
+        .type('form')
+        .expect(400)
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+          expect(errorDetail(spy)).to.equal('device code not found');
+        })
+        .expect((response) => {
+          expect(response.body).to.have.property('error', 'invalid_grant');
+        });
+    });
+
+    it('validates account is still there', async function () {
+      sinon.stub(this.provider.Account, 'findById').callsFake(() => Promise.resolve());
+
+      const spy = sinon.spy();
+      this.provider.once('grant.error', spy);
+
+      const deviceCode = new this.provider.DeviceCode({
+        accountId: 'sub',
+        scope: 'openid',
+        clientId: 'client',
+      });
+      const code = await deviceCode.save();
+
+      return this.agent.post(route)
+        .send({
+          client_id: 'client',
+          device_code: code,
+          grant_type,
+        })
+        .type('form')
+        .expect(() => {
+          this.provider.Account.findById.restore();
+        })
+        .expect(400)
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+          expect(errorDetail(spy)).to.equal('device code invalid (referenced account not found)');
+        })
+        .expect((response) => {
+          expect(response.body).to.have.property('error', 'invalid_grant');
+        });
+    });
+
+    describe('PKCE', () => {
+      it('passes with plain values', async function () {
+        const deviceCode = new this.provider.DeviceCode({
+          accountId: 'sub',
+          scope: 'openid',
+          clientId: 'client',
+          codeChallenge: 'plainFoobar',
+          codeChallengeMethod: 'plain',
+        });
+        const code = await deviceCode.save();
+
+        return this.agent.post('/token')
+          .type('form')
+          .send({
+            client_id: 'client',
+            device_code: code,
+            grant_type,
+            code_verifier: 'plainFoobar',
+          })
+          .expect(200);
+      });
+
+      it('passes with S256 values', async function () {
+        const deviceCode = new this.provider.DeviceCode({
+          accountId: 'sub',
+          scope: 'openid',
+          clientId: 'client',
+          codeChallenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+          codeChallengeMethod: 'S256',
+        });
+        const code = await deviceCode.save();
+
+        return this.agent.post('/token')
+          .type('form')
+          .send({
+            client_id: 'client',
+            device_code: code,
+            grant_type,
+            code_verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+          })
+          .expect(200);
+      });
+
+      it('checks presence of code_verifier param if code has codeChallenge', async function () {
+        const deviceCode = new this.provider.DeviceCode({
+          accountId: 'sub',
+          scope: 'openid',
+          clientId: 'client',
+          codeChallenge: 'plainFoobar',
+          codeChallengeMethod: 'plain',
+        });
+        const code = await deviceCode.save();
+
+        return this.agent.post('/token')
+          .type('form')
+          .send({
+            client_id: 'client',
+            device_code: code,
+            grant_type,
+          })
+          .expect(400)
+          .expect((response) => {
+            expect(response.body).to.have.property('error', 'invalid_grant');
+          });
+      });
+
+      it('checks value of code_verifier when method = plain', async function () {
+        const deviceCode = new this.provider.DeviceCode({
+          accountId: 'sub',
+          scope: 'openid',
+          clientId: 'client',
+          codeChallenge: 'plainFoobar',
+          codeChallengeMethod: 'plain',
+        });
+        const code = await deviceCode.save();
+
+        return this.agent.post('/token')
+          .type('form')
+          .send({
+            client_id: 'client',
+            device_code: code,
+            grant_type,
+            code_verifier: 'plainFoobars',
+          })
+          .expect(400)
+          .expect((response) => {
+            expect(response.body).to.have.property('error', 'invalid_grant');
+          });
+      });
+
+      it('checks value of code_verifier when method = S256', async function () {
+        const deviceCode = new this.provider.DeviceCode({
+          accountId: 'sub',
+          scope: 'openid',
+          clientId: 'client',
+          codeChallenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+          codeChallengeMethod: 'S256',
+        });
+        const code = await deviceCode.save();
+
+        return this.agent.post('/token')
+          .type('form')
+          .send({
+            client_id: 'client',
+            device_code: code,
+            grant_type,
+            code_verifier: 'invalidE9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+          })
+          .expect(400)
+          .expect((response) => {
+            expect(response.body).to.have.property('error', 'invalid_grant');
+          });
+      });
+
+      describe('only S256 is supported', () => {
+        before(function () {
+          i(this.provider).configuration('features.pkce').supportedMethods = ['S256'];
+        });
+
+        after(function () {
+          i(this.provider).configuration('features.pkce').supportedMethods = ['plain', 'S256'];
+        });
+
+        it('passes if S256 is used', async function () {
+          const deviceCode = new this.provider.DeviceCode({
+            accountId: 'sub',
+            scope: 'openid',
+            clientId: 'client',
+            codeChallenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+            codeChallengeMethod: 'S256',
+          });
+          const code = await deviceCode.save();
+
+          return this.agent.post('/token')
+            .type('form')
+            .send({
+              client_id: 'client',
+              device_code: code,
+              grant_type,
+              code_verifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+            })
+            .expect(200);
+        });
+      });
+    });
+
+    it('code belongs to client', async function () {
+      const spy = sinon.spy();
+      this.provider.once('grant.error', spy);
+
+      const deviceCode = new this.provider.DeviceCode({
+        accountId: 'sub',
+        scope: 'openid',
+        clientId: 'client-other',
+      });
+      const code = await deviceCode.save();
+
+      return this.agent.post(route)
+        .send({
+          client_id: 'client',
+          device_code: code,
+          grant_type,
+        })
+        .type('form')
+        .expect(400)
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+          expect(errorDetail(spy)).to.equal('device code client mismatch');
+        })
+        .expect((response) => {
+          expect(response.body).to.have.property('error', 'invalid_grant');
+        });
+    });
+
+    context('', () => {
+      before(function () {
+        this.prev = this.provider.DeviceCode.expiresIn;
+        i(this.provider).configuration('ttl').DeviceCode = 0;
+      });
+
+      after(function () {
+        i(this.provider).configuration('ttl').DeviceCode = this.prev;
+      });
+
+      it('validates code is not expired', async function () {
+        const deviceCode = new this.provider.DeviceCode({
+          scope: 'openid',
+          clientId: 'client',
+        });
+        const code = await deviceCode.save();
+
+        return this.agent.post(route)
+          .send({
+            client_id: 'client',
+            device_code: code,
+            grant_type,
+          })
+          .type('form')
+          .expect(400)
+          .expect({
+            error: 'expired_token',
+            error_description: 'device code is expired',
+          });
+      });
+    });
+
+    it('consumes the code', async function () {
+      const deviceCode = new this.provider.DeviceCode({
+        accountId: 'sub',
+        scope: 'openid',
+        clientId: 'client',
+      });
+      const code = await deviceCode.save();
+
+      return this.agent.post(route)
+        .send({
+          client_id: 'client',
+          device_code: code,
+          grant_type,
+        })
+        .type('form')
+        .expect(200)
+        .expect(() => {
+          const jti = this.getTokenJti(code);
+          const stored = this.TestAdapter.for('DeviceCode').syncFind(jti);
+          expect(stored).to.have.property('consumed').and.be.most(epochTime());
+        });
+    });
+
+    it('validates code is not already used', async function () {
+      const spy = sinon.spy();
+      this.provider.once('grant.error', spy);
+
+      const deviceCode = new this.provider.DeviceCode({
+        accountId: 'sub',
+        scope: 'openid',
+        clientId: 'client',
+      });
+      const code = await deviceCode.save();
+      await deviceCode.consume();
+
+      return this.agent.post(route)
+        .send({
+          client_id: 'client',
+          device_code: code,
+          grant_type,
+        })
+        .type('form')
+        .expect(400)
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+          expect(errorDetail(spy)).to.equal('device code already consumed');
+        })
+        .expect((response) => {
+          expect(response.body).to.have.property('error', 'invalid_grant');
+        });
+    });
+  });
+
+  it('responds with authorization_pending if interactions are still pending resolving', async function () {
+    const deviceCode = new this.provider.DeviceCode({
+      scope: 'openid',
+      clientId: 'client',
+      // error: missing
+      // accountId: missing
+    });
+    const code = await deviceCode.save();
+
+    return this.agent.post(route)
+      .send({
+        client_id: 'client',
+        device_code: code,
+        grant_type,
+      })
+      .type('form')
+      .expect(400)
+      .expect({
+        error: 'authorization_pending',
+        error_description: 'authorization request is still pending as the end-user hasn\'t yet completed the user interaction steps',
+      });
+  });
+
+  it('responds with a custom error if one is resolved with', async function () {
+    const deviceCode = new this.provider.DeviceCode({
+      scope: 'openid',
+      clientId: 'client',
+      error: 'foo',
+      errorDescription: 'bar',
+    });
+    const code = await deviceCode.save();
+
+    return this.agent.post(route)
+      .send({
+        client_id: 'client',
+        device_code: code,
+        grant_type,
+      })
+      .type('form')
+      .expect(400)
+      .expect({
+        error: 'foo',
+        error_description: 'bar',
+      });
+  });
+
+  it('responds with a built-in error if one is resolved with', async function () {
+    const spy = sinon.spy();
+    this.provider.once('grant.error', spy);
+
+    const deviceCode = new this.provider.DeviceCode({
+      scope: 'openid',
+      clientId: 'client',
+      error: 'access_denied',
+      errorDescription: 'user has denied access',
+    });
+    const code = await deviceCode.save();
+
+    return this.agent.post(route)
+      .send({
+        client_id: 'client',
+        device_code: code,
+        grant_type,
+      })
+      .type('form')
+      .expect(400)
+      .expect({
+        error: 'access_denied',
+        error_description: 'user has denied access',
+      })
+      .expect(() => {
+        expect(spy.calledOnce).to.be.true;
+      });
+  });
+});

--- a/test/device_code/device_resume.test.js
+++ b/test/device_code/device_resume.test.js
@@ -1,0 +1,454 @@
+/* eslint-disable no-underscore-dangle */
+const { expect } = require('chai');
+const uuid = require('uuid/v4');
+const KeyGrip = require('keygrip'); // eslint-disable-line import/no-extraneous-dependencies
+const sinon = require('sinon');
+
+const bootstrap = require('../test_helper');
+const epochTime = require('../../lib/helpers/epoch_time');
+const generateUserCode = require('../../lib/helpers/generate_user_code');
+
+const { any } = sinon.match;
+
+const expire = new Date();
+expire.setDate(expire.getDate() + 1);
+
+let grantId;
+let userCode;
+let path;
+
+describe('device interaction resume /device/:user_code/:grant/', () => {
+  before(bootstrap(__dirname));
+
+  beforeEach(() => {
+    grantId = uuid();
+    userCode = generateUserCode('0123456789', '****-****');
+    path = `/device/${userCode}/${grantId}`;
+  });
+
+  afterEach(function () {
+    if (this.provider.Session.find.restore) {
+      this.provider.Session.find.restore();
+    }
+    if (this.provider.interactionDetails.restore) {
+      this.provider.interactionDetails.restore();
+    }
+    if (this.provider.DeviceCode.findByUserCode.restore) {
+      this.provider.DeviceCode.findByUserCode.restore();
+    }
+    if (i(this.provider).configuration().deviceCodeSuccess.restore) {
+      i(this.provider).configuration().deviceCodeSuccess.restore();
+    }
+    if (i(this.provider).configuration().userCodeInputSource.restore) {
+      i(this.provider).configuration().userCodeInputSource.restore();
+    }
+  });
+
+  function setup(auth, result) {
+    expect(auth).to.be.ok;
+
+    const cookies = [];
+
+    const params = {
+      client_id: 'client',
+      ...auth,
+    };
+
+    const interaction = new this.provider.Session(grantId, {});
+    const session = new this.provider.Session('sess', {});
+    const keys = new KeyGrip(i(this.provider).configuration('cookies.keys'));
+    const code = new this.provider.DeviceCode({
+      params,
+      clientId: 'client',
+      grantId,
+      userCode,
+    });
+
+    const cookie = `_grant=${grantId}; path=${path}; expires=${expire.toGMTString()}; httponly`;
+    cookies.push(cookie);
+    let [pre, ...post] = cookie.split(';');
+    cookies.push([`_grant.sig=${keys.sign(pre)}`, ...post].join(';'));
+    Object.assign(interaction, { params });
+
+    const sessionCookie = `_session=sess; path=/; expires=${expire.toGMTString()}; httponly`;
+    [pre, ...post] = sessionCookie.split(';');
+    cookies.push([`_session.sig=${keys.sign(pre)}`, ...post].join(';'));
+
+    if (result) {
+      if (result.login && !result.login.ts) {
+        Object.assign(result.login, { ts: epochTime() });
+      }
+      Object.assign(interaction, { result });
+    }
+
+    this.agent._saveCookies.bind(this.agent)({
+      headers: {
+        'set-cookie': cookies,
+      },
+    });
+
+    return Promise.all([
+      code.save(),
+      interaction.save(),
+      session.save(),
+    ]);
+  }
+
+  context('general', () => {
+    it('needs the resume cookie to be present, else renders an err', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(400)
+        .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+        .expect(/<p class="red">There was an error processing your request<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name).to.equal('SessionNotFound');
+        expect(err.error_description).to.equal('authorization request has expired');
+        return true;
+      }));
+    });
+
+    it('needs to find the session to resume', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+
+      const auth = new this.AuthorizationRequest({
+        response_type: 'code',
+        scope: 'openid',
+      });
+
+      setup.call(this, auth);
+
+      sinon.stub(this.provider.Session, 'find').resolves();
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(400)
+        .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+        .expect(/<p class="red">There was an error processing your request<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name).to.equal('SessionNotFound');
+        expect(err.error_description).to.equal('interaction session not found');
+        return true;
+      }));
+    });
+
+    it('needs to find the code to resume', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+
+      const auth = new this.AuthorizationRequest({
+        response_type: 'code',
+        scope: 'openid',
+      });
+
+      setup.call(this, auth);
+
+      sinon.stub(this.provider.DeviceCode, 'findByUserCode').resolves();
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(200)
+        .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+        .expect(/<p class="red">There was an error processing your request<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name).to.equal('NotFoundError');
+        expect(err.message).to.equal('the code was not found');
+        return true;
+      }));
+    });
+
+    it('checks code is not expired', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+
+      const auth = new this.AuthorizationRequest({
+        response_type: 'code',
+        scope: 'openid',
+      });
+
+      setup.call(this, auth);
+
+      sinon.stub(this.provider.DeviceCode, 'findByUserCode').resolves({ grantId, isExpired: true });
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(200)
+        .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+        .expect(/<p class="red">There was an error processing your request<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name).to.equal('ExpiredError');
+        expect(err.message).to.equal('the code has expired');
+        return true;
+      }));
+    });
+
+    it('checks code is not used already (1/2)', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+
+      const auth = new this.AuthorizationRequest({
+        response_type: 'code',
+        scope: 'openid',
+      });
+
+      setup.call(this, auth);
+
+      sinon.stub(this.provider.DeviceCode, 'findByUserCode').resolves({ grantId, accountId: 'foo' });
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(200)
+        .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+        .expect(/<p class="red">There was an error processing your request<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name).to.equal('AlreadyUsedError');
+        expect(err.message).to.equal('code has already been used');
+        return true;
+      }));
+    });
+
+    it('checks code is not used already (2/2)', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+
+      const auth = new this.AuthorizationRequest({
+        response_type: 'code',
+        scope: 'openid',
+      });
+
+      setup.call(this, auth);
+
+      sinon.stub(this.provider.DeviceCode, 'findByUserCode').resolves({ grantId, error: 'access_denied' });
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(200)
+        .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+        .expect(/<p class="red">There was an error processing your request<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name).to.equal('AlreadyUsedError');
+        expect(err.message).to.equal('code has already been used');
+        return true;
+      }));
+    });
+
+    it('checks for mismatches in resume and code grants', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+
+      const auth = new this.AuthorizationRequest({
+        response_type: 'code',
+        scope: 'openid',
+      });
+
+      setup.call(this, auth);
+
+      sinon.stub(this.provider.DeviceCode, 'findByUserCode').resolves({ grantId: 'foo', save: sinon.stub().resolves() });
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(400)
+        .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+        .expect(/<p class="red">There was an error processing your request<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name).to.equal('InvalidRequest');
+        expect(err.error).to.equal('invalid_request');
+        expect(err.error_description).to.equal('grantId mismatch');
+        return true;
+      }));
+    });
+  });
+
+  context('login results', () => {
+    it('should re-render if there was no session created', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+
+      setup.call(this, {
+        scope: 'openid',
+      });
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(400)
+        .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+        .expect(/<p class="red">There was an error processing your request<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.message).to.equal('login_required');
+        expect(err.error_description).to.equal('End-User authentication is required');
+        return true;
+      }));
+    });
+
+    it('should process newly established permanent sessions', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'deviceCodeSuccess');
+
+      setup.call(this, {
+        scope: 'openid',
+      }, {
+        login: {
+          account: uuid(),
+          remember: true,
+        },
+      });
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+        })
+        .expect(200)
+        .expect('set-cookie', /expires/) // expect a permanent cookie
+        .expect(() => {
+          expect(this.getSession()).to.be.ok.and.not.have.property('transient');
+        });
+
+      const code = await this.provider.DeviceCode.findByUserCode(userCode);
+      expect(code).to.have.property('accountId');
+    });
+
+    it('should process newly established temporary sessions', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'deviceCodeSuccess');
+
+      setup.call(this, {
+        scope: 'openid',
+      }, {
+        login: {
+          account: uuid(),
+        },
+      });
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+        })
+        .expect(200)
+        .expect(() => {
+          expect(this.getSession()).to.be.ok.and.have.property('transient');
+        });
+
+      const code = await this.provider.DeviceCode.findByUserCode(userCode);
+      expect(code).to.have.property('accountId');
+    });
+  });
+
+  context('consent results', () => {
+    it('when scope includes offline_access', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'deviceCodeSuccess');
+
+      setup.call(this, {
+        scope: 'openid offline_access',
+      }, {
+        login: {
+          account: uuid(),
+          remember: true,
+        },
+        consent: {},
+      });
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+        })
+        .expect(200);
+
+      const code = await this.provider.DeviceCode.findByUserCode(userCode);
+      expect(code).to.have.property('accountId');
+      expect(code).to.have.property('scope', 'openid offline_access');
+    });
+
+    it('should use the scope from resume cookie if provided', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'deviceCodeSuccess');
+
+      setup.call(this, {
+        scope: 'openid offline_access',
+      }, {
+        login: {
+          account: uuid(),
+          remember: true,
+        },
+        consent: {
+          scope: 'openid',
+        },
+      });
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(() => {
+          expect(spy.calledOnce).to.be.true;
+        })
+        .expect(200);
+
+      const code = await this.provider.DeviceCode.findByUserCode(userCode);
+      expect(code).to.have.property('accountId');
+      expect(code).to.have.property('scope', 'openid');
+    });
+
+    it('if not resolved returns consent_required error', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+
+      setup.call(this, {
+        scope: 'openid',
+        prompt: 'consent',
+      }, {
+        login: {
+          account: uuid(),
+          remember: true,
+        },
+      });
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(400)
+        .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+        .expect(/<p class="red">There was an error processing your request<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.message).to.equal('consent_required');
+        expect(err.error_description).to.equal('prompt consent was not resolved');
+        return true;
+      }));
+    });
+  });
+
+  context('interaction errors', () => {
+    it('should abort an interaction when given an error result object', async function () {
+      const spy = sinon.spy(i(this.provider).configuration(), 'userCodeInputSource');
+
+      setup.call(this, {
+        scope: 'openid',
+      }, {
+        error: 'access_denied',
+        error_description: 'scope out of reach',
+      });
+
+      await this.agent.get(path)
+        .accept('text/html')
+        .expect(400)
+        .expect(/<form id="op\.deviceInputForm" method="post" action="\/device">/)
+        .expect(/<p class="red">There was an error processing your request<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.message).to.equal('access_denied');
+        expect(err.error_description).to.equal('scope out of reach');
+        return true;
+      }));
+    });
+  });
+});

--- a/test/dynamic_registration/dynamic_registration.test.js
+++ b/test/dynamic_registration/dynamic_registration.test.js
@@ -148,7 +148,11 @@ describe('registration features', () => {
           redirect_uris: ['https://client.example.com/cb'],
         })
         .type('form')
-        .expect(this.failWith(400, 'invalid_request', 'only application/json content-type POST bodies are supported'));
+        .expect(400)
+        .expect({
+          error: 'invalid_request',
+          error_description: 'only application/json content-type bodies are supported on POST /reg',
+        });
     });
 
     describe('initial access tokens', () => {

--- a/test/interaction/interaction.test.js
+++ b/test/interaction/interaction.test.js
@@ -254,6 +254,7 @@ describe('resume after interaction', () => {
     it('should process newly established permanent sessions', function () {
       const auth = new this.AuthorizationRequest({
         response_type: 'code',
+        response_mode: 'query',
         scope: 'openid',
       });
 
@@ -278,6 +279,7 @@ describe('resume after interaction', () => {
     it('should process newly established temporary sessions', function () {
       const auth = new this.AuthorizationRequest({
         response_type: 'code',
+        response_mode: 'query',
         scope: 'openid',
       });
 
@@ -391,6 +393,7 @@ describe('resume after interaction', () => {
     it('should process and store meta-informations provided alongside login', function () {
       const auth = new this.AuthorizationRequest({
         response_type: 'code',
+        response_mode: 'fragment',
         scope: 'openid',
       });
 

--- a/test/introspection/introspection.test.js
+++ b/test/introspection/introspection.test.js
@@ -23,6 +23,7 @@ describe('introspection features', () => {
     it('returns the properties for access token [no hint]', async function () {
       const at = new this.provider.AccessToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -44,6 +45,7 @@ describe('introspection features', () => {
     it('returns the properties for access token [correct hint]', async function () {
       const at = new this.provider.AccessToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -66,6 +68,7 @@ describe('introspection features', () => {
     it('returns the properties for access token [wrong hint]', async function () {
       const at = new this.provider.AccessToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -88,6 +91,7 @@ describe('introspection features', () => {
     it('returns the properties for access token [unrecognized hint]', async function () {
       const at = new this.provider.AccessToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -110,6 +114,7 @@ describe('introspection features', () => {
     it('returns the properties for refresh token [no hint]', async function () {
       const rt = new this.provider.RefreshToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -128,6 +133,7 @@ describe('introspection features', () => {
     it('returns the properties for refresh token [correct hint]', async function () {
       const rt = new this.provider.RefreshToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -146,6 +152,7 @@ describe('introspection features', () => {
     it('returns the properties for refresh token [wrong hint]', async function () {
       const rt = new this.provider.RefreshToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -164,6 +171,7 @@ describe('introspection features', () => {
     it('returns the properties for refresh token [unrecognized hint]', async function () {
       const rt = new this.provider.RefreshToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -246,6 +254,7 @@ describe('introspection features', () => {
     it('can be called by RS clients and uses the original subject_type', async function () {
       const rt = new this.provider.RefreshToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client-pairwise',
         scope: 'scope',
       });
@@ -300,6 +309,7 @@ describe('introspection features', () => {
     it('responds with active=false when client auth = none and token does not belong to it', async function () {
       const at = new this.provider.AccessToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -350,6 +360,7 @@ describe('introspection features', () => {
     it('responds only with active=false when token is expired', async function () {
       const at = new this.provider.AccessToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
         expiresIn: -1,
@@ -371,6 +382,7 @@ describe('introspection features', () => {
     it('responds only with active=false when token is already consumed', async function () {
       const rt = new this.provider.RefreshToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });

--- a/test/models.js
+++ b/test/models.js
@@ -63,6 +63,7 @@ class TestAdapter {
 
   syncFind(id, { payload = false } = {}) {
     const found = store.get(this.key(id));
+    if (!found) return undefined;
     if (payload && FORMAT === 'legacy') {
       return JSON.parse(base64url.decode(found.payload));
     }
@@ -71,6 +72,7 @@ class TestAdapter {
 
   syncUpdate(id, update) {
     const found = store.get(this.key(id));
+    if (!found) return;
     switch (FORMAT) {
       case 'legacy': {
         const payload = JSON.parse(base64url.decode(found.payload));

--- a/test/models.js
+++ b/test/models.js
@@ -9,6 +9,10 @@ function grantKeyFor(id) {
   return ['grant', id].join(':');
 }
 
+function userCodeKeyFor(userCode) {
+  return ['userCode', userCode].join(':');
+}
+
 class TestAdapter {
   constructor(name) {
     this.name = name;
@@ -87,10 +91,15 @@ class TestAdapter {
     return Promise.resolve(this.syncFind(id));
   }
 
+  findByUserCode(userCode) {
+    const id = store.get(userCodeKeyFor(userCode));
+    return this.find(id);
+  }
+
   upsert(id, payload, expiresIn) {
     const key = this.key(id);
 
-    const { grantId } = payload;
+    const { grantId, userCode } = payload;
     if (grantId) {
       const grantKey = grantKeyFor(grantId);
       const grant = store.get(grantKey);
@@ -99,6 +108,10 @@ class TestAdapter {
       } else {
         grant.push(key);
       }
+    }
+
+    if (userCode) {
+      store.set(userCodeKeyFor(userCode), id, expiresIn * 1000);
     }
 
     store.set(key, payload, expiresIn * 1000);

--- a/test/provider/provider_class.test.js
+++ b/test/provider/provider_class.test.js
@@ -11,6 +11,8 @@ describe('Provider', () => {
     });
     expect(Provider.errors).to.have.keys([
       'AccessDenied',
+      'AuthorizationPending',
+      'ExpiredToken',
       'InvalidClient',
       'InvalidClientAuth',
       'InvalidClientMetadata',
@@ -27,6 +29,7 @@ describe('Provider', () => {
       'RequestUriNotSupported',
       'RestrictedGrantType',
       'RestrictedResponseType',
+      'SlowDown',
       'TemporarilyUnavailable',
       'UnauthorizedClient',
       'UnsupportedGrantType',

--- a/test/request/request.config.js
+++ b/test/request/request.config.js
@@ -6,6 +6,7 @@ config.features = {
   request: true,
   requestUri: { requireRequestUriRegistration: false },
   claimsParameter: true,
+  deviceCode: true,
 };
 config.unsupported = {
   requestObjectSigningAlgValues: ['HS384'],
@@ -16,11 +17,13 @@ module.exports = {
   clients: [{
     client_id: 'client',
     client_secret: 'its48bytes_____________________________________!',
+    grant_types: ['urn:ietf:params:oauth:grant-type:device_code', 'authorization_code'],
     redirect_uris: ['https://client.example.com/cb'],
   }, {
     client_id: 'client-with-HS-sig',
     client_secret: 'atleast32byteslongforHS256mmkay?',
     request_object_signing_alg: 'HS256',
+    grant_types: ['urn:ietf:params:oauth:grant-type:device_code', 'authorization_code'],
     redirect_uris: ['https://client.example.com/cb'],
   }],
 };

--- a/test/revocation/revocation.test.js
+++ b/test/revocation/revocation.test.js
@@ -23,6 +23,7 @@ describe('revocation features', () => {
     it('revokes access token [no hint]', async function () {
       const at = new this.provider.AccessToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -45,6 +46,7 @@ describe('revocation features', () => {
     it('revokes access token [correct hint]', async function () {
       const at = new this.provider.AccessToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -67,6 +69,7 @@ describe('revocation features', () => {
     it('revokes access token [wrong hint]', async function () {
       const at = new this.provider.AccessToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -89,6 +92,7 @@ describe('revocation features', () => {
     it('revokes access token [unrecognized hint]', async function () {
       const at = new this.provider.AccessToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -111,6 +115,7 @@ describe('revocation features', () => {
     it('propagates exceptions on find', async function () {
       const at = new this.provider.AccessToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -134,6 +139,7 @@ describe('revocation features', () => {
     it('revokes refresh token [no hint]', async function () {
       const rt = new this.provider.RefreshToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -156,6 +162,7 @@ describe('revocation features', () => {
     it('revokes refresh token [correct hint]', async function () {
       const rt = new this.provider.RefreshToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -178,6 +185,7 @@ describe('revocation features', () => {
     it('revokes refresh token [wrong hint]', async function () {
       const rt = new this.provider.RefreshToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -200,6 +208,7 @@ describe('revocation features', () => {
     it('revokes refresh token [unrecognized hint]', async function () {
       const rt = new this.provider.RefreshToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client',
         scope: 'scope',
       });
@@ -336,6 +345,7 @@ describe('revocation features', () => {
     it('does not revoke tokens of other clients', async function () {
       const at = new this.provider.AccessToken({
         accountId: 'accountId',
+        grantId: 'foo',
         clientId: 'client2',
         scope: 'scope',
       });

--- a/test/storage/jwt.test.js
+++ b/test/storage/jwt.test.js
@@ -28,17 +28,23 @@ if (FORMAT === 'jwt') {
     const codeChallenge = 'codeChallenge';
     const codeChallengeMethod = 'codeChallengeMethod';
     const aud = [clientId, 'foo'];
+    const error = 'access_denied';
+    const errorDescription = 'resource owner denied access';
+    const params = { foo: 'bar' };
+    const userCode = '1384-3217';
+    const deviceInfo = { foo: 'bar' };
 
     /* eslint-disable object-property-newline */
     const fullPayload = {
       accountId, claims, clientId, grantId, scope, sid, consumed, acr, amr, authTime, nonce,
-      redirectUri, codeChallenge, codeChallengeMethod, aud,
+      redirectUri, codeChallenge, codeChallengeMethod, aud, error, errorDescription, params,
+      userCode, deviceInfo,
     };
     /* eslint-enable object-property-newline */
 
     afterEach(function () {
       [
-        'AuthorizationCode', 'AccessToken', 'RefreshToken', 'ClientCredentials', 'InitialAccessToken', 'RegistrationAccessToken',
+        'AuthorizationCode', 'AccessToken', 'RefreshToken', 'ClientCredentials', 'InitialAccessToken', 'RegistrationAccessToken', 'DeviceCode',
       ].forEach((model) => {
         if (this.TestAdapter.for(model).upsert.restore) {
           this.TestAdapter.for(model).upsert.restore();
@@ -160,6 +166,40 @@ if (FORMAT === 'jwt') {
         aud: clientId,
         scope,
         iss: this.provider.issuer,
+      });
+    });
+
+    it('for DeviceCode', async function () {
+      const kind = 'DeviceCode';
+      const upsert = spy(this.TestAdapter.for('DeviceCode'), 'upsert');
+      const token = new this.provider.DeviceCode(fullPayload);
+      const jwt = await token.save();
+
+      assert.calledWith(upsert, string, {
+        jwt,
+        accountId,
+        acr,
+        amr,
+        authTime,
+        claims,
+        clientId,
+        codeChallenge,
+        codeChallengeMethod,
+        consumed,
+        error,
+        errorDescription,
+        exp: number,
+        grantId,
+        iat: number,
+        iss: this.provider.issuer,
+        jti: upsert.getCall(0).args[0],
+        kind,
+        nonce,
+        params,
+        scope,
+        sid,
+        userCode,
+        deviceInfo,
       });
     });
 

--- a/test/storage/jwt.test.js
+++ b/test/storage/jwt.test.js
@@ -28,6 +28,7 @@ if (FORMAT === 'jwt') {
     const codeChallenge = 'codeChallenge';
     const codeChallengeMethod = 'codeChallengeMethod';
     const aud = [clientId, 'foo'];
+    const gty = 'foo';
     const error = 'access_denied';
     const errorDescription = 'resource owner denied access';
     const params = { foo: 'bar' };
@@ -38,7 +39,7 @@ if (FORMAT === 'jwt') {
     const fullPayload = {
       accountId, claims, clientId, grantId, scope, sid, consumed, acr, amr, authTime, nonce,
       redirectUri, codeChallenge, codeChallengeMethod, aud, error, errorDescription, params,
-      userCode, deviceInfo,
+      userCode, deviceInfo, gty,
     };
     /* eslint-enable object-property-newline */
 
@@ -59,32 +60,33 @@ if (FORMAT === 'jwt') {
       const jwt = await token.save();
 
       assert.calledWith(upsert, string, {
-        jwt: string,
-        grantId,
         accountId,
+        aud,
         claims,
         clientId,
-        aud,
-        scope,
-        sid,
-        kind,
+        exp: number,
+        grantId,
+        gty,
+        iat: number,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
-        iat: number,
-        exp: number,
+        jwt: string,
+        kind,
+        scope,
+        sid,
       });
 
       const { iat, jti, exp } = upsert.getCall(0).args[1];
       const payload = decode(jwt.split('.')[1]);
       expect(payload).to.eql({
-        iat,
-        jti,
-        exp,
-        sub: accountId,
-        azp: clientId,
         aud,
-        scope,
+        azp: clientId,
+        exp,
+        iat,
         iss: this.provider.issuer,
+        jti,
+        scope,
+        sub: accountId,
       });
     });
 
@@ -95,38 +97,38 @@ if (FORMAT === 'jwt') {
       const jwt = await token.save();
 
       assert.calledWith(upsert, string, {
-        jwt: string,
-        grantId,
-        consumed,
+        accountId,
         acr,
-        codeChallenge,
-        codeChallengeMethod,
         amr,
         authTime,
-        accountId,
         claims,
         clientId,
-        scope,
-        nonce,
-        redirectUri,
-        sid,
-        kind,
+        codeChallenge,
+        codeChallengeMethod,
+        consumed,
+        exp: number,
+        grantId,
+        iat: number,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
-        iat: number,
-        exp: number,
+        jwt: string,
+        kind,
+        nonce,
+        redirectUri,
+        scope,
+        sid,
       });
 
       const { iat, jti, exp } = upsert.getCall(0).args[1];
       const payload = decode(jwt.split('.')[1]);
       expect(payload).to.eql({
-        iat,
-        jti,
-        exp,
-        sub: accountId,
         aud: clientId,
-        scope,
+        exp,
+        iat,
         iss: this.provider.issuer,
+        jti,
+        scope,
+        sub: accountId,
       });
     });
 
@@ -137,35 +139,36 @@ if (FORMAT === 'jwt') {
       const jwt = await token.save();
 
       assert.calledWith(upsert, string, {
-        jwt: string,
-        grantId,
-        consumed,
         accountId,
         acr,
         amr,
         authTime,
         claims,
         clientId,
+        consumed,
+        exp: number,
+        grantId,
+        gty,
+        iat: number,
+        iss: this.provider.issuer,
+        jti: upsert.getCall(0).args[0],
+        jwt: string,
+        kind,
         nonce,
         scope,
         sid,
-        kind,
-        iss: this.provider.issuer,
-        jti: upsert.getCall(0).args[0],
-        iat: number,
-        exp: number,
       });
 
       const { iat, jti, exp } = upsert.getCall(0).args[1];
       const payload = decode(jwt.split('.')[1]);
       expect(payload).to.eql({
-        iat,
-        jti,
-        exp,
-        sub: accountId,
         aud: clientId,
-        scope,
+        exp,
+        iat,
         iss: this.provider.issuer,
+        jti,
+        scope,
+        sub: accountId,
       });
     });
 
@@ -176,7 +179,6 @@ if (FORMAT === 'jwt') {
       const jwt = await token.save();
 
       assert.calledWith(upsert, string, {
-        jwt,
         accountId,
         acr,
         amr,
@@ -186,20 +188,22 @@ if (FORMAT === 'jwt') {
         codeChallenge,
         codeChallengeMethod,
         consumed,
+        deviceInfo,
         error,
         errorDescription,
         exp: number,
         grantId,
+        gty,
         iat: number,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
+        jwt,
         kind,
         nonce,
         params,
         scope,
         sid,
         userCode,
-        deviceInfo,
       });
     });
 
@@ -210,27 +214,27 @@ if (FORMAT === 'jwt') {
       const jwt = await token.save();
 
       assert.calledWith(upsert, string, {
-        jwt: string,
-        clientId,
-        scope,
         aud,
-        kind,
+        clientId,
+        exp: number,
+        iat: number,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
-        iat: number,
-        exp: number,
+        jwt: string,
+        kind,
+        scope,
       });
 
       const { iat, jti, exp } = upsert.getCall(0).args[1];
       const payload = decode(jwt.split('.')[1]);
       expect(payload).to.eql({
-        iat,
-        jti,
-        exp,
-        azp: clientId,
         aud,
-        scope,
+        azp: clientId,
+        exp,
+        iat,
         iss: this.provider.issuer,
+        jti,
+        scope,
       });
     });
 
@@ -244,21 +248,21 @@ if (FORMAT === 'jwt') {
       const jwt = await token.save();
 
       assert.calledWith(upsert, string, {
-        jwt: string,
-        kind,
+        exp: number,
+        iat: number,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
-        iat: number,
-        exp: number,
+        jwt: string,
+        kind,
       });
 
       const { iat, jti, exp } = upsert.getCall(0).args[1];
       const payload = decode(jwt.split('.')[1]);
       expect(payload).to.eql({
-        iat,
-        jti,
         exp,
+        iat,
         iss: this.provider.issuer,
+        jti,
       });
     });
 
@@ -272,23 +276,23 @@ if (FORMAT === 'jwt') {
       const jwt = await token.save();
 
       assert.calledWith(upsert, string, {
-        jwt: string,
         clientId,
-        kind,
+        exp: number,
+        iat: number,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
-        iat: number,
-        exp: number,
+        jwt: string,
+        kind,
       });
 
       const { iat, jti, exp } = upsert.getCall(0).args[1];
       const payload = decode(jwt.split('.')[1]);
       expect(payload).to.eql({
-        iat,
-        jti,
-        exp,
         aud: clientId,
+        exp,
+        iat,
         iss: this.provider.issuer,
+        jti,
       });
     });
   });

--- a/test/storage/legacy.test.js
+++ b/test/storage/legacy.test.js
@@ -28,6 +28,7 @@ if (FORMAT === 'legacy') {
     const codeChallenge = 'codeChallenge';
     const codeChallengeMethod = 'codeChallengeMethod';
     const aud = [clientId, 'foo'];
+    const gty = 'foo';
     const error = 'access_denied';
     const errorDescription = 'resource owner denied access';
     const params = { foo: 'bar' };
@@ -38,7 +39,7 @@ if (FORMAT === 'legacy') {
     const fullPayload = {
       accountId, claims, clientId, grantId, scope, sid, consumed, acr, amr, authTime, nonce,
       redirectUri, codeChallenge, codeChallengeMethod, aud, error, errorDescription, params,
-      userCode, deviceInfo,
+      userCode, deviceInfo, gty,
     };
     /* eslint-enable object-property-newline */
 
@@ -70,15 +71,16 @@ if (FORMAT === 'legacy') {
       expect(exp).to.be.a('number');
       expect(payload).to.eql({
         accountId,
+        aud,
         claims,
         clientId,
-        aud,
         grantId,
-        scope,
-        sid,
-        kind,
+        gty,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
+        kind,
+        scope,
+        sid,
       });
     });
 
@@ -89,8 +91,8 @@ if (FORMAT === 'legacy') {
       await token.save();
 
       assert.calledWith(upsert, string, {
-        grantId,
         consumed,
+        grantId,
         header: string,
         payload: string,
         signature: string,
@@ -100,22 +102,22 @@ if (FORMAT === 'legacy') {
       expect(iat).to.be.a('number');
       expect(exp).to.be.a('number');
       expect(payload).to.eql({
+        accountId,
         acr,
-        codeChallenge,
-        codeChallengeMethod,
         amr,
         authTime,
-        accountId,
         claims,
         clientId,
+        codeChallenge,
+        codeChallengeMethod,
         grantId,
-        scope,
-        nonce,
-        redirectUri,
-        sid,
-        kind,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
+        kind,
+        nonce,
+        redirectUri,
+        scope,
+        sid,
       });
     });
 
@@ -126,8 +128,8 @@ if (FORMAT === 'legacy') {
       await token.save();
 
       assert.calledWith(upsert, string, {
-        grantId,
         consumed,
+        grantId,
         header: string,
         payload: string,
         signature: string,
@@ -144,12 +146,13 @@ if (FORMAT === 'legacy') {
         claims,
         clientId,
         grantId,
+        gty,
+        iss: this.provider.issuer,
+        jti: upsert.getCall(0).args[0],
+        kind,
         nonce,
         scope,
         sid,
-        kind,
-        iss: this.provider.issuer,
-        jti: upsert.getCall(0).args[0],
       });
     });
 
@@ -160,24 +163,18 @@ if (FORMAT === 'legacy') {
       await token.save();
 
       assert.calledWith(upsert, string, {
-        grantId,
-        userCode,
         consumed,
+        grantId,
         header: string,
         payload: string,
         signature: string,
+        userCode,
       });
 
       const { iat, exp, ...payload } = decode(upsert.getCall(0).args[1].payload);
       expect(iat).to.be.a('number');
       expect(exp).to.be.a('number');
       expect(payload).to.eql({
-        kind,
-        nonce,
-        params,
-        scope,
-        sid,
-        userCode,
         accountId,
         acr,
         amr,
@@ -186,12 +183,19 @@ if (FORMAT === 'legacy') {
         clientId,
         codeChallenge,
         codeChallengeMethod,
+        deviceInfo,
         error,
         errorDescription,
         grantId,
-        deviceInfo,
+        gty,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
+        kind,
+        nonce,
+        params,
+        scope,
+        sid,
+        userCode,
       });
     });
 
@@ -211,12 +215,12 @@ if (FORMAT === 'legacy') {
       expect(iat).to.be.a('number');
       expect(exp).to.be.a('number');
       expect(payload).to.eql({
-        clientId,
-        scope,
         aud,
-        kind,
+        clientId,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
+        kind,
+        scope,
       });
     });
 
@@ -239,9 +243,9 @@ if (FORMAT === 'legacy') {
       expect(iat).to.be.a('number');
       expect(exp).to.be.a('number');
       expect(payload).to.eql({
-        kind,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
+        kind,
       });
     });
 
@@ -265,9 +269,9 @@ if (FORMAT === 'legacy') {
       expect(exp).to.be.a('number');
       expect(payload).to.eql({
         clientId,
-        kind,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
+        kind,
       });
     });
   });

--- a/test/storage/opaque.test.js
+++ b/test/storage/opaque.test.js
@@ -22,17 +22,23 @@ if (FORMAT === 'opaque') {
     const codeChallenge = 'codeChallenge';
     const codeChallengeMethod = 'codeChallengeMethod';
     const aud = [clientId, 'foo'];
+    const error = 'access_denied';
+    const errorDescription = 'resource owner denied access';
+    const params = { foo: 'bar' };
+    const userCode = '1384-3217';
+    const deviceInfo = { foo: 'bar' };
 
     /* eslint-disable object-property-newline */
     const fullPayload = {
       accountId, claims, clientId, grantId, scope, sid, consumed, acr, amr, authTime, nonce,
-      redirectUri, codeChallenge, codeChallengeMethod, aud,
+      redirectUri, codeChallenge, codeChallengeMethod, aud, error, errorDescription, params,
+      userCode, deviceInfo,
     };
     /* eslint-enable object-property-newline */
 
     afterEach(function () {
       [
-        'AuthorizationCode', 'AccessToken', 'RefreshToken', 'ClientCredentials', 'InitialAccessToken', 'RegistrationAccessToken',
+        'AuthorizationCode', 'AccessToken', 'RefreshToken', 'ClientCredentials', 'InitialAccessToken', 'RegistrationAccessToken', 'DeviceCode',
       ].forEach((model) => {
         if (this.TestAdapter.for(model).upsert.restore) {
           this.TestAdapter.for(model).upsert.restore();
@@ -88,6 +94,39 @@ if (FORMAT === 'opaque') {
         jti: upsert.getCall(0).args[0],
         iat: number,
         exp: number,
+      });
+    });
+
+    it('for DeviceCode', async function () {
+      const kind = 'DeviceCode';
+      const upsert = spy(this.TestAdapter.for('DeviceCode'), 'upsert');
+      const token = new this.provider.DeviceCode(fullPayload);
+      await token.save();
+
+      assert.calledWith(upsert, string, {
+        accountId,
+        acr,
+        amr,
+        authTime,
+        claims,
+        clientId,
+        codeChallenge,
+        codeChallengeMethod,
+        consumed,
+        error,
+        errorDescription,
+        exp: number,
+        grantId,
+        iat: number,
+        iss: this.provider.issuer,
+        jti: upsert.getCall(0).args[0],
+        kind,
+        nonce,
+        params,
+        scope,
+        sid,
+        userCode,
+        deviceInfo,
       });
     });
 

--- a/test/storage/opaque.test.js
+++ b/test/storage/opaque.test.js
@@ -22,6 +22,7 @@ if (FORMAT === 'opaque') {
     const codeChallenge = 'codeChallenge';
     const codeChallengeMethod = 'codeChallengeMethod';
     const aud = [clientId, 'foo'];
+    const gty = 'foo';
     const error = 'access_denied';
     const errorDescription = 'resource owner denied access';
     const params = { foo: 'bar' };
@@ -32,7 +33,7 @@ if (FORMAT === 'opaque') {
     const fullPayload = {
       accountId, claims, clientId, grantId, scope, sid, consumed, acr, amr, authTime, nonce,
       redirectUri, codeChallenge, codeChallengeMethod, aud, error, errorDescription, params,
-      userCode, deviceInfo,
+      userCode, deviceInfo, gty,
     };
     /* eslint-enable object-property-newline */
 
@@ -53,18 +54,19 @@ if (FORMAT === 'opaque') {
       await token.save();
 
       assert.calledWith(upsert, string, {
-        grantId,
         accountId,
+        aud,
         claims,
         clientId,
-        aud,
-        scope,
-        sid,
-        kind,
+        exp: number,
+        grantId,
+        gty,
+        iat: number,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
-        iat: number,
-        exp: number,
+        kind,
+        scope,
+        sid,
       });
     });
 
@@ -75,25 +77,25 @@ if (FORMAT === 'opaque') {
       await token.save();
 
       assert.calledWith(upsert, string, {
-        grantId,
-        consumed,
+        accountId,
         acr,
-        codeChallenge,
-        codeChallengeMethod,
         amr,
         authTime,
-        accountId,
         claims,
         clientId,
-        scope,
-        nonce,
-        redirectUri,
-        sid,
-        kind,
+        codeChallenge,
+        codeChallengeMethod,
+        consumed,
+        exp: number,
+        grantId,
+        iat: number,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
-        iat: number,
-        exp: number,
+        kind,
+        nonce,
+        redirectUri,
+        scope,
+        sid,
       });
     });
 
@@ -113,10 +115,12 @@ if (FORMAT === 'opaque') {
         codeChallenge,
         codeChallengeMethod,
         consumed,
+        deviceInfo,
         error,
         errorDescription,
         exp: number,
         grantId,
+        gty,
         iat: number,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
@@ -126,7 +130,6 @@ if (FORMAT === 'opaque') {
         scope,
         sid,
         userCode,
-        deviceInfo,
       });
     });
 
@@ -137,22 +140,23 @@ if (FORMAT === 'opaque') {
       await token.save();
 
       assert.calledWith(upsert, string, {
-        grantId,
-        consumed,
         accountId,
         acr,
         amr,
         authTime,
         claims,
         clientId,
+        consumed,
+        exp: number,
+        grantId,
+        gty,
+        iat: number,
+        iss: this.provider.issuer,
+        jti: upsert.getCall(0).args[0],
+        kind,
         nonce,
         scope,
         sid,
-        kind,
-        iss: this.provider.issuer,
-        jti: upsert.getCall(0).args[0],
-        iat: number,
-        exp: number,
       });
     });
 
@@ -163,14 +167,14 @@ if (FORMAT === 'opaque') {
       await token.save();
 
       assert.calledWith(upsert, string, {
-        clientId,
-        scope,
         aud,
-        kind,
+        clientId,
+        exp: number,
+        iat: number,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
-        iat: number,
-        exp: number,
+        kind,
+        scope,
       });
     });
 
@@ -184,11 +188,11 @@ if (FORMAT === 'opaque') {
       await token.save();
 
       assert.calledWith(upsert, string, {
-        kind,
+        exp: number,
+        iat: number,
         iss: this.provider.issuer,
         jti: upsert.getCall(0).args[0],
-        iat: number,
-        exp: number,
+        kind,
       });
     });
 

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -96,6 +96,7 @@ module.exports = function testHelper(dir, { config: base = path.basename(dir), m
       this.state = Math.random().toString();
       this.nonce = Math.random().toString();
       this.redirect_uri = parameters.redirect_uri || clients[0].redirect_uris[0];
+      this.res = {};
 
       Object.assign(this, parameters);
 
@@ -130,6 +131,7 @@ module.exports = function testHelper(dir, { config: base = path.basename(dir), m
           const interaction = TestAdapter.for('Session').syncFind(grantid);
 
           Object.entries(this).forEach(([key, value]) => {
+            if (key === 'res') return;
             expect(interaction.params).to.have.property(key, value);
           });
         },
@@ -167,6 +169,9 @@ module.exports = function testHelper(dir, { config: base = path.basename(dir), m
       } else {
         expect(query).to.contain.keys(keys);
       }
+      keys.forEach((key) => {
+        this.res[key] = query[key];
+      });
     };
   };
 


### PR DESCRIPTION
📢 **_Calling for a review/comments from the users of this library._** 📢

**Adds Device Flow**

Based on [OAuth 2.0 Device Flow for Browserless and Input Constrained Devices - draft 10](https://tools.ietf.org/html/draft-ietf-oauth-device-flow-10) with added OIDC flavor

- device_authorization_endpoint accepts additional OIDC defined params (i.e. claims, request, request_uri, etc...) and processes them in the same way a regular OIDC authorization endpoint would
- device_authorization_endpoint ignores response_type, response_mode, state, redirect_uri params

> This OAuth 2.0 authorization flow for browserless and input
> constrained devices, often referred to as the device flow, enables
> OAuth clients to request user authorization from devices that have an
> Internet connection, but don't have an easy input method (such as a
> smart TV, media console, picture frame, or printer), or lack a
> suitable browser for a more traditional OAuth flow.  This
> authorization flow instructs the user to perform the authorization
> request on a secondary device, such as a smartphone.  There is no
> requirement for communication between the constrained device and the
> user's secondary device.

**Adds `gty` claim in storage for Access and Refresh Tokens**

This claim indicates the grants the token originates from, possible
values are:

- `implicit` (access token from authorization_endpoint)
- `authorization_code` (access/refresh token from authorization_code grant)
- `authorization_code refresh_token` (refreshed access/refresh token from authorization_code grant)
- `device_code` (access/refresh token from device_code grant)
- `device_code refresh_token` (refreshed access/refresh token from device_code grant)
