### PR TITLE
fix: add scope to implicit responses when different from request

### DIFF
--- a/lib/actions/authorization/process_response_types.js
+++ b/lib/actions/authorization/process_response_types.js
@@ -28,11 +28,17 @@ async function tokenHandler(ctx) {
 
   ctx.oidc.entity('AccessToken', token);
 
-  return {
+  const result = {
     access_token: await token.save(),
     expires_in: token.expiration,
     token_type: 'Bearer',
   };
+
+  if (token.scope !== ctx.oidc.params.scope) {
+    result.scope = token.scope;
+  }
+
+  return result;
 }
 
 async function codeHandler(ctx) {

--- a/test/core/hybrid/code+id_token+token.authorization.test.js
+++ b/test/core/hybrid/code+id_token+token.authorization.test.js
@@ -105,6 +105,30 @@ describe('HYBRID code+id_token+token', () => {
       });
     });
 
+    describe(`${verb} ${route} with the scope not being fulfilled`, () => {
+      before(function () {
+        return this.login({
+          scope: 'openid profile email',
+          rejectedScopes: ['email'],
+        });
+      });
+
+      it('responds with an extra parameter scope', async function () {
+        const auth = new this.AuthorizationRequest({
+          response_type,
+          scope: 'openid profile email',
+        });
+
+        await this.wrap({ route, verb, auth })
+          .expect(302)
+          .expect(auth.validateFragment)
+          .expect(auth.validatePresence(['code', 'id_token', 'state', 'access_token', 'expires_in', 'token_type', 'scope']))
+          .expect(auth.validateState)
+          .expect(auth.validateClientLocation)
+          .expect(auth.validateResponseParameter('scope', 'openid profile'));
+      });
+    });
+
     describe(`${verb} ${route} errors`, () => {
       it('disallowed response mode', function () {
         const spy = sinon.spy();

--- a/test/core/hybrid/code+token.authorization.test.js
+++ b/test/core/hybrid/code+token.authorization.test.js
@@ -76,6 +76,30 @@ describe('HYBRID code+token', () => {
       });
     });
 
+    describe(`${verb} ${route} with the scope not being fulfilled`, () => {
+      before(function () {
+        return this.login({
+          scope: 'openid profile email',
+          rejectedScopes: ['email'],
+        });
+      });
+
+      it('responds with an extra parameter scope', async function () {
+        const auth = new this.AuthorizationRequest({
+          response_type,
+          scope: 'openid profile email',
+        });
+
+        await this.wrap({ route, verb, auth })
+          .expect(302)
+          .expect(auth.validateFragment)
+          .expect(auth.validatePresence(['code', 'state', 'access_token', 'expires_in', 'token_type', 'scope']))
+          .expect(auth.validateState)
+          .expect(auth.validateClientLocation)
+          .expect(auth.validateResponseParameter('scope', 'openid profile'));
+      });
+    });
+
     describe(`${verb} ${route} errors`, () => {
       it('disallowed response mode', function () {
         const spy = sinon.spy();

--- a/test/core/implicit/id_token+token.authorization.test.js
+++ b/test/core/implicit/id_token+token.authorization.test.js
@@ -83,6 +83,30 @@ describe('IMPLICIT id_token+token', () => {
       });
     });
 
+    describe(`${verb} ${route} with the scope not being fulfilled`, () => {
+      before(function () {
+        return this.login({
+          scope: 'openid profile email',
+          rejectedScopes: ['email'],
+        });
+      });
+
+      it('responds with an extra parameter scope', async function () {
+        const auth = new this.AuthorizationRequest({
+          response_type,
+          scope: 'openid profile email',
+        });
+
+        await this.wrap({ route, verb, auth })
+          .expect(302)
+          .expect(auth.validateFragment)
+          .expect(auth.validatePresence(['id_token', 'state', 'access_token', 'expires_in', 'token_type', 'scope']))
+          .expect(auth.validateState)
+          .expect(auth.validateClientLocation)
+          .expect(auth.validateResponseParameter('scope', 'openid profile'));
+      });
+    });
+
     describe(`${verb} ${route} errors`, () => {
       it('disallowed response mode', function () {
         const spy = sinon.spy();

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -233,37 +233,27 @@ module.exports = function testHelper(dir, { config: base = path.basename(dir), m
     };
   };
 
-  AuthorizationRequest.prototype.validateError = function (expected) {
+  AuthorizationRequest.prototype.validateResponseParameter = function (parameter, expected) {
     return (response) => {
-      const { query: { error } } = parse(response.headers.location, true);
+      const { query: { [parameter]: value } } = parse(response.headers.location, true);
       if (expected.exec) {
-        expect(error).to.match(expected);
+        expect(value).to.match(expected);
       } else {
-        expect(error).to.equal(expected);
+        expect(value).to.equal(expected);
       }
     };
+  };
+
+  AuthorizationRequest.prototype.validateError = function (expected) {
+    return this.validateResponseParameter('error', expected);
   };
 
   AuthorizationRequest.prototype.validateScope = function (expected) {
-    return (response) => {
-      const { query: { scope } } = parse(response.headers.location, true);
-      if (expected.exec) {
-        expect(scope).to.match(expected);
-      } else {
-        expect(scope).to.equal(expected);
-      }
-    };
+    return this.validateResponseParameter('scope', expected);
   };
 
   AuthorizationRequest.prototype.validateErrorDescription = function (expected) {
-    return (response) => {
-      const { query: { error_description } } = parse(response.headers.location, true);
-      if (expected.exec) {
-        expect(error_description).to.match(expected);
-      } else {
-        expect(error_description).to.equal(expected);
-      }
-    };
+    return this.validateResponseParameter('error_description', expected);
   };
 
   function getSession({ instantiate } = { instantiate: false }) {


### PR DESCRIPTION
`scope` in authorization response must exist if it is not equal to the one requested by client. 

>   The authorization server MAY fully or partially ignore the scope
>    requested by the client, based on the authorization server policy or
>    the resource owner's instructions.  If the issued access token scope
>    is different from the one requested by the client, the authorization
>    server MUST include the "scope" response parameter to inform the
>    client of the actual scope granted.
See [RFC6749](https://tools.ietf.org/html/rfc6749#section-3.3)

It is stated as optional in [Section 5.1 - Issuing an Access Token - Successful Response](https://tools.ietf.org/html/rfc6749#section-5.1)

>    scope
>    &nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL, if identical to the scope requested by the client;
>    &nbsp;&nbsp;&nbsp;&nbsp;otherwise, REQUIRED.  The scope of the access token as
>    &nbsp;&nbsp;&nbsp;&nbsp;described by Section 3.3.

Also you could see `scope` is optional in token responses for all OAuth2 grant types.
See followings:
[Authorization Code Grant](https://tools.ietf.org/html/rfc6749#section-4.1.4)
[Implicit Grant](https://tools.ietf.org/html/rfc6749#section-4.2.2)
[Resource Owner Password Credentials Grant](https://tools.ietf.org/html/rfc6749#section-4.3.3)
[Client Credentials Grant](https://tools.ietf.org/html/rfc6749#section-4.4.3)
