### PR TITLE
Allow post_logout_uris array

### DIFF
--- a/lib/consts/client_attributes.js
+++ b/lib/consts/client_attributes.js
@@ -17,6 +17,7 @@ const RECOGNIZED_METADATA = [
   'logo_uri',
   'policy_uri',
   'redirect_uris',
+  'post_logout_redirect_uris',
   'require_auth_time',
   'response_types',
   'sector_identifier_uri',
@@ -148,6 +149,7 @@ const WEB_URI = [
 
   // in arrays
   'request_uris',
+  'post_logout_redirect_uris'
 ];
 
 const HTTPS_URI = [

--- a/lib/consts/param_list.js
+++ b/lib/consts/param_list.js
@@ -12,6 +12,7 @@ module.exports = [
   'nonce',
   'prompt',
   'redirect_uri',
+  'post_logout_redirect_uris',
   'registration',
   'request',
   'request_uri',


### PR DESCRIPTION
Without it when registering new clients the post_logout_redirect_uris are not saved in client records.