### PR TITLE
feat: make refreshing a keystore safer

### DIFF
--- a/lib/helpers/jwt.js
+++ b/lib/helpers/jwt.js
@@ -2,10 +2,16 @@ const assert = require('assert');
 
 const base64url = require('base64url');
 const {
-  JWK: { isKeyStore },
+  JWK: { createKeyStore },
   JWS: { createSign, createVerify },
   JWE: { createEncrypt, createDecrypt },
 } = require('node-jose');
+
+const JWKStore = createKeyStore().constructor;
+
+function isKeyStore(obj) {
+  return obj instanceof JWKStore;
+}
 
 const epochTime = require('./epoch_time');
 

--- a/lib/helpers/jwt.js
+++ b/lib/helpers/jwt.js
@@ -108,7 +108,7 @@ class JWT {
     try {
       verified = await createVerify(keyOrStore).verify(jwt);
     } catch (err) {
-      if (isKeyStore(keyOrStore) && keyOrStore.stale && keyOrStore.stale()) {
+      if (isKeyStore(keyOrStore)) {
         await keyOrStore.refresh();
         verified = await createVerify(keyOrStore).verify(jwt);
       } else {

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -112,7 +112,8 @@ Object.defineProperties(JWKStore.prototype, {
     },
   },
   refresh: {
-    async value() {
+    async value(force = false) {
+      if (!force && this.fresh()) return;
       try {
         const {
           headers,

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -105,6 +105,7 @@ Object.defineProperties(JWKStore.prototype, {
       const now = epochTime();
       return !!this.freshUntil && this.freshUntil > now;
     },
+    configurable: true,
   },
   stale: {
     value() {
@@ -112,8 +113,8 @@ Object.defineProperties(JWKStore.prototype, {
     },
   },
   refresh: {
-    async value(force = false) {
-      if (!force && this.fresh()) return;
+    async value() {
+      if (this.fresh()) return;
       try {
         const {
           headers,

--- a/lib/models/id_token.js
+++ b/lib/models/id_token.js
@@ -137,7 +137,7 @@ module.exports = function getIdToken(provider) {
       }
 
       if (!encryption.enc) return signed;
-      if (client.keystore.stale()) await client.keystore.refresh();
+      await client.keystore.refresh();
 
       const encryptionKey = client.keystore.get({ alg: encryption.alg, use: 'enc' });
       if (!encryptionKey) {

--- a/lib/shared/token_auth.js
+++ b/lib/shared/token_auth.js
@@ -203,7 +203,7 @@ module.exports = function tokenAuth(provider, endpoint) {
               throw new InvalidClientAuth('client cert was not provided');
             }
 
-            if (ctx.oidc.client.keystore.stale()) await ctx.oidc.client.keystore.refresh();
+            await ctx.oidc.client.keystore.refresh();
 
             const normalized = cert.replace(/(?:-----(?:BEGIN|END) CERTIFICATE-----|\s)/g, '');
             const match = ctx.oidc.client.keystore.all().find((key) => {

--- a/test/configuration/client_keystore.test.js
+++ b/test/configuration/client_keystore.test.js
@@ -54,7 +54,7 @@ describe('client keystore refresh', () => {
     await keystore.generate('EC', 'P-256');
     setResponse();
 
-    await client.keystore.refresh();
+    await client.keystore.refresh(true);
     expect(client.keystore.all({ kty: 'EC' })).to.have.lengthOf(2);
   });
 
@@ -62,7 +62,7 @@ describe('client keystore refresh', () => {
     setResponse({ keys: [] });
 
     const client = await this.provider.Client.find('client');
-    await client.keystore.refresh();
+    await client.keystore.refresh(true);
 
     expect(client.keystore.get({ kty: 'EC' })).not.to.be.ok;
   });
@@ -71,7 +71,7 @@ describe('client keystore refresh', () => {
     setResponse('/somewhere', 302);
 
     const client = await this.provider.Client.find('client');
-    await client.keystore.refresh().then(fail, (err) => {
+    await client.keystore.refresh(true).then(fail, (err) => {
       expect(err).to.be.an('error');
       expect(err.message).to.equal('invalid_client_metadata');
       expect(err.error_description).to.match(/jwks_uri could not be refreshed/);
@@ -83,7 +83,7 @@ describe('client keystore refresh', () => {
     setResponse('not json');
 
     const client = await this.provider.Client.find('client');
-    await client.keystore.refresh().then(fail, (err) => {
+    await client.keystore.refresh(true).then(fail, (err) => {
       expect(err).to.be.an('error');
       expect(err.message).to.equal('invalid_client_metadata');
       expect(err.error_description).to.match(/jwks_uri could not be refreshed/);
@@ -95,7 +95,7 @@ describe('client keystore refresh', () => {
     setResponse({ keys: {} });
 
     const client = await this.provider.Client.find('client');
-    await client.keystore.refresh().then(fail, (err) => {
+    await client.keystore.refresh(true).then(fail, (err) => {
       expect(err).to.be.an('error');
       expect(err.message).to.equal('invalid_client_metadata');
       expect(err.error_description).to.match(/jwks_uri could not be refreshed/);
@@ -115,7 +115,7 @@ describe('client keystore refresh', () => {
 
       const freshUntil = epochTime(until);
 
-      await client.keystore.refresh();
+      await client.keystore.refresh(true);
       expect(client.keystore.fresh()).to.be.true;
       expect(client.keystore.stale()).to.be.false;
       expect(client.keystore.freshUntil).to.equal(freshUntil);
@@ -133,7 +133,7 @@ describe('client keystore refresh', () => {
 
       const freshUntil = epochTime(until);
 
-      await client.keystore.refresh();
+      await client.keystore.refresh(true);
       expect(client.keystore.fresh()).to.be.true;
       expect(client.keystore.stale()).to.be.false;
       expect(client.keystore.freshUntil).to.equal(freshUntil);
@@ -149,7 +149,7 @@ describe('client keystore refresh', () => {
 
       const freshUntil = epochTime() + 3600;
 
-      await client.keystore.refresh();
+      await client.keystore.refresh(true);
       expect(client.keystore.fresh()).to.be.true;
       expect(client.keystore.stale()).to.be.false;
       expect(client.keystore.freshUntil).to.be.closeTo(freshUntil, 1);
@@ -163,7 +163,7 @@ describe('client keystore refresh', () => {
 
       const freshUntil = epochTime() + 60;
 
-      await client.keystore.refresh();
+      await client.keystore.refresh(true);
       expect(client.keystore.fresh()).to.be.true;
       expect(client.keystore.stale()).to.be.false;
       expect(client.keystore.freshUntil).to.be.closeTo(freshUntil, 1);


### PR DESCRIPTION
This move the staleness check (which contains a
check if a jwks_uri exists) into the refresh method.
This reduces some duplication and makes it easier
to use for people who interact with `client.keystore`.

I added an option to force a refresh, as this was
needed to enable the tests to pass.

#415