### PR TITLE
feat: option to setInteractionResult without calling interactionFinished

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -320,6 +320,27 @@ router.post('/interaction/:grant', async (ctx, next) => {
 }
 ```
 
+**`#provider.interactionResult`**
+Unlike `#provider.interactionFinished` redirect uri is returned instead of immediate http redirect.
+It should be used when custom response handling is needed e.g. making AJAX login where redirect uri 
+is expected to be available in the response.
+
+```js
+// with express
+expressApp.post('/interaction/:grant/login', async (req, res) => {
+  const redirectTo = await provider.interactionResult(req, res, results);
+  
+  res.send({ redirectTo });
+});
+
+// with koa
+router.post('/interaction/:grant', async (ctx, next) => {
+  const redirectTo = await provider.interactionResult(ctx.req, ctx.res, results);
+  
+  res.send({ redirectTo });
+});
+```
+
 **`#provider.setProviderSession`**
 Sometimes interactions need to be interrupted before finishing and need to be picked up later,
 or a session just needs to be established from outside the regular authorization request.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -321,9 +321,9 @@ router.post('/interaction/:grant', async (ctx, next) => {
 ```
 
 **`#provider.interactionResult`**
-Unlike `#provider.interactionFinished` redirect uri is returned instead of immediate http redirect.
-It should be used when custom response handling is needed e.g. making AJAX login where redirect uri 
-is expected to be available in the response.
+Unlike `#provider.interactionFinished` authorization request resume uri is returned instead of 
+immediate http redirect. It should be used when custom response handling is needed e.g. making AJAX 
+login where redirect information is expected to be available in the response.
 
 ```js
 // with express

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -197,27 +197,43 @@ class Provider extends events.EventEmitter {
     return [mountPath, routerUrl].join('');
   }
 
-  async setInteractionResult(req, res, result) {
+  /**
+   * @name interactionResult
+   * @api public
+   */
+  async interactionResult(req, res, result) {
     const interaction = await getInteraction.call(this, req, res);
     interaction.result = result;
     await interaction.save(interaction.exp - epochTime());
 
-    return interaction;
+    return interaction.returnTo;
   }
 
+  /**
+   * @name interactionFinished
+   * @api public
+   */
   async interactionFinished(req, res, result) {
-    const interaction = await this.setInteractionResult(req, res, result);
+    const returnTo = await this.interactionResult(req, res, result);
 
     res.statusCode = 302; // eslint-disable-line no-param-reassign
-    res.setHeader('Location', interaction.returnTo);
+    res.setHeader('Location', returnTo);
     res.setHeader('Content-Length', '0');
     res.end();
   }
 
+  /**
+   * @name interactionDetails
+   * @api public
+   */
   async interactionDetails(req) {
     return getInteraction.call(this, req);
   }
 
+  /**
+   * @name interactionDetails
+   * @api public
+   */
   async setProviderSession(req, res, {
     account,
     ts = epochTime(),

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -231,7 +231,7 @@ class Provider extends events.EventEmitter {
   }
 
   /**
-   * @name interactionDetails
+   * @name setProviderSession
    * @api public
    */
   async setProviderSession(req, res, {

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -197,10 +197,16 @@ class Provider extends events.EventEmitter {
     return [mountPath, routerUrl].join('');
   }
 
-  async interactionFinished(req, res, result) {
+  async setInteractionResult(req, res, result) {
     const interaction = await getInteraction.call(this, req, res);
     interaction.result = result;
     await interaction.save(interaction.exp - epochTime());
+
+    return interaction;
+  }
+
+  async interactionFinished(req, res, result) {
+    const interaction = await this.setInteractionResult(req, res, result);
 
     res.statusCode = 302; // eslint-disable-line no-param-reassign
     res.setHeader('Location', interaction.returnTo);


### PR DESCRIPTION
As already mentioned here #350. We have no clear way to propagate interaction result without causing response redirect. To allow custom response handling I'm submitting this non-breaking PR which simply extracts result propagation to its own method.

Now, instead of calling `provider. interactionFinished` we have option to call `provider.setInteractionResult` with same arguments to prevent immediate redirection.