### PR TITLE
fix: allow http2 in assertReqRes (fixes #383)

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,7 +1,10 @@
+const HTTP2_SUPPORTED = Number(process.version.match(/^v(\d+)/)[1]) >= 10;
+
 const url = require('url');
 const assert = require('assert');
 const http = require('http');
 const events = require('events');
+const http2 = HTTP2_SUPPORTED ? require('http2') : null;
 
 const { get, merge } = require('lodash');
 const Koa = require('koa');
@@ -36,12 +39,14 @@ function getCookie(name, opts, cookies) {
 
 function assertReqRes(req, res) {
   assert(
-    req instanceof http.IncomingMessage,
+    req instanceof http.IncomingMessage
+    || (HTTP2_SUPPORTED && req instanceof http2.Http2ServerRequest),
     'first argument must be the request (http.IncomingMessage), for express req, for koa ctx.req',
   );
   if (arguments.length === 2) {
     assert(
-      res instanceof http.ServerResponse,
+      res instanceof http.ServerResponse
+      || (HTTP2_SUPPORTED && res instanceof http2.Http2ServerResponse),
       'second argument must be the response (http.ServerResponse), for express res, for koa ctx.res',
     );
   }

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -1,17 +1,23 @@
-const HTTP2_SUPPORTED = Number(process.version.match(/^v(\d+)/)[1]) >= 10;
-
 const url = require('url');
 const assert = require('assert');
-const http = require('http');
+const { IncomingMessage, ServerResponse } = require('http');
 const events = require('events');
-const http2 = HTTP2_SUPPORTED ? require('http2') : null;
 
 const { get, merge } = require('lodash');
 const Koa = require('koa');
 const delegate = require('delegates');
 const uuid = require('uuid/v4');
+const semver = require('semver');
 
 const pkg = require('../package.json');
+
+const HTTP2_STABLE = semver.satisfies(process.version, '>=10.10.0');
+let Http2ServerResponse;
+let Http2ServerRequest;
+/* istanbul ignore if */
+if (HTTP2_STABLE) {
+  ({ Http2ServerRequest, Http2ServerResponse } = require('http2')); // eslint-disable-line global-require
+}
 
 const { DEFAULT_HTTP_OPTIONS } = require('./consts');
 const attention = require('./helpers/attention');
@@ -39,15 +45,15 @@ function getCookie(name, opts, cookies) {
 
 function assertReqRes(req, res) {
   assert(
-    req instanceof http.IncomingMessage
-    || (HTTP2_SUPPORTED && req instanceof http2.Http2ServerRequest),
-    'first argument must be the request (http.IncomingMessage), for express req, for koa ctx.req',
+    req instanceof IncomingMessage
+    || (HTTP2_STABLE && req instanceof Http2ServerRequest),
+    'first argument must be the request (http.IncomingMessage || http2.Http2ServerRequest), for express req, for koa ctx.req',
   );
   if (arguments.length === 2) {
     assert(
-      res instanceof http.ServerResponse
-      || (HTTP2_SUPPORTED && res instanceof http2.Http2ServerResponse),
-      'second argument must be the response (http.ServerResponse), for express res, for koa ctx.res',
+      res instanceof ServerResponse
+      || (HTTP2_STABLE && res instanceof Http2ServerResponse),
+      'second argument must be the response (http.ServerResponse || http2.Http2ServerResponse), for express res, for koa ctx.res',
     );
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "object-hash": "^1.3.0",
     "oidc-token-hash": "^3.0.1",
     "raw-body": "^2.3.3",
+    "semver": "^5.6.0",
     "uuid": "^3.3.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This is the fix for #383 and adds support for http2 in `assertReqRes`.

The http2 module is only stable in node >= v10.0.0. Therefore http2 is only supported if node >= v10.0.0 is used.