### PR TITLE
idTokenSigningAlgValues uses whitelistedJWA

### DIFF
--- a/lib/helpers/client_schema.js
+++ b/lib/helpers/client_schema.js
@@ -157,9 +157,9 @@ module.exports = function getSchema(provider) {
     id_token_encrypted_response_enc: () => configuration.idTokenEncryptionEncValues,
     id_token_signed_response_alg: (metadata) => {
       if (!metadata.response_types.join(' ').includes('id_token')) {
-        return configuration.idTokenSigningAlgValues;
+        return configuration.whitelistedJWA.idTokenSigningAlgValues;
       }
-      return _.without(configuration.idTokenSigningAlgValues, 'none');
+      return _.without(configuration.whitelistedJWA.idTokenSigningAlgValues, 'none');
     },
     request_object_signing_alg: () => configuration.requestObjectSigningAlgValues,
     request_object_encryption_alg: () => configuration.requestObjectEncryptionAlgValues,


### PR DESCRIPTION
Before this used an `idTokenSigningAlgValues` from the root configuration. I'm not exactly sure what this was generated by, but it's value was only `['HS256']`. This caused problems for my RP which registered without an `id_token_signing_alg_values` and defaulted to `RS256`