### PR TITLE
Passed ctx into id factory

### DIFF
--- a/lib/actions/registration.js
+++ b/lib/actions/registration.js
@@ -91,7 +91,7 @@ module.exports = {
       const { oidc: { provider } } = ctx;
       const { idFactory, secretFactory } = instance(provider).configuration('features.registration');
       const properties = {};
-      const clientId = String(idFactory());
+      const clientId = String(idFactory(ctx));
 
       const rat = new provider.RegistrationAccessToken({ clientId });
       ctx.oidc.entity('RegistrationAccessToken', rat);


### PR DESCRIPTION
@panva Do you think that this change would be in the spirit of the openid standards?

Here's the use case: I would like to generate client_ids based on the Origin header during dynamic registration. I'll then use the client_id to validate if provided redirect URLs are valid (only redirect urls with the same hostname as the client_id will be allowed). I know that "it’s best that it isn’t guessable by third parties" (https://www.oauth.com/oauth2-servers/client-registration/client-id-secret/), but putting the extra restriction on the redirect should negate that weakness.

For more information on the reasoning behind this, see this thread (https://github.com/solid/webid-oidc-spec/issues/12#issuecomment-481835310)