### PR TITLE
refactor: enhance interactionResult function

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -377,23 +377,24 @@ router.post('/interaction/:grant', async (ctx, next) => {
 ```
 
 **`#provider.interactionResult`**
-Unlike `#provider.interactionFinished` authorization request resume uri is returned instead of
-immediate http redirect. It should be used when custom response handling is needed e.g. making AJAX
+Unlike `#provider.interactionFinished` will redirect to the resume uri immediately,
+the `#provider.interactionResult` will return the entire interaction result which 
+includes the resume uri. It is useful when custom response handling is needed e.g. making AJAX
 login where redirect information is expected to be available in the response.
 
 ```js
 // with express
 expressApp.post('/interaction/:grant/login', async (req, res) => {
-  const redirectTo = await provider.interactionResult(req, res, result);
+  const interaction = await provider.interactionResult(req, res, result);
 
-  res.send({ redirectTo });
+  res.send({ interaction.returnTo });
 });
 
 // with koa
 router.post('/interaction/:grant', async (ctx, next) => {
-  const redirectTo = await provider.interactionResult(ctx.req, ctx.res, result);
+  const interaction = await provider.interactionResult(ctx.req, ctx.res, result);
 
-  ctx.body = { redirectTo };
+  ctx.body = { interaction.returnTo };
 });
 ```
 

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -222,7 +222,7 @@ class Provider extends events.EventEmitter {
     interaction.result = result;
     await interaction.save(interaction.exp - epochTime());
 
-    return interaction.returnTo;
+    return interaction;
   }
 
   /**
@@ -230,10 +230,10 @@ class Provider extends events.EventEmitter {
    * @api public
    */
   async interactionFinished(req, res, result) {
-    const returnTo = await this.interactionResult(req, res, result);
+    const interaction = await this.interactionResult(req, res, result);
 
     res.statusCode = 302; // eslint-disable-line no-param-reassign
-    res.setHeader('Location', returnTo);
+    res.setHeader('Location', interaction.returnTo);
     res.setHeader('Content-Length', '0');
     res.end();
   }


### PR DESCRIPTION
In order to reduce additional query effort for interaction details, I would like to expose much more information in `interactionResult` function, typically, the entire interaction result!

On the other hand, returning the entire interaction result is more consistent with the name of the method. after all, `interaction result` not only contains `returnTo`.

BTW: the `interactionResult` will do the `session` check as well. 
