### PR TITLE
feat: added TypeScript definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ oidc-provider allows to be extended and configured in various ways to fit a vari
 the [available configuration](/docs/README.md).
 
 ```js
-const Provider = require('oidc-provider');
+const { Provider } = require('oidc-provider');
 const configuration = {
   // ... see available options /docs
   clients: [{
@@ -121,6 +121,33 @@ oidc.app
 
 // or just expose a server standalone, see /examples/standalone.js
 const server = oidc.listen(3000, () => {
+  console.log('oidc-provider listening on port 3000, check http://localhost:3000/.well-known/openid-configuration');
+});
+```
+
+```ts
+import * as oidc from 'oidc-provider';
+
+const configuration = {
+  // ... see available options /docs
+  clients: [{
+    client_id: 'foo',
+    client_secret: 'bar',
+    redirect_uris: ['http://lvh.me:8080/cb'],
+    // + other client properties
+  }],
+};
+
+const provider = new oidc.Provider('http://localhost:3000', configuration);
+
+// express/nodejs style application callback (req, res, next) for use with express apps, see /examples/express.js
+provider.callback
+
+// koa application for use with koa apps, see /examples/koa.js
+provider.app
+
+// or just expose a server standalone, see /examples/standalone.js
+const server = provider.listen(3000, () => {
   console.log('oidc-provider listening on port 3000, check http://localhost:3000/.well-known/openid-configuration');
 });
 ```

--- a/certification/docker.js
+++ b/certification/docker.js
@@ -6,7 +6,7 @@ const https = require('https');
 const pem = require('https-pem');
 const render = require('koa-ejs');
 
-const Provider = require('../lib'); // require('oidc-provider');
+const { Provider } = require('../lib'); // require('oidc-provider');
 const Account = require('../example/support/account');
 const routes = require('../example/routes/koa');
 

--- a/certification/fapi/index.js
+++ b/certification/fapi/index.js
@@ -6,7 +6,7 @@ const jose = require('@panva/jose');
 const helmet = require('koa-helmet');
 const pem = require('https-pem');
 
-const Server = require('../../lib'); // require('oidc-provider');
+const { Provider } = require('../../lib'); // require('oidc-provider');
 
 const OFFICIAL_CERTIFICATION = 'https://www.certification.openid.net';
 const { PORT = 3000, ISSUER = `http://localhost:${PORT}`, SUITE_BASE_URL = OFFICIAL_CERTIFICATION } = process.env;
@@ -21,7 +21,7 @@ const JWK_PKJWTTWO = jose.JWK.asKey(readFileSync(path.join(__dirname, 'pkjwttwo.
 const JWK_MTLSONE = jose.JWK.asKey(readFileSync(path.join(__dirname, 'mtlsone.key')), { x5c: [normalize(readFileSync(path.join(__dirname, 'mtlsone.crt')))], alg: 'PS256', use: 'sig' }).toJWK();
 const JWK_MTLSTWO = jose.JWK.asKey(readFileSync(path.join(__dirname, 'mtlstwo.key')), { x5c: [normalize(readFileSync(path.join(__dirname, 'mtlstwo.crt')))], alg: 'PS256', use: 'sig' }).toJWK();
 
-const fapi = new Server(ISSUER, {
+const fapi = new Provider(ISSUER, {
   acrValues: ['urn:mace:incommon:iap:silver'],
   routes: {
     userinfo: '/accounts',

--- a/certification/oidc.js
+++ b/certification/oidc.js
@@ -6,7 +6,7 @@ const set = require('lodash/set');
 const render = require('koa-ejs');
 const helmet = require('koa-helmet');
 
-const Provider = require('../lib'); // require('oidc-provider');
+const { Provider } = require('../lib'); // require('oidc-provider');
 const Account = require('../example/support/account');
 const routes = require('../example/routes/koa');
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,7 +96,7 @@ If you or your business use oidc-provider, please consider becoming a [sponsor][
 ## Basic configuration example
 
 ```js
-const Provider = require('oidc-provider');
+const { Provider } = require('oidc-provider');
 const configuration = {
   // ... see the available options in Configuration options section
   features: {

--- a/docs/events.md
+++ b/docs/events.md
@@ -56,8 +56,6 @@ loaded client or session.
 | `registration_read.error` | `(ctx, error)` | ... whenever a handled error is encountered in the GET `registration` endpoint |
 | `registration_update.error` | `(ctx, error)` | ... whenever a handled error is encountered in the PUT `registration` endpoint |
 | `registration_update.success` | `(ctx, client)` | ... with every successful update client registration request |
-| `replay_detection.destroyed` | `(replay)` | ... whenever replay detection document is destroyed |
-| `replay_detection.saved` | `(replay)` | ... whenever replay detection document is saved |
 | `revocation.error` | `(ctx, error)` | ... whenever a handled error is encountered in the `revocation` endpoint |
 | `server_error` | `(ctx, error)` | ... whenever an exception is thrown or promise rejected from   either the Provider or your provided  adapters. If it comes from the library you should probably report it |
 | `session.destroyed` | `(session)` | ... whenever session is destroyed |

--- a/example/express.js
+++ b/example/express.js
@@ -7,7 +7,7 @@ const set = require('lodash/set');
 const express = require('express'); // eslint-disable-line import/no-unresolved
 const helmet = require('helmet');
 
-const Provider = require('../lib'); // require('oidc-provider');
+const { Provider } = require('../lib'); // require('oidc-provider');
 
 const Account = require('./support/account');
 const configuration = require('./support/configuration');

--- a/example/koa.js
+++ b/example/koa.js
@@ -8,7 +8,7 @@ const render = require('koa-ejs');
 const helmet = require('koa-helmet');
 const mount = require('koa-mount');
 
-const Provider = require('../lib'); // require('oidc-provider');
+const { Provider } = require('../lib'); // require('oidc-provider');
 
 const Account = require('./support/account');
 const configuration = require('./support/configuration');

--- a/example/my_adapter.js
+++ b/example/my_adapter.js
@@ -123,7 +123,7 @@ class MyAdapter {
      * - kind {string} - "Interaction" fixed string value
      * - exp {number} - timestamp of the interaction's expiration
      * - iat {number} - timestamp of the interaction's creation
-     * - uid {number} - the uid of the authorizing client's established session
+     * - uid {string} - the uid of the authorizing client's established session
      * - returnTo {string} - after resolving interactions send the user-agent to this url
      * - params {object} - parsed recognized parameters object
      * - lastSubmission {object} - previous interaction result submission
@@ -141,7 +141,6 @@ class MyAdapter {
      * - kind {string} - "ReplayDetection" fixed string value
      * - exp {number} - timestamp of the replay object cache expiration
      * - iat {number} - timestamp of the replay object cache's creation
-     * - replay {object} - the object replay prevention is calculated from
      */
   }
 

--- a/example/standalone.js
+++ b/example/standalone.js
@@ -6,7 +6,7 @@ const set = require('lodash/set');
 const render = require('koa-ejs');
 const helmet = require('koa-helmet');
 
-const Provider = require('../lib'); // require('oidc-provider');
+const { Provider } = require('../lib'); // require('oidc-provider');
 
 const Account = require('./support/account');
 const configuration = require('./support/configuration');

--- a/lib/actions/authorization/device_authorization_response.js
+++ b/lib/actions/authorization/device_authorization_response.js
@@ -9,8 +9,6 @@ module.exports = async function deviceAuthorizationResponse(ctx, next) {
 
   const dc = new ctx.oidc.provider.DeviceCode({
     client: ctx.oidc.client,
-    codeChallenge: ctx.oidc.params.code_challenge,
-    codeChallengeMethod: ctx.oidc.params.code_challenge_method,
     deviceInfo: deviceInfo(ctx),
     grantId: ctx.oidc.uid,
     params: ctx.oidc.params.toPlainObject(),

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@ const errors = require('./helpers/errors');
 const { DYNAMIC_SCOPE_LABEL } = require('./consts');
 
 module.exports = Provider;
+module.exports.Provider = Provider;
 module.exports.errors = errors;
 module.exports.DYNAMIC_SCOPE_LABEL = DYNAMIC_SCOPE_LABEL;
 module.exports.interactionPolicy = require('./helpers/interaction_policy');

--- a/lib/models/session.js
+++ b/lib/models/session.js
@@ -133,7 +133,7 @@ module.exports = function getSession(provider) {
       this.destroyed = true; // TODO:
     }
 
-    async resetIdentifier() {
+    resetIdentifier() {
       this.oldId = this.id;
       this.id = nanoid();
       this.touched = true;

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -128,6 +128,7 @@ class Provider extends events.EventEmitter {
 
     const grantParams = new Set(['grant_type']);
     grantTypeHandlers.set(name, handler);
+
     if (dupes && typeof dupes === 'string') {
       grantTypeDupes.set(name, new Set([dupes]));
     } else if (dupes && (Array.isArray(dupes) || dupes instanceof Set)) {
@@ -139,6 +140,7 @@ class Provider extends events.EventEmitter {
     } else if (params && (Array.isArray(params) || params instanceof Set)) {
       params.forEach(Set.prototype.add.bind(grantParams));
     }
+
     grantTypeParams.set(name, grantParams);
     grantParams.forEach(Set.prototype.add.bind(grantTypeParams.get(undefined)));
   }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
   "author": "Filip Skokan <panva.ip@gmail.com>",
   "files": [
     "lib",
-    "docs/*.md",
-    "recipes/*.md"
+    "types/index.d.ts"
   ],
   "main": "lib/index.js",
+  "types": "types/index.d.ts",
   "scripts": {
     "coverage": "nyc node ./test/run",
     "heroku-postbuild": "npm install mongodb@^3.0.0 openid-client@^3.0.0",
@@ -43,6 +43,9 @@
   "dependencies": {
     "@koa/cors": "^3.0.0",
     "@panva/jose": "^1.8.0",
+    "@types/cookies": "^0.7.2",
+    "@types/koa": "^2.0.49",
+    "@types/node": "^12.7.4",
     "bowser": "^2.5.3",
     "debug": "^4.1.1",
     "ejs": "^2.6.2",
@@ -63,6 +66,7 @@
     "base64url": "^3.0.1",
     "chai": "^4.2.0",
     "clear-module": "^4.0.0",
+    "dtslint": "^0.9.6",
     "eslint": "^6.2.2",
     "eslint-config-airbnb-base": "^14.0.0",
     "eslint-plugin-import": "^2.18.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "coverage": "nyc node ./test/run",
     "heroku-postbuild": "npm install mongodb@^3.0.0 openid-client@^3.0.0",
-    "lint": "eslint lib example certification test",
+    "lint": "eslint lib example certification test && dtslint --onlyTestTsNext types",
     "lint-fix": "eslint lib example certification test --fix",
     "test": "node ./test/run"
   },

--- a/test/body_parser/body_parser.test.js
+++ b/test/body_parser/body_parser.test.js
@@ -5,7 +5,7 @@ const upstreamParser = require('koa-body');
 const sinon = require('sinon');
 const { expect } = require('chai');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('body parser', () => {
   afterEach(() => {

--- a/test/client_auth/client_auth.test.js
+++ b/test/client_auth/client_auth.test.js
@@ -8,7 +8,7 @@ const cloneDeep = require('lodash/cloneDeep');
 
 const runtimeSupport = require('../../lib/helpers/runtime_support');
 const nanoid = require('../../lib/helpers/nanoid');
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 const bootstrap = require('../test_helper');
 const clientKey = require('../client.sig.key');
 const JWT = require('../../lib/helpers/jwt');

--- a/test/configuration/account_find_by_id.test.js
+++ b/test/configuration/account_find_by_id.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('default findAccount behavior', () => {
   it('returns a promise', () => {

--- a/test/configuration/client_metadata.test.js
+++ b/test/configuration/client_metadata.test.js
@@ -7,7 +7,7 @@ const pull = require('lodash/pull');
 const cloneDeep = require('lodash/cloneDeep');
 
 const runtimeSupport = require('../../lib/helpers/runtime_support');
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 const { whitelistedJWA } = require('../default.config');
 const mtlsKeys = require('../jwks/jwks.json');
 

--- a/test/configuration/constructor.test.js
+++ b/test/configuration/constructor.test.js
@@ -2,7 +2,7 @@
 
 const { expect } = require('chai');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('Provider configuration', () => {
   describe('clients', () => {

--- a/test/configuration/custom_client_metadata.test.js
+++ b/test/configuration/custom_client_metadata.test.js
@@ -3,7 +3,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 const { InvalidClientMetadata } = require('../../lib/helpers/errors');
 
 describe('extraClientMetadata configuration', () => {

--- a/test/configuration/interaction_url.test.js
+++ b/test/configuration/interaction_url.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('pathFor related behaviors', () => {
   it('throws an Error when invalid route path is requested', () => {

--- a/test/configuration/issuer.test.js
+++ b/test/configuration/issuer.test.js
@@ -4,7 +4,7 @@ const { strict: assert } = require('assert');
 
 const { expect } = require('chai');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('Provider issuer configuration', () => {
   it('validates the issuer input to be present and valid', () => {

--- a/test/configuration/keystore_configuration.test.js
+++ b/test/configuration/keystore_configuration.test.js
@@ -3,7 +3,7 @@
 const jose = require('@panva/jose');
 const { expect } = require('chai');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('configuration.jwks', () => {
   beforeEach(function () {

--- a/test/configuration/omit_algs.test.js
+++ b/test/configuration/omit_algs.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const jose = require('@panva/jose');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('Provider declaring supported algorithms', () => {
   it('validates the configuration properties', () => {

--- a/test/configuration/pairwise.test.js
+++ b/test/configuration/pairwise.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('Provider configuration', () => {
   it('validates subjectTypes members', () => {

--- a/test/configuration/request_uris.test.js
+++ b/test/configuration/request_uris.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('client.requestUris', () => {
   it('defaults to empty array when registration of them is a must', () => {

--- a/test/configuration/response_types.test.js
+++ b/test/configuration/response_types.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('response_types Provider configuration', () => {
   it('fixes common issues', () => {

--- a/test/configuration/scopes_claims.test.js
+++ b/test/configuration/scopes_claims.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('custom claims', () => {
   it('allows for claims to be added under openid scope using array syntax', () => {

--- a/test/device_code/device_code.test.js
+++ b/test/device_code/device_code.test.js
@@ -1,6 +1,6 @@
 const { expect } = require('chai');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 const bootstrap = require('../test_helper');
 
 describe('configuration features.deviceFlow', () => {

--- a/test/jwt_introspection/jwt_introspection.test.js
+++ b/test/jwt_introspection/jwt_introspection.test.js
@@ -2,7 +2,7 @@ const { expect } = require('chai');
 
 const bootstrap = require('../test_helper');
 const JWT = require('../../lib/helpers/jwt');
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 const route = '/token/introspection';
 

--- a/test/provider/provider_instance.test.js
+++ b/test/provider/provider_instance.test.js
@@ -1,7 +1,7 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('provider instance', () => {
   context('draft/experimental spec warnings', () => {

--- a/test/pushed_request_objects/pushed_request_objects.test.js
+++ b/test/pushed_request_objects/pushed_request_objects.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 
 const JWT = require('../../lib/helpers/jwt');
 const bootstrap = require('../test_helper');
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('Pushed Request Object', () => {
   before(bootstrap(__dirname));

--- a/test/registration_management/registration_management.test.js
+++ b/test/registration_management/registration_management.test.js
@@ -3,7 +3,7 @@ const sinon = require('sinon');
 const { expect } = require('chai');
 
 const bootstrap = require('../test_helper');
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 describe('OAuth 2.0 Dynamic Client Registration Management Protocol', () => {
   before(bootstrap(__dirname));

--- a/test/registration_policies/registration_policies.test.js
+++ b/test/registration_policies/registration_policies.test.js
@@ -6,7 +6,7 @@ const sinon = require('sinon');
 const { expect } = require('chai');
 
 const bootstrap = require('../test_helper');
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 
 const fail = () => { throw new Error('expected promise to be rejected'); };
 

--- a/test/request/jwt_request.test.js
+++ b/test/request/jwt_request.test.js
@@ -4,7 +4,7 @@ const jose = require('@panva/jose');
 const sinon = require('sinon');
 const { expect } = require('chai');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 const JWT = require('../../lib/helpers/jwt');
 const bootstrap = require('../test_helper');
 

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -17,7 +17,7 @@ const KeyGrip = require('keygrip'); // eslint-disable-line import/no-extraneous-
 
 const nanoid = require('../lib/helpers/nanoid');
 const epochTime = require('../lib/helpers/epoch_time');
-const Provider = require('../lib');
+const { Provider } = require('../lib');
 
 const { Account, TestAdapter } = require('./models');
 

--- a/test/userinfo/userinfo.test.js
+++ b/test/userinfo/userinfo.test.js
@@ -3,7 +3,7 @@ const url = require('url');
 const { expect } = require('chai');
 const sinon = require('sinon');
 
-const Provider = require('../../lib');
+const { Provider } = require('../../lib');
 const bootstrap = require('../test_helper');
 
 describe('userinfo /me', () => {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -911,7 +911,7 @@ export interface Configuration {
     };
   };
 
-  extraAccessTokenClaims?: (ctx: KoaContextWithOIDC, token: AccessToken | ClientCredentials) => Promise<object> | object | Promise<void> | void;
+  extraAccessTokenClaims?: (ctx: KoaContextWithOIDC, token: AccessToken | ClientCredentials) => Promise<AnyObject> | AnyObject | Promise<void> | void;
 
   formats?: {
     AccessToken?: AccessTokenFormatFunction | TokenFormat;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,1465 @@
+/// <reference types="node" />
+
+import * as events from 'events';
+import * as http from 'http';
+import * as http2 from 'http2';
+import * as https from 'https';
+import * as net from 'net';
+import * as tls from 'tls';
+
+import * as jose from '@panva/jose';
+import * as cookies from 'cookies';
+import * as Koa from 'koa';
+
+export {};
+
+export type RetryFunction = (retry: number, error: Error) => number;
+export type FindAccount = (ctx: KoaContextWithOIDC, sub: string, token: object) => Account;
+export type TokenFormat = 'opaque' | 'jwt' | 'jwt-ietf' | 'paseto';
+
+export type AccessTokenFormatFunction = (ctx: KoaContextWithOIDC, token: AccessToken) => TokenFormat;
+export type ClientCredentialsFormatFunction = (ctx: KoaContextWithOIDC, token: ClientCredentials) => TokenFormat;
+
+export type AccessTokenTTLFunction = (ctx: KoaContextWithOIDC, accessToken: AccessToken, client: Client) => number;
+export type AuthorizationCodeTTLFunction = (ctx: KoaContextWithOIDC, authorizationCode: AuthorizationCode, client: Client) => number;
+export type ClientCredentialsTTLFunction = (ctx: KoaContextWithOIDC, clientCredentials: ClientCredentials, client: Client) => number;
+export type DeviceCodeTTLFunction = (ctx: KoaContextWithOIDC, deviceCode: DeviceCode, client: Client) => number;
+export type IdTokenTTLFunction = (ctx: KoaContextWithOIDC, idToken: IdToken, client: Client) => number;
+export type RefreshTokenTTLFunction = (ctx: KoaContextWithOIDC, refreshToken: RefreshToken, client: Client) => number;
+
+export interface AnyObject {
+  [key: string]: unknown;
+}
+
+/**
+ * @see https://github.com/sindresorhus/got/tree/v9.6.0#options
+ */
+export interface HttpRequestOptions extends tls.SecureContextOptions {
+  url?: string;
+  headers?: AnyObject;
+  query?: AnyObject;
+  body?: AnyObject;
+  form?: boolean;
+  json?: boolean;
+  timeout?: number | {
+    lookup?: number;
+    connect?: number;
+    secureConnect?: number;
+    socket?: number;
+    response?: number;
+    send?: number;
+    request?: number;
+  };
+  retry?: number | {
+    retries?: number | RetryFunction;
+    methods?: Array<'GET' | 'POST' | 'PUT' | 'HEAD' | 'DELETE' | 'OPTIONS' | 'TRACE'>;
+    statusCodes?: Array<408 | 413 | 429 | 500 | 502 | 503 | 504>;
+    maxRetryAfter?: number;
+    errorCodes?: string[];
+  };
+  followRedirect?: boolean;
+  throwHttpErrors?: boolean;
+  agent?: http.Agent | https.Agent | boolean | {
+    http: http.Agent,
+    https: https.Agent,
+  };
+
+  [key: string]: unknown;
+}
+
+export interface ClientMetadata {
+  client_id: string;
+  redirect_uris: string[];
+  grant_types?: string[];
+  response_types?: ResponseType[];
+
+  application_type?: 'web' | 'native';
+  client_id_issued_at?: number;
+  client_name?: string;
+  client_secret_expires_at?: number;
+  client_secret?: string;
+  client_uri?: string;
+  contacts?: string[];
+  default_acr_values?: string[];
+  default_max_age?: number;
+  id_token_signed_response_alg?: string;
+  initiate_login_uri?: string;
+  jwks_uri?: string;
+  jwks?: jose.JSONWebKeySet;
+  logo_uri?: string;
+  policy_uri?: string;
+  post_logout_redirect_uris?: string[];
+  require_auth_time?: boolean;
+  scope?: string;
+  sector_identifier_uri?: string;
+  subject_type?: SubjectTypes;
+  token_endpoint_auth_method?: ClientAuthMethod;
+  tos_uri?: string;
+
+  tls_client_auth_subject_dn?: string;
+  tls_client_auth_san_dns?: string;
+  tls_client_auth_san_uri?: string;
+  tls_client_auth_san_ip?: string;
+  tls_client_auth_san_email?: string;
+  token_endpoint_auth_signing_alg?: string;
+  userinfo_signed_response_alg?: string;
+  introspection_endpoint_auth_method?: ClientAuthMethod;
+  introspection_endpoint_auth_signing_alg?: string;
+  introspection_signed_response_alg?: string;
+  introspection_encrypted_response_alg?: string;
+  introspection_encrypted_response_enc?: string;
+  revocation_endpoint_auth_method?: ClientAuthMethod;
+  revocation_endpoint_auth_signing_alg?: string;
+  backchannel_logout_session_required?: boolean;
+  backchannel_logout_uri?: string;
+  frontchannel_logout_session_required?: boolean;
+  frontchannel_logout_uri?: string;
+  request_object_signing_alg?: string;
+  request_object_encryption_alg?: string;
+  request_object_encryption_enc?: string;
+  request_uris?: string[];
+  id_token_encrypted_response_alg?: string;
+  id_token_encrypted_response_enc?: string;
+  userinfo_encrypted_response_alg?: string;
+  userinfo_encrypted_response_enc?: string;
+  authorization_signed_response_alg?: string;
+  authorization_encrypted_response_alg?: string;
+  authorization_encrypted_response_enc?: string;
+  web_message_uris?: string[];
+  tls_client_certificate_bound_access_tokens?: boolean;
+
+  [key: string]: unknown;
+}
+
+export type ResponseType = 'code' | 'id_token' | 'code id_token' | 'code token' | 'code id_token token' | 'none';
+export type PKCEMethods = 'S256' | 'plain';
+export type SubjectTypes = 'public' | 'pairwise';
+export type ClientAuthMethod = 'client_secret_basic' | 'client_secret_post' | 'client_secret_jwt' | 'private_key_jwt' | 'tls_client_auth' | 'self_signed_tls_client_auth' | 'none';
+
+export interface ClaimsParameterMember {
+  essential?: boolean;
+  value?: string;
+  values?: string[];
+
+  [key: string]: unknown;
+}
+
+export interface ClaimsParameter {
+  id_token?: {
+    [key: string]: null | ClaimsParameterMember
+  };
+  userinfo?: {
+    [key: string]: null | ClaimsParameterMember
+  };
+}
+
+export interface ClaimsWithRejects extends ClaimsParameter {
+  rejected?: string[];
+}
+
+export interface ClientAuthorizationState {
+  persistsLogout?: boolean;
+  sid?: string;
+  grantId?: string;
+  meta?: AnyObject;
+  rejectedScopes?: string[];
+  rejectedClaims?: string[];
+  promptedClaims?: string[];
+  promptedScopes?: string[];
+}
+
+declare class Interaction {
+  readonly kind: 'Interaction';
+  iat: number;
+  exp: number;
+  session?: {
+    accountId: string;
+    cookie: string;
+    jti?: string;
+    acr?: string;
+    amr?: string[];
+  };
+  params: AnyObject;
+  prompt: {
+    name: 'login' | 'consent' | string;
+    reasons: string[];
+    details: AnyObject;
+  };
+  result: InteractionResults;
+  returnTo: string;
+  signed?: string[];
+  uid: string;
+  lastSubmission?: InteractionResults;
+
+  save(ttl?: number): Promise<void>;
+}
+
+declare class Session {
+  readonly kind: 'Session';
+  iat: number;
+  exp: number;
+  uid: string;
+  jti: string;
+
+  account?: string;
+  acr?: string;
+  amr?: string[];
+  loginTs?: number;
+  transient?: boolean;
+  state?: AnyObject;
+  authorizations?: {
+    [clientId: string]: ClientAuthorizationState;
+  };
+
+  accountId(): string | void;
+  authTime(): string | void;
+  past(age: number): boolean;
+
+  ensureClientContainer(clientId: string): void;
+  loginAccount(details: {
+    account: string;
+    acr?: string;
+    amr?: string[];
+    loginTs?: number;
+    transient?: boolean;
+  }): void;
+  authorizationFor(clientId: string): ClientAuthorizationState | void;
+  stateFor(clientId: string): string;
+  sidFor(clientId: string): string;
+  sidFor(clientId: string, value: string): void;
+  grantIdFor(clientId: string): string;
+  grantIdFor(clientId: string, value: string): void;
+  metaFor(clientId: string): AnyObject | void;
+  metaFor(clientId: string, value: string): void;
+  acceptedScopesFor(clientId: string): Set<string>;
+  acceptedClaimsFor(clientId: string): Set<string>;
+  promptedScopesFor(clientId: string): Set<string>;
+  promptedScopesFor(clientId: string, scopes: string[]): void;
+  promptedClaimsFor(clientId: string): Set<string>;
+  promptedClaimsFor(clientId: string, claims: string[]): void;
+  rejectedScopesFor(clientId: string): Set<string>;
+  rejectedScopesFor(clientId: string, scopes: string[], replace?: boolean): void;
+  rejectedClaimsFor(clientId: string): Set<string>;
+  rejectedClaimsFor(clientId: string, claims: string[], replace?: boolean): void;
+
+  save(ttl?: number): Promise<void>;
+  destroy(): Promise<void>;
+  resetIdentifier(): void;
+  static find(cookieId: string): Promise<Session | undefined>;
+  static findByUid(uid: string): Promise<Session | undefined>;
+  static get(ctx: Koa.Context): Promise<Session>;
+}
+
+declare class RequestUriCache {
+  resolveUrn(urn: string): Promise<string>;
+  resolveWebUri(requestUri: string): Promise<string>;
+}
+
+declare class JWTStructured {
+  header?: AnyObject;
+  payload: AnyObject;
+}
+
+declare class PASETOStructured {
+  footer?: AnyObject | Buffer | string;
+  payload: AnyObject;
+}
+
+declare class BaseToken {
+  iat: number;
+  exp?: number;
+  jti: string;
+  readonly kind: string;
+  clientId?: string;
+  client?: Client;
+  readonly format?: string;
+  readonly scopes: Set<string>;
+
+  ttlPercentagePassed(): boolean;
+
+  readonly isValid: boolean;
+  readonly isExpired: boolean;
+  readonly remainingTTL: number;
+  readonly expiration: number;
+
+  static IN_PAYLOAD: string[];
+
+  static find(jti: string, options?: { ignoreExpiration?: boolean }): Promise<BaseToken>;
+  save(): Promise<string>;
+
+  readonly adapter: Adapter;
+  static readonly adapter: Adapter;
+}
+
+declare class ReplayDetection {
+  readonly kind: 'ReplayDetection';
+  unique(iss: string, jti: string, exp?: number): Promise<boolean>;
+
+  readonly adapter: Adapter;
+  static readonly adapter: Adapter;
+}
+
+declare class RequestObject extends BaseToken {
+  constructor(properties: { request: string });
+  readonly kind: 'RequestObject';
+  request: string;
+
+  static find(jti: string, options?: { ignoreExpiration?: boolean }): Promise<RequestObject>;
+}
+
+declare class RefreshToken extends BaseToken {
+  constructor(properties: {
+    client: Client;
+    accountId: string;
+    acr?: string;
+    amr?: string[];
+    authTime?: number;
+    claims?: ClaimsWithRejects;
+    nonce?: string;
+    resource?: string | string[];
+    scope: string;
+    sid?: string;
+    sessionUid?: string;
+    expiresWithSession?: boolean;
+    'x5t#S256'?: string;
+    'jkt#S256'?: string;
+    grantId: string;
+    gty: string;
+    [key: string]: unknown;
+  });
+  readonly kind: 'RefreshToken';
+  rotations?: number;
+  iiat?: number;
+  accountId: string;
+  acr?: string;
+  amr?: string[];
+  authTime?: number;
+  claims?: ClaimsWithRejects;
+  nonce?: string;
+  resource?: string | string[];
+  scope?: string;
+  sid?: string;
+  sessionUid?: string;
+  expiresWithSession?: boolean;
+  'x5t#S256'?: string;
+  'jkt#S256'?: string;
+  grantId?: string;
+  gty?: string;
+  consumed: any;
+
+  totalLifetime(): number;
+  isSenderConstrained(): boolean;
+  consume(): Promise<void>;
+
+  static find(jti: string, options?: { ignoreExpiration?: boolean }): Promise<RefreshToken>;
+}
+
+declare class AuthorizationCode extends BaseToken {
+  constructor(properties: {
+    client: Client;
+    accountId: string;
+    redirectUri?: string;
+    acr?: string;
+    amr?: string[];
+    authTime?: number;
+    claims?: ClaimsWithRejects;
+    nonce?: string;
+    resource?: string | string[];
+    codeChallenge?: string;
+    codeChallengeMethod?: string;
+    scope: string;
+    sid?: string;
+    sessionUid?: string;
+    expiresWithSession?: boolean;
+    'x5t#S256'?: string;
+    'jkt#S256'?: string;
+    grantId: string;
+    gty: string;
+    [key: string]: unknown;
+  });
+  readonly kind: 'AuthorizationCode';
+  redirectUri?: string;
+  codeChallenge?: string;
+  codeChallengeMethod?: string;
+  accountId?: string;
+  acr?: string;
+  amr?: string[];
+  authTime?: number;
+  claims?: ClaimsWithRejects;
+  nonce?: string;
+  resource?: string | string[];
+  scope?: string;
+  sid?: string;
+  sessionUid?: string;
+  expiresWithSession?: boolean;
+  'x5t#S256'?: string;
+  'jkt#S256'?: string;
+  grantId?: string;
+  gty?: string;
+
+  consume(): Promise<void>;
+
+  static find(jti: string, options?: { ignoreExpiration?: boolean }): Promise<RefreshToken>;
+}
+
+declare class DeviceCode extends BaseToken {
+  constructor(properties: {
+    params: AnyObject;
+    userCode: string;
+    grantId: string;
+    client: Client;
+    deviceInfo: AnyObject;
+    [key: string]: unknown;
+  });
+  readonly kind: 'DeviceCode';
+  error?: string;
+  errorDescription?: string;
+  params?: AnyObject;
+  userCode: string;
+  inFlight?: boolean;
+  deviceInfo?: AnyObject;
+  codeChallenge?: string;
+  codeChallengeMethod?: string;
+  accountId?: string;
+  acr?: string;
+  amr?: string[];
+  authTime?: number;
+  claims?: ClaimsWithRejects;
+  nonce?: string;
+  resource?: string | string[];
+  scope?: string;
+  sid?: string;
+  sessionUid?: string;
+  expiresWithSession?: boolean;
+  grantId: string;
+  gty: string;
+  consumed: any;
+
+  consume(): Promise<void>;
+
+  static find(jti: string, options?: { ignoreExpiration?: boolean }): Promise<DeviceCode>;
+}
+
+declare class ClientCredentials extends BaseToken {
+  constructor(properties: {
+    client: Client;
+    resource?: string | string[];
+    scope: string;
+    [key: string]: unknown;
+  });
+  readonly kind: 'ClientCredentials';
+  scope?: string;
+  extra?: AnyObject;
+  aud: string | string[];
+  readonly tokenType: string;
+  'x5t#S256'?: string;
+  'jkt#S256'?: string;
+
+  setAudiences(audience: string | string[]): void;
+  isSenderConstrained(): boolean;
+}
+
+declare class InitialAccessToken extends BaseToken {
+  constructor(properties?: {
+    expiresIn?: number;
+    policies?: string[];
+    [key: string]: unknown;
+  });
+  readonly kind: 'InitialAccessToken';
+  clientId: undefined;
+  policies?: string[];
+
+  static find(jti: string, options?: { ignoreExpiration?: boolean }): Promise<InitialAccessToken>;
+}
+
+declare class RegistrationAccessToken extends BaseToken {
+  readonly kind: 'RegistrationAccessToken';
+  policies?: string[];
+
+  static find(jti: string, options?: { ignoreExpiration?: boolean }): Promise<RegistrationAccessToken>;
+}
+
+declare class AccessToken extends BaseToken {
+  constructor(properties: {
+    client: Client;
+    accountId: string;
+    claims?: ClaimsWithRejects;
+    aud?: string | string[];
+    scope: string;
+    sid?: string;
+    sessionUid?: string;
+    expiresWithSession?: boolean;
+    'x5t#S256'?: string;
+    'jkt#S256'?: string;
+    grantId: string;
+    gty: string;
+    [key: string]: unknown;
+  });
+  readonly kind: 'AccessToken';
+  accountId: string;
+  aud: string | string[];
+  claims?: ClaimsWithRejects;
+  extra?: AnyObject;
+  grantId: string;
+  scope?: string;
+  gty: string;
+  sid?: string;
+  sessionUid?: string;
+  expiresWithSession?: boolean;
+  readonly tokenType: string;
+  'x5t#S256'?: string;
+  'jkt#S256'?: string;
+
+  setAudiences(audience: string | string[]): void;
+  isSenderConstrained(): boolean;
+
+  static find(jti: string, options?: { ignoreExpiration?: boolean }): Promise<AccessToken>;
+}
+
+declare class IdToken {
+  constructor(claims: AnyObject, context?: { ctx?: KoaContextWithOIDC, client?: Client });
+
+  readonly ctx: KoaContextWithOIDC;
+  readonly client: Client;
+  readonly available: AnyObject;
+  readonly extra: AnyObject;
+
+  set(key: string, value: any): void;
+  payload(): Promise<AnyObject>;
+  issue(context?: { use: 'idtoken' | 'logout' | 'userinfo' | 'introspection' | 'authorization', expiresAt?: number }): Promise<string>;
+  validate(idToken: string, client: Client): Promise<{ header: AnyObject, payload: AnyObject }>;
+}
+
+declare class ClientKeystore {
+  fresh(): boolean;
+  stale(): boolean;
+  refresh(): Promise<void>;
+  readonly size: number;
+  all(parameters?: jose.JWKS.KeyQuery): jose.JWK.Key[];
+  get(parameters?: jose.JWKS.KeyQuery): jose.JWK.Key;
+  toJWKS(private?: boolean): jose.JSONWebKeySet;
+}
+
+declare class Client {
+  responseTypeAllowed(type: ResponseType): boolean;
+  grantTypeAllowed(type: string): boolean;
+  redirectUriAllowed(redirectUri: string): boolean;
+  checkSessionOriginAllowed(origin: string): boolean;
+  webMessageUriAllowed(webMessageUri: string): boolean;
+  requestUriAllowed(requestUri: string): boolean;
+  postLogoutRedirectUriAllowed(postLogoutRedirectUri: string): boolean;
+  includeSid(): boolean;
+
+  metadata(): ClientMetadata;
+
+  readonly keystore: ClientKeystore;
+
+  readonlyclientId: string;
+
+  readonly grantTypes?: string[];
+  readonly redirectUris?: string[];
+  readonly responseTypes?: ResponseType[];
+
+  readonly applicationType?: 'web' | 'native';
+  readonly clientIdIssuedAt?: number;
+  readonly clientName?: string;
+  readonly clientSecretExpiresAt?: number;
+  readonly clientSecret?: string;
+  readonly clientUri?: string;
+  readonly contacts?: string[];
+  readonly defaultAcrValues?: string[];
+  readonly defaultMaxAge?: number;
+  readonly idTokenSignedResponseAlg?: string;
+  readonly initiateLoginUri?: string;
+  readonly jwksUri?: string;
+  readonly jwks?: jose.JSONWebKeySet;
+  readonly logoUri?: string;
+  readonly policyUri?: string;
+  readonly postLogoutRedirectUris?: string[];
+  readonly requireAuthTime?: boolean;
+  readonly scope?: string;
+  readonly sectorIdentifierUri?: string;
+  readonly subjectType?: SubjectTypes;
+  readonly tokenEndpointAuthMethod?: string;
+  readonly tosUri?: string;
+
+  readonly tlsClientAuthSubjectDn?: string;
+  readonly tlsClientAuthSanDns?: string;
+  readonly tlsClientAuthSanUri?: string;
+  readonly tlsClientAuthSanIp?: string;
+  readonly tlsClientAuthSanEmail?: string;
+  readonly tokenEndpointAuthSigningAlg?: string;
+  readonly userinfoSignedResponseAlg?: string;
+  readonly introspectionEndpointAuthMethod?: string;
+  readonly introspectionEndpointAuthSigningAlg?: string;
+  readonly introspectionSignedResponseAlg?: string;
+  readonly introspectionEncryptedResponseAlg?: string;
+  readonly introspectionEncryptedResponseEnc?: string;
+  readonly revocationEndpointAuthMethod?: string;
+  readonly revocationEndpointAuthSigningAlg?: string;
+  readonly backchannelLogoutSessionRequired?: boolean;
+  readonly backchannelLogoutUri?: string;
+  readonly frontchannelLogoutSessionRequired?: boolean;
+  readonly frontchannelLogoutUri?: string;
+  readonly requestObjectSigningAlg?: string;
+  readonly requestObjectEncryptionAlg?: string;
+  readonly requestObjectEncryptionEnc?: string;
+  readonly requestUris?: string[];
+  readonly idTokenEncryptedResponseAlg?: string;
+  readonly idTokenEncryptedResponseEnc?: string;
+  readonly userinfoEncryptedResponseAlg?: string;
+  readonly userinfoEncryptedResponseEnc?: string;
+  readonly authorizationSignedResponseAlg?: string;
+  readonly authorizationEncryptedResponseAlg?: string;
+  readonly authorizationEncryptedResponseEnc?: string;
+  readonly webMessageUris?: string[];
+  readonly tlsClientCertificateBoundAccessTokens?: boolean;
+
+  [key: string]: unknown;
+
+  static find(id: string): Promise<Client>;
+}
+
+declare class OIDCContext {
+  readonly route: string;
+  uid: string;
+  readonly entities: {
+    readonly AccessToken?: AccessToken;
+    readonly Account?: Account;
+    readonly AuthorizationCode?: AuthorizationCode;
+    readonly Client?: Client;
+    readonly ClientCredentials?: ClientCredentials;
+    readonly DeviceCode?: DeviceCode;
+    readonly IdTokenHint?: { header: AnyObject, payload: AnyObject };
+    readonly InitialAccessToken?: InitialAccessToken;
+    readonly RefreshToken?: RefreshToken;
+    readonly RegistrationAccessToken?: RegistrationAccessToken;
+    readonly RequestObject?: RequestObject;
+    readonly RotatedRefreshToken?: RefreshToken;
+    readonly RotatedRegistrationAccessToken?: RegistrationAccessToken;
+    readonly [key: string]: unknown;
+  };
+  readonly claims: ClaimsParameter;
+  readonly issuer: string;
+  readonly provider: Provider;
+
+  entity(key: string, value: any): void;
+
+  promptPending(name: string): boolean;
+
+  readonly requestParamClaims: Set<string>;
+  readonly requestParamScopes: Set<string>;
+  readonly prompts: Set<string>;
+
+  readonly registrationAccessToken?: RegistrationAccessToken;
+  readonly deviceCode?: DeviceCode;
+  readonly accessToken?: AccessToken;
+  readonly account?: Account;
+  readonly client?: Client;
+  readonly acr: string;
+  readonly amr: string[];
+
+  acceptedScope(): string[] | void;
+  resolvedClaims(): ClaimsWithRejects;
+
+  getAccessToken(opts?: { acceptDPoP?: boolean, acceptQueryParam?: boolean }): string;
+}
+
+export interface KoaContextWithOIDC extends Koa.Context {
+  oidc: OIDCContext;
+}
+
+export const DYNAMIC_SCOPE_LABEL: symbol;
+
+export type TLSClientAuthProperty = 'tls_client_auth_subject_dn' | 'tls_client_auth_san_dns' | 'tls_client_auth_san_uri' | 'tls_client_auth_san_ip' | 'tls_client_auth_san_email';
+
+export interface AccountClaims {
+  sub: string;
+
+  [key: string]: unknown;
+}
+
+export interface Account {
+  accountId: string;
+  claims: (use: string, scope: string, claims: { [key: string]: null | ClaimsParameterMember }, rejected: string[]) => Promise<AccountClaims> | AccountClaims;
+}
+
+export type RotateRegistrationAccessTokenFunction = (ctx: KoaContextWithOIDC) => Promise<boolean> | boolean;
+
+export interface ErrorOut {
+  error: string;
+  error_description?: string;
+  scope?: string;
+  state?: string;
+}
+
+export interface AdapterPayload {
+  account?: string;
+  accountId?: string;
+  acr?: string;
+  amr?: string[];
+  aud?: string[];
+  authorizations?: {
+    [clientId: string]: ClientAuthorizationState;
+  };
+  authTime?: number;
+  claims?: ClaimsWithRejects;
+  clientId?: string;
+  codeChallenge?: string;
+  codeChallengeMethod?: string;
+  deviceInfo?: AnyObject;
+  error?: string;
+  errorDescription?: string;
+  exp?: number;
+  expiresWithSession?: boolean;
+  extra?: AnyObject;
+  format?: string;
+  grantId?: string;
+  gty?: string;
+  iat?: number;
+  iiat?: number;
+  inFlight?: boolean;
+  jti?: string;
+  jwt?: string;
+  kind?: string;
+  lastSubmission?: InteractionResults;
+  loginTs?: number;
+  nonce?: string;
+  params?: AnyObject;
+  paseto?: string;
+  policies?: string[];
+  redirectUri?: string;
+  request?: string;
+  resource?: string;
+  result?: InteractionResults;
+  returnTo?: string;
+  rotations?: number;
+  scope?: string;
+  session?: {
+    accountId?: string;
+    acr?: string;
+    amr?: string[];
+    cookie?: string;
+    uid?: string;
+  };
+  sessionUid?: string;
+  sid?: string;
+  signed?: string[];
+  state?: AnyObject;
+  transient?: boolean;
+  uid?: string;
+  userCode?: string;
+  'jkt#S256'?: string;
+  'jwt-ietf'?: string;
+  'x5t#S256'?: string;
+}
+
+export interface Adapter {
+  upsert(id: string, payload: AdapterPayload, expiresIn: number): Promise<void>;
+  find(id: string): Promise<AdapterPayload | undefined>;
+  findByUserCode(userCode: string): Promise<AdapterPayload | undefined>;
+  findByUid(uid: string): Promise<AdapterPayload | undefined>;
+  consume(id: string): Promise<void>;
+  destroy(id: string): Promise<void>;
+  revokeByGrantId(grantId: string): Promise<void>;
+}
+
+export interface AdapterConstructor {
+  new(name: string): Adapter;
+}
+
+export interface Configuration {
+  acrValues?: string[] | Set<string>;
+
+  adapter?: AdapterConstructor;
+
+  claims?: {
+    [key: string]: null | string[]
+  };
+
+  clientBasedCORS?: (ctx: KoaContextWithOIDC, origin: string, client: Client) => boolean;
+
+  clients?: ClientMetadata[];
+
+  clientDefaults?: ClientMetadata;
+
+  clockTolerance?: number;
+
+  conformIdTokenClaims?: boolean;
+
+  cookies?: {
+    names?: {
+      session?: string;
+      interaction?: string;
+      resume?: string;
+      state?: string;
+    };
+    long?: cookies.SetOption,
+    short?: cookies.SetOption,
+    keys?: string[] | Buffer[];
+  };
+
+  discovery?: AnyObject;
+
+  extraParams?: string[];
+
+  features?: {
+    devInteractions?: { enabled?: boolean };
+
+    claimsParameter?: { enabled?: boolean };
+
+    clientCredentials?: { enabled?: boolean };
+
+    introspection?: { enabled?: boolean };
+
+    revocation?: { enabled?: boolean };
+
+    userinfo?: { enabled?: boolean };
+
+    jwtUserinfo?: { enabled?: boolean };
+
+    encryption?: { enabled?: boolean };
+
+    registration?: {
+      enabled?: boolean;
+      initialAccessToken?: boolean | string;
+      policies?: {
+        [key: string]: (ctx: KoaContextWithOIDC, metadata: ClientMetadata) => void;
+      };
+      idFactory?: () => string;
+      secretFactory?: () => string;
+    };
+
+    registrationManagement?: {
+      enabled?: boolean;
+      rotateRegistrationAccessToken?: RotateRegistrationAccessTokenFunction | boolean
+    };
+
+    deviceFlow?: {
+      enabled?: boolean;
+      charset?: 'base-20' | 'digits';
+      mask?: string;
+      deviceInfo?: (ctx: KoaContextWithOIDC) => AnyObject;
+      userCodeInputSource?: (ctx: KoaContextWithOIDC, form: string, out: ErrorOut, err: errors.OIDCProviderError | Error) => Promise<void> | void;
+      userCodeConfirmSource?: (ctx: KoaContextWithOIDC, form: string, client: Client, deviceInfo: AnyObject, userCode: string) => Promise<void> | void;
+      successSource?: (ctx: KoaContextWithOIDC) => Promise<void> | void;
+    };
+
+    requestObjects?: {
+      request?: boolean;
+      requestUri?: boolean;
+      requireUriRegistration?: boolean;
+      mergingStrategy?: {
+        name?: 'lax' | 'strict' | 'whitelist',
+        whitelist?: string[] | Set<string>;
+      };
+    };
+    dPoP?: { enabled?: boolean, iatTolerance?: number, ack?: number | string },
+
+    sessionManagement?: { enabled?: boolean, keepHeaders?: boolean, ack?: number | string },
+
+    backchannelLogout?: { enabled?: boolean, ack?: number | string },
+
+    ietfJWTAccessTokenProfile?: { enabled?: boolean, ack?: number | string },
+
+    fapiRW?: { enabled?: boolean, ack?: number | string },
+
+    webMessageResponseMode?: { enabled?: boolean, ack?: number | string },
+
+    jwtIntrospection?: { enabled?: boolean, ack?: number | string },
+
+    jwtResponseModes?: { enabled?: boolean, ack?: number | string },
+
+    pushedRequestObjects?: { enabled?: boolean, ack?: number | string },
+
+    mTLS?: {
+      enabled?: boolean;
+      ack?: number | string;
+      certificateBoundAccessTokens?: boolean;
+      selfSignedTlsClientAuth?: boolean;
+      tlsClientAuth?: boolean;
+      getCertificate?: (ctx: KoaContextWithOIDC) => string;
+      certificateAuthorized?: (ctx: KoaContextWithOIDC) => boolean;
+      certificateSubjectMatches?: (ctx: KoaContextWithOIDC, property: TLSClientAuthProperty, expected: string) => boolean;
+    };
+
+    resourceIndicators?: {
+      enabled?: boolean;
+      ack?: number | string;
+      allowedPolicy?: (ctx: KoaContextWithOIDC, resources: string | string[], client: Client) => Promise<boolean> | boolean;
+    };
+
+    frontchannelLogout?: {
+      enabled?: boolean;
+      ack?: number | string;
+      logoutPendingSource?: (ctx: KoaContextWithOIDC, frames: string[], postLogoutRedirectUri: string) => Promise<void>;
+    };
+  };
+
+  extraAccessTokenClaims?: (ctx: KoaContextWithOIDC, token: AccessToken | ClientCredentials) => Promise<object> | object | Promise<void> | void;
+
+  formats?: {
+    AccessToken?: AccessTokenFormatFunction | TokenFormat;
+    ClientCredentials?: ClientCredentialsFormatFunction | TokenFormat;
+    jwtAccessTokenSigningAlg?: (ctx: KoaContextWithOIDC, token: AccessToken | ClientCredentials, client: Client) => string;
+    customizers?: {
+      jwt?: (ctx: KoaContextWithOIDC, token: AccessToken | ClientCredentials, parts: JWTStructured) => JWTStructured;
+      'jwt-ietf'?: (ctx: KoaContextWithOIDC, token: AccessToken | ClientCredentials, parts: JWTStructured) => JWTStructured;
+      paseto?: (ctx: KoaContextWithOIDC, token: AccessToken | ClientCredentials, parts: PASETOStructured) => PASETOStructured;
+    };
+  };
+
+  httpOptions?: (options: HttpRequestOptions) => HttpRequestOptions;
+
+  expiresWithSession?: (ctx: KoaContextWithOIDC, token: AccessToken | AuthorizationCode | DeviceCode) => Promise<boolean> | boolean;
+
+  issueRefreshToken?: (ctx: KoaContextWithOIDC, client: Client, code: AuthorizationCode | DeviceCode) => Promise<boolean> | boolean;
+
+  jwks?: jose.JSONWebKeySet;
+
+  responseTypes?: ResponseType[];
+
+  pkceMethods?: PKCEMethods[];
+
+  routes?: {
+    authorization?: string;
+    check_session?: string;
+    code_verification?: string;
+    device_authorization?: string;
+    end_session?: string;
+    introspection?: string;
+    jwks?: string;
+    registration?: string;
+    revocation?: string;
+    token?: string;
+    userinfo?: string;
+    request_object?: string;
+  };
+
+  scopes?: string[];
+
+  dynamicScopes?: RegExp[];
+
+  subjectTypes?: SubjectTypes[];
+
+  pairwiseIdentifier?: (ctx: KoaContextWithOIDC, accountId: string, client: Client) => Promise<string> | string;
+
+  tokenEndpointAuthMethods?: ClientAuthMethod[];
+
+  introspectionEndpointAuthMethods?: ClientAuthMethod[];
+
+  revocationEndpointAuthMethods?: ClientAuthMethod[];
+
+  ttl?: {
+    AccessToken?: AccessTokenTTLFunction | number;
+    AuthorizationCode?: AuthorizationCodeTTLFunction | number;
+    ClientCredentials?: ClientCredentialsTTLFunction | number;
+    DeviceCode?: DeviceCodeTTLFunction | number;
+    IdToken?: IdTokenTTLFunction | number;
+    RefreshToken?: RefreshTokenTTLFunction | number;
+  };
+
+  extraClientMetadata?: {
+    properties?: string[];
+
+    validator?: (key: string, value: any, metadata: ClientMetadata, ctx: KoaContextWithOIDC) => void;
+  };
+
+  postLogoutSuccessSource?: (ctx: KoaContextWithOIDC) => void;
+
+  rotateRefreshToken?: (ctx: KoaContextWithOIDC) => void;
+
+  logoutSource?: (ctx: KoaContextWithOIDC, form: string) => void;
+
+  renderError?: (ctx: KoaContextWithOIDC, out: ErrorOut, error: errors.OIDCProviderError | Error) => void;
+
+  interactions?: {
+    policy?: interactionPolicy.Prompt[];
+    url?: (ctx: KoaContextWithOIDC, interaction: Interaction) => Promise<void> | void;
+  };
+
+  audiences?: (ctx: KoaContextWithOIDC, sub: string, token: AccessToken | ClientCredentials, use: 'access_token' | 'client_credentials') => false | string | string[];
+
+  findAccount?: FindAccount;
+
+  whitelistedJWA?: {
+    authorizationEncryptionAlgValues?: EncryptionAlgValues[];
+    authorizationEncryptionEncValues?: EncryptionEncValues[];
+    authorizationSigningAlgValues?: SigningAlgorithms[];
+    dPoPSigningAlgValues?: AsymmetricSigningAlgoritms[];
+    idTokenEncryptionAlgValues?: EncryptionAlgValues[];
+    idTokenEncryptionEncValues?: EncryptionEncValues[];
+    idTokenSigningAlgValues?: SigningAlgorithmsWithNone[];
+    introspectionEncryptionAlgValues?: EncryptionAlgValues[];
+    introspectionEncryptionEncValues?: EncryptionEncValues[];
+    introspectionEndpointAuthSigningAlgValues?: SigningAlgorithms[];
+    introspectionSigningAlgValues?: SigningAlgorithmsWithNone[];
+    requestObjectEncryptionAlgValues?: EncryptionAlgValues[];
+    requestObjectEncryptionEncValues?: EncryptionEncValues[];
+    requestObjectSigningAlgValues?: SigningAlgorithmsWithNone[];
+    revocationEndpointAuthSigningAlgValues?: SigningAlgorithms[];
+    tokenEndpointAuthSigningAlgValues?: SigningAlgorithms[];
+    userinfoEncryptionAlgValues?: EncryptionAlgValues[];
+    userinfoEncryptionEncValues?: EncryptionEncValues[];
+    userinfoSigningAlgValues?: SigningAlgorithmsWithNone[];
+  };
+}
+
+export type NoneAlg = 'none';
+export type AsymmetricSigningAlgoritms = 'PS256' | 'PS384' | 'PS512' | 'ES256' | 'ES384' | 'ES512' | 'EdDSA' | 'RS256' | 'RS384' | 'RS512';
+export type SymmetricSigningAlgorithms = 'HS256' | 'HS384' | 'HS512';
+export type SigningAlgorithms = AsymmetricSigningAlgoritms | SymmetricSigningAlgorithms;
+export type SigningAlgorithmsWithNone = AsymmetricSigningAlgoritms | SymmetricSigningAlgorithms | NoneAlg;
+export type EncryptionAlgValues = 'RSA-OAEP' | 'RSA-OAEP-256' | 'RSA1_5' | 'ECDH-ES' |
+  'ECDH-ES+A128KW' | 'ECDH-ES+A192KW' | 'ECDH-ES+A256KW' | 'A128KW' | 'A192KW' | 'A256KW' |
+  'A128GCMKW' | 'A192GCMKW' | 'A256GCMKW' | 'PBES2-HS256+A128KW' | 'PBES2-HS384+A192KW' |
+  'PBES2-HS512+A256KW' | 'dir';
+export type EncryptionEncValues = 'A128CBC-HS256' |'A128GCM' |'A192CBC-HS384' |'A192GCM' |'A256CBC-HS512' |'A256GCM';
+
+export interface InteractionResults {
+  login?: {
+    remember?: boolean;
+    account: string;
+    ts?: number;
+    amr?: string[];
+    acr?: string;
+  };
+
+  consent?: {
+    rejectedClaims?: string[] | Set<string>
+    rejectedScopes?: string[] | Set<string>
+    replace?: boolean;
+  };
+
+  meta?: AnyObject;
+
+  [key: string]: unknown;
+}
+
+export class Provider extends events.EventEmitter {
+  constructor(issuer: string, configuration?: Configuration);
+
+  readonly app: Koa;
+  readonly callback: (req: http.IncomingMessage | http2.Http2ServerRequest, res: http.ServerResponse | http2.Http2ServerResponse) => void;
+
+  env?: string;
+  proxy?: boolean;
+  subdomainOffset?: number;
+  keys?: string[] | Buffer[];
+
+  // tslint:disable:unified-signatures
+  listen(port?: number, hostname?: string, backlog?: number, listeningListener?: () => void): this;
+  listen(port?: number, hostname?: string, listeningListener?: () => void): this;
+  listen(port?: number, backlog?: number, listeningListener?: () => void): this;
+  listen(port?: number, listeningListener?: () => void): this;
+  listen(path: string, backlog?: number, listeningListener?: () => void): this;
+  listen(path: string, listeningListener?: () => void): this;
+  listen(options: net.ListenOptions, listeningListener?: () => void): this;
+  listen(handle: any, backlog?: number, listeningListener?: () => void): this;
+  listen(handle: any, listeningListener?: () => void): this;
+  // tslint:enable:unified-signatures
+
+  interactionResult(
+    req: http.IncomingMessage | http2.Http2ServerRequest,
+    res: http.ServerResponse | http2.Http2ServerResponse,
+    result: InteractionResults,
+    options?: { mergeWithLastSubmission?: boolean }
+  ): Promise<string>;
+
+  interactionFinished(
+    req: http.IncomingMessage | http2.Http2ServerRequest,
+    res: http.ServerResponse | http2.Http2ServerResponse,
+    result: InteractionResults,
+    options?: { mergeWithLastSubmission?: boolean }
+  ): Promise<void>;
+
+  interactionDetails(req: http.IncomingMessage | http2.Http2ServerRequest, res: http.ServerResponse | http2.Http2ServerResponse): Promise<Interaction>;
+
+  setProviderSession(
+    req: http.IncomingMessage | http2.Http2ServerRequest,
+    res: http.ServerResponse | http2.Http2ServerResponse,
+    options: {
+      account: string;
+      ts?: number;
+      remember?: boolean;
+      clients?: string[];
+      meta?: AnyObject;
+    }
+  ): Promise<Session>;
+
+  // tslint:disable:unified-signatures
+  addListener(event: string, listener: (...args: any[]) => void): this;
+  addListener(event: 'access_token.destroyed', listener: (accessToken: AccessToken) => void): this;
+  addListener(event: 'access_token.saved', listener: (accessToken: AccessToken) => void): this;
+  addListener(event: 'authorization_code.saved', listener: (authorizationCode: AuthorizationCode) => void): this;
+  addListener(event: 'authorization_code.destroyed', listener: (authorizationCode: AuthorizationCode) => void): this;
+  addListener(event: 'authorization_code.consumed', listener: (authorizationCode: AuthorizationCode) => void): this;
+  addListener(event: 'device_code.saved', listener: (deviceCode: DeviceCode) => void): this;
+  addListener(event: 'device_code.destroyed', listener: (deviceCode: DeviceCode) => void): this;
+  addListener(event: 'device_code.consumed', listener: (deviceCode: DeviceCode) => void): this;
+  addListener(event: 'client_credentials.destroyed', listener: (clientCredentials: ClientCredentials) => void): this;
+  addListener(event: 'client_credentials.saved', listener: (clientCredentials: ClientCredentials) => void): this;
+  addListener(event: 'interaction.destroyed', listener: (interaction: Interaction) => void): this;
+  addListener(event: 'interaction.saved', listener: (interaction: Interaction) => void): this;
+  addListener(event: 'session.destroyed', listener: (session: Session) => void): this;
+  addListener(event: 'session.saved', listener: (session: Session) => void): this;
+  addListener(event: 'replay_detection.destroyed', listener: (replayDetection: ReplayDetection) => void): this;
+  addListener(event: 'replay_detection.saved', listener: (replayDetection: ReplayDetection) => void): this;
+  addListener(event: 'request_object.destroyed', listener: (requestObject: RequestObject) => void): this;
+  addListener(event: 'request_object.saved', listener: (requestObject: RequestObject) => void): this;
+  addListener(event: 'registration_access_token.destroyed', listener: (registrationAccessToken: RegistrationAccessToken) => void): this;
+  addListener(event: 'registration_access_token.saved', listener: (registrationAccessToken: RegistrationAccessToken) => void): this;
+  addListener(event: 'refresh_token.destroyed', listener: (refreshToken: RefreshToken) => void): this;
+  addListener(event: 'refresh_token.saved', listener: (refreshToken: RefreshToken) => void): this;
+  addListener(event: 'refresh_token.consumed', listener: (refreshToken: RefreshToken) => void): this;
+  addListener(event: 'authorization.accepted', listener: (ctx: KoaContextWithOIDC) => void): this;
+  addListener(event: 'authorization.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  addListener(event: 'authorization.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'end_session.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  addListener(event: 'end_session.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'grant.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  addListener(event: 'interaction.ended', listener: (ctx: KoaContextWithOIDC) => void): this;
+  addListener(event: 'interaction.started', listener: (ctx: KoaContextWithOIDC, interaction: Interaction) => void): this;
+  addListener(event: 'grant.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'grant.revoked', listener: (ctx: KoaContextWithOIDC, grantId: string) => void): this;
+  addListener(event: 'backchannel.success', listener: (ctx: KoaContextWithOIDC, client: Client, accountId: string, sid: string) => void): this;
+  addListener(event: 'backchannel.error', listener: (ctx: KoaContextWithOIDC, err: Error, client: Client, accountId: string, sid: string) => void): this;
+  addListener(event: 'request_object.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  addListener(event: 'request_object.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'registration_update.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  addListener(event: 'registration_update.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'registration_delete.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  addListener(event: 'registration_delete.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'registration_create.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  addListener(event: 'registration_create.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'introspection.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'registration_read.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'jwks.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'discovery.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'check_session.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'check_session_origin.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'userinfo.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'revocation.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  addListener(event: 'server_error', listener: (ctx: KoaContextWithOIDC, err: Error) => void): this;
+
+  on(event: string, listener: (...args: any[]) => void): this;
+  on(event: 'access_token.destroyed', listener: (accessToken: AccessToken) => void): this;
+  on(event: 'access_token.saved', listener: (accessToken: AccessToken) => void): this;
+  on(event: 'authorization_code.saved', listener: (authorizationCode: AuthorizationCode) => void): this;
+  on(event: 'authorization_code.destroyed', listener: (authorizationCode: AuthorizationCode) => void): this;
+  on(event: 'authorization_code.consumed', listener: (authorizationCode: AuthorizationCode) => void): this;
+  on(event: 'device_code.saved', listener: (deviceCode: DeviceCode) => void): this;
+  on(event: 'device_code.destroyed', listener: (deviceCode: DeviceCode) => void): this;
+  on(event: 'device_code.consumed', listener: (deviceCode: DeviceCode) => void): this;
+  on(event: 'client_credentials.destroyed', listener: (clientCredentials: ClientCredentials) => void): this;
+  on(event: 'client_credentials.saved', listener: (clientCredentials: ClientCredentials) => void): this;
+  on(event: 'interaction.destroyed', listener: (interaction: Interaction) => void): this;
+  on(event: 'interaction.saved', listener: (interaction: Interaction) => void): this;
+  on(event: 'session.destroyed', listener: (session: Session) => void): this;
+  on(event: 'session.saved', listener: (session: Session) => void): this;
+  on(event: 'replay_detection.destroyed', listener: (replayDetection: ReplayDetection) => void): this;
+  on(event: 'replay_detection.saved', listener: (replayDetection: ReplayDetection) => void): this;
+  on(event: 'request_object.destroyed', listener: (requestObject: RequestObject) => void): this;
+  on(event: 'request_object.saved', listener: (requestObject: RequestObject) => void): this;
+  on(event: 'registration_access_token.destroyed', listener: (registrationAccessToken: RegistrationAccessToken) => void): this;
+  on(event: 'registration_access_token.saved', listener: (registrationAccessToken: RegistrationAccessToken) => void): this;
+  on(event: 'refresh_token.destroyed', listener: (refreshToken: RefreshToken) => void): this;
+  on(event: 'refresh_token.saved', listener: (refreshToken: RefreshToken) => void): this;
+  on(event: 'refresh_token.consumed', listener: (refreshToken: RefreshToken) => void): this;
+  on(event: 'authorization.accepted', listener: (ctx: KoaContextWithOIDC) => void): this;
+  on(event: 'authorization.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  on(event: 'authorization.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'end_session.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  on(event: 'end_session.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'grant.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  on(event: 'interaction.ended', listener: (ctx: KoaContextWithOIDC) => void): this;
+  on(event: 'interaction.started', listener: (ctx: KoaContextWithOIDC, interaction: Interaction) => void): this;
+  on(event: 'grant.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'grant.revoked', listener: (ctx: KoaContextWithOIDC, grantId: string) => void): this;
+  on(event: 'backchannel.success', listener: (ctx: KoaContextWithOIDC, client: Client, accountId: string, sid: string) => void): this;
+  on(event: 'backchannel.error', listener: (ctx: KoaContextWithOIDC, err: Error, client: Client, accountId: string, sid: string) => void): this;
+  on(event: 'request_object.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  on(event: 'request_object.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'registration_update.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  on(event: 'registration_update.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'registration_delete.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  on(event: 'registration_delete.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'registration_create.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  on(event: 'registration_create.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'introspection.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'registration_read.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'jwks.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'discovery.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'check_session.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'check_session_origin.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'userinfo.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'revocation.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  on(event: 'server_error', listener: (ctx: KoaContextWithOIDC, err: Error) => void): this;
+
+  once(event: string, listener: (...args: any[]) => void): this;
+  once(event: 'access_token.destroyed', listener: (accessToken: AccessToken) => void): this;
+  once(event: 'access_token.saved', listener: (accessToken: AccessToken) => void): this;
+  once(event: 'authorization_code.saved', listener: (authorizationCode: AuthorizationCode) => void): this;
+  once(event: 'authorization_code.destroyed', listener: (authorizationCode: AuthorizationCode) => void): this;
+  once(event: 'authorization_code.consumed', listener: (authorizationCode: AuthorizationCode) => void): this;
+  once(event: 'device_code.saved', listener: (deviceCode: DeviceCode) => void): this;
+  once(event: 'device_code.destroyed', listener: (deviceCode: DeviceCode) => void): this;
+  once(event: 'device_code.consumed', listener: (deviceCode: DeviceCode) => void): this;
+  once(event: 'client_credentials.destroyed', listener: (clientCredentials: ClientCredentials) => void): this;
+  once(event: 'client_credentials.saved', listener: (clientCredentials: ClientCredentials) => void): this;
+  once(event: 'interaction.destroyed', listener: (interaction: Interaction) => void): this;
+  once(event: 'interaction.saved', listener: (interaction: Interaction) => void): this;
+  once(event: 'session.destroyed', listener: (session: Session) => void): this;
+  once(event: 'session.saved', listener: (session: Session) => void): this;
+  once(event: 'replay_detection.destroyed', listener: (replayDetection: ReplayDetection) => void): this;
+  once(event: 'replay_detection.saved', listener: (replayDetection: ReplayDetection) => void): this;
+  once(event: 'request_object.destroyed', listener: (requestObject: RequestObject) => void): this;
+  once(event: 'request_object.saved', listener: (requestObject: RequestObject) => void): this;
+  once(event: 'registration_access_token.destroyed', listener: (registrationAccessToken: RegistrationAccessToken) => void): this;
+  once(event: 'registration_access_token.saved', listener: (registrationAccessToken: RegistrationAccessToken) => void): this;
+  once(event: 'refresh_token.destroyed', listener: (refreshToken: RefreshToken) => void): this;
+  once(event: 'refresh_token.saved', listener: (refreshToken: RefreshToken) => void): this;
+  once(event: 'refresh_token.consumed', listener: (refreshToken: RefreshToken) => void): this;
+  once(event: 'authorization.accepted', listener: (ctx: KoaContextWithOIDC) => void): this;
+  once(event: 'authorization.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  once(event: 'authorization.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'end_session.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  once(event: 'end_session.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'grant.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  once(event: 'interaction.ended', listener: (ctx: KoaContextWithOIDC) => void): this;
+  once(event: 'interaction.started', listener: (ctx: KoaContextWithOIDC, interaction: Interaction) => void): this;
+  once(event: 'grant.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'grant.revoked', listener: (ctx: KoaContextWithOIDC, grantId: string) => void): this;
+  once(event: 'backchannel.success', listener: (ctx: KoaContextWithOIDC, client: Client, accountId: string, sid: string) => void): this;
+  once(event: 'backchannel.error', listener: (ctx: KoaContextWithOIDC, err: Error, client: Client, accountId: string, sid: string) => void): this;
+  once(event: 'request_object.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  once(event: 'request_object.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'registration_update.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  once(event: 'registration_update.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'registration_delete.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  once(event: 'registration_delete.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'registration_create.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  once(event: 'registration_create.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'introspection.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'registration_read.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'jwks.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'discovery.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'check_session.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'check_session_origin.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'userinfo.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'revocation.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  once(event: 'server_error', listener: (ctx: KoaContextWithOIDC, err: Error) => void): this;
+
+  prependListener(event: string, listener: (...args: any[]) => void): this;
+  prependListener(event: 'access_token.destroyed', listener: (accessToken: AccessToken) => void): this;
+  prependListener(event: 'access_token.saved', listener: (accessToken: AccessToken) => void): this;
+  prependListener(event: 'authorization_code.saved', listener: (authorizationCode: AuthorizationCode) => void): this;
+  prependListener(event: 'authorization_code.destroyed', listener: (authorizationCode: AuthorizationCode) => void): this;
+  prependListener(event: 'authorization_code.consumed', listener: (authorizationCode: AuthorizationCode) => void): this;
+  prependListener(event: 'device_code.saved', listener: (deviceCode: DeviceCode) => void): this;
+  prependListener(event: 'device_code.destroyed', listener: (deviceCode: DeviceCode) => void): this;
+  prependListener(event: 'device_code.consumed', listener: (deviceCode: DeviceCode) => void): this;
+  prependListener(event: 'client_credentials.destroyed', listener: (clientCredentials: ClientCredentials) => void): this;
+  prependListener(event: 'client_credentials.saved', listener: (clientCredentials: ClientCredentials) => void): this;
+  prependListener(event: 'interaction.destroyed', listener: (interaction: Interaction) => void): this;
+  prependListener(event: 'interaction.saved', listener: (interaction: Interaction) => void): this;
+  prependListener(event: 'session.destroyed', listener: (session: Session) => void): this;
+  prependListener(event: 'session.saved', listener: (session: Session) => void): this;
+  prependListener(event: 'replay_detection.destroyed', listener: (replayDetection: ReplayDetection) => void): this;
+  prependListener(event: 'replay_detection.saved', listener: (replayDetection: ReplayDetection) => void): this;
+  prependListener(event: 'request_object.destroyed', listener: (requestObject: RequestObject) => void): this;
+  prependListener(event: 'request_object.saved', listener: (requestObject: RequestObject) => void): this;
+  prependListener(event: 'registration_access_token.destroyed', listener: (registrationAccessToken: RegistrationAccessToken) => void): this;
+  prependListener(event: 'registration_access_token.saved', listener: (registrationAccessToken: RegistrationAccessToken) => void): this;
+  prependListener(event: 'refresh_token.destroyed', listener: (refreshToken: RefreshToken) => void): this;
+  prependListener(event: 'refresh_token.saved', listener: (refreshToken: RefreshToken) => void): this;
+  prependListener(event: 'refresh_token.consumed', listener: (refreshToken: RefreshToken) => void): this;
+  prependListener(event: 'authorization.accepted', listener: (ctx: KoaContextWithOIDC) => void): this;
+  prependListener(event: 'authorization.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  prependListener(event: 'authorization.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'end_session.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  prependListener(event: 'end_session.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'grant.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  prependListener(event: 'interaction.ended', listener: (ctx: KoaContextWithOIDC) => void): this;
+  prependListener(event: 'interaction.started', listener: (ctx: KoaContextWithOIDC, interaction: Interaction) => void): this;
+  prependListener(event: 'grant.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'grant.revoked', listener: (ctx: KoaContextWithOIDC, grantId: string) => void): this;
+  prependListener(event: 'backchannel.success', listener: (ctx: KoaContextWithOIDC, client: Client, accountId: string, sid: string) => void): this;
+  prependListener(event: 'backchannel.error', listener: (ctx: KoaContextWithOIDC, err: Error, client: Client, accountId: string, sid: string) => void): this;
+  prependListener(event: 'request_object.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  prependListener(event: 'request_object.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'registration_update.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  prependListener(event: 'registration_update.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'registration_delete.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  prependListener(event: 'registration_delete.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'registration_create.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  prependListener(event: 'registration_create.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'introspection.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'registration_read.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'jwks.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'discovery.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'check_session.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'check_session_origin.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'userinfo.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'revocation.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependListener(event: 'server_error', listener: (ctx: KoaContextWithOIDC, err: Error) => void): this;
+
+  prependOnceListener(event: string, listener: (...args: any[]) => void): this;
+  prependOnceListener(event: 'access_token.destroyed', listener: (accessToken: AccessToken) => void): this;
+  prependOnceListener(event: 'access_token.saved', listener: (accessToken: AccessToken) => void): this;
+  prependOnceListener(event: 'authorization_code.saved', listener: (authorizationCode: AuthorizationCode) => void): this;
+  prependOnceListener(event: 'authorization_code.destroyed', listener: (authorizationCode: AuthorizationCode) => void): this;
+  prependOnceListener(event: 'authorization_code.consumed', listener: (authorizationCode: AuthorizationCode) => void): this;
+  prependOnceListener(event: 'device_code.saved', listener: (deviceCode: DeviceCode) => void): this;
+  prependOnceListener(event: 'device_code.destroyed', listener: (deviceCode: DeviceCode) => void): this;
+  prependOnceListener(event: 'device_code.consumed', listener: (deviceCode: DeviceCode) => void): this;
+  prependOnceListener(event: 'client_credentials.destroyed', listener: (clientCredentials: ClientCredentials) => void): this;
+  prependOnceListener(event: 'client_credentials.saved', listener: (clientCredentials: ClientCredentials) => void): this;
+  prependOnceListener(event: 'interaction.destroyed', listener: (interaction: Interaction) => void): this;
+  prependOnceListener(event: 'interaction.saved', listener: (interaction: Interaction) => void): this;
+  prependOnceListener(event: 'session.destroyed', listener: (session: Session) => void): this;
+  prependOnceListener(event: 'session.saved', listener: (session: Session) => void): this;
+  prependOnceListener(event: 'replay_detection.destroyed', listener: (replayDetection: ReplayDetection) => void): this;
+  prependOnceListener(event: 'replay_detection.saved', listener: (replayDetection: ReplayDetection) => void): this;
+  prependOnceListener(event: 'request_object.destroyed', listener: (requestObject: RequestObject) => void): this;
+  prependOnceListener(event: 'request_object.saved', listener: (requestObject: RequestObject) => void): this;
+  prependOnceListener(event: 'registration_access_token.destroyed', listener: (registrationAccessToken: RegistrationAccessToken) => void): this;
+  prependOnceListener(event: 'registration_access_token.saved', listener: (registrationAccessToken: RegistrationAccessToken) => void): this;
+  prependOnceListener(event: 'refresh_token.destroyed', listener: (refreshToken: RefreshToken) => void): this;
+  prependOnceListener(event: 'refresh_token.saved', listener: (refreshToken: RefreshToken) => void): this;
+  prependOnceListener(event: 'refresh_token.consumed', listener: (refreshToken: RefreshToken) => void): this;
+  prependOnceListener(event: 'authorization.accepted', listener: (ctx: KoaContextWithOIDC) => void): this;
+  prependOnceListener(event: 'authorization.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  prependOnceListener(event: 'authorization.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'end_session.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  prependOnceListener(event: 'end_session.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'grant.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  prependOnceListener(event: 'interaction.ended', listener: (ctx: KoaContextWithOIDC) => void): this;
+  prependOnceListener(event: 'interaction.started', listener: (ctx: KoaContextWithOIDC, interaction: Interaction) => void): this;
+  prependOnceListener(event: 'grant.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'grant.revoked', listener: (ctx: KoaContextWithOIDC, grantId: string) => void): this;
+  prependOnceListener(event: 'backchannel.success', listener: (ctx: KoaContextWithOIDC, client: Client, accountId: string, sid: string) => void): this;
+  prependOnceListener(event: 'backchannel.error', listener: (ctx: KoaContextWithOIDC, err: Error, client: Client, accountId: string, sid: string) => void): this;
+  prependOnceListener(event: 'request_object.success', listener: (ctx: KoaContextWithOIDC) => void): this;
+  prependOnceListener(event: 'request_object.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'registration_update.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  prependOnceListener(event: 'registration_update.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'registration_delete.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  prependOnceListener(event: 'registration_delete.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'registration_create.success', listener: (ctx: KoaContextWithOIDC, client: Client) => void): this;
+  prependOnceListener(event: 'registration_create.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'introspection.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'registration_read.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'jwks.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'discovery.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'check_session.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'check_session_origin.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'userinfo.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'revocation.error', listener: (ctx: KoaContextWithOIDC, err: errors.OIDCProviderError) => void): this;
+  prependOnceListener(event: 'server_error', listener: (ctx: KoaContextWithOIDC, err: Error) => void): this;
+  // tslint:enable:unified-signatures
+
+  readonly Client: typeof Client;
+  readonly AccessToken: typeof AccessToken;
+  readonly InitialAccessToken: typeof InitialAccessToken;
+  readonly RefreshToken: typeof RefreshToken;
+  readonly AuthorizationCode: typeof AuthorizationCode;
+  readonly RegistrationAccessToken: typeof RegistrationAccessToken;
+  readonly RequestObject: typeof RequestObject;
+  readonly ClientCredentials: typeof ClientCredentials;
+  readonly DeviceCode: typeof DeviceCode;
+  readonly BaseToken: typeof BaseToken;
+  readonly Account: { findAccount: FindAccount; };
+  readonly IdToken: typeof IdToken;
+  readonly ReplayDetection: typeof ReplayDetection;
+  readonly requestUriCache: RequestUriCache;
+  readonly OIDCContext: typeof OIDCContext;
+  readonly Session: typeof Session;
+  readonly Interaction: typeof Interaction;
+}
+
+export default Provider;
+
+declare class DefaultPolicy extends Array<interactionPolicy.Prompt> {
+  get(name: string): interactionPolicy.Prompt;
+  remove(name: string): void;
+  clear(): void;
+  add(prompt: interactionPolicy.Prompt, index?: number): void;
+}
+
+export namespace interactionPolicy {
+  class Check {
+    constructor(
+      reason: string,
+      description: string,
+      error: string,
+      check: (ctx: KoaContextWithOIDC) => Promise<boolean> | boolean,
+      details?: (ctx: KoaContextWithOIDC) => Promise<AnyObject> | AnyObject
+    );
+    constructor(
+      reason: string,
+      description: string,
+      check: (ctx: KoaContextWithOIDC) => Promise<boolean> | boolean,
+      details?: (ctx: KoaContextWithOIDC) => Promise<AnyObject> | AnyObject
+    );
+
+    reason: string;
+    description: string;
+    error: string;
+    details: (ctx: KoaContextWithOIDC) => Promise<AnyObject> | AnyObject;
+    check: (ctx: KoaContextWithOIDC) => Promise<boolean> | boolean;
+  }
+
+  class Prompt {
+    constructor(info: { name: string, requestable?: boolean }, ...checks: Check[]);
+    constructor(info: { name: string, requestable?: boolean }, details: (ctx: KoaContextWithOIDC) => Promise<AnyObject> | AnyObject, ...checks: Check[]);
+
+    name: string;
+    requestable: boolean;
+    details?: (ctx: KoaContextWithOIDC) => Promise<AnyObject>;
+    checks: Check[];
+  }
+
+  function base(): DefaultPolicy;
+}
+
+export namespace errors {
+  class OIDCProviderError extends Error {
+    error: string;
+    error_description?: string;
+    error_detail?: string;
+    expose: boolean;
+    statusCode: number;
+    status: number;
+  }
+  class AccessDenied extends OIDCProviderError {}
+  class AuthorizationPending extends OIDCProviderError {}
+  class ConsentRequired extends OIDCProviderError {}
+  class ExpiredToken extends OIDCProviderError {}
+  class InteractionRequired extends OIDCProviderError {}
+  class InvalidClient extends OIDCProviderError {}
+  class InvalidClientAuth extends OIDCProviderError {}
+  class InvalidClientMetadata extends OIDCProviderError {}
+  class InvalidGrant extends OIDCProviderError {}
+  class InvalidRequest extends OIDCProviderError {}
+  class InvalidRequestObject extends OIDCProviderError {}
+  class InvalidRequestUri extends OIDCProviderError {}
+  class InvalidScope extends OIDCProviderError {}
+  class InvalidSoftwareStatement extends OIDCProviderError {}
+  class InvalidTarget extends OIDCProviderError {}
+  class InvalidToken extends OIDCProviderError {}
+  class LoginRequired extends OIDCProviderError {}
+  class RedirectUriMismatch extends OIDCProviderError {}
+  class RegistrationNotSupported extends OIDCProviderError {}
+  class RequestNotSupported extends OIDCProviderError {}
+  class RequestUriNotSupported extends OIDCProviderError {}
+  class SessionNotFound extends OIDCProviderError {}
+  class SlowDown extends OIDCProviderError {}
+  class TemporarilyUnavailable extends OIDCProviderError {}
+  class UnapprovedSoftwareStatement extends OIDCProviderError {}
+  class UnauthorizedClient extends OIDCProviderError {}
+  class UnsupportedGrantType extends OIDCProviderError {}
+  class UnsupportedResponseMode extends OIDCProviderError {}
+  class UnsupportedResponseType extends OIDCProviderError {}
+  class WebMessageUriMismatch extends OIDCProviderError {}
+}

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1110,8 +1110,13 @@ export class Provider extends events.EventEmitter {
     }
   ): Promise<Session>;
 
-  registerGrantType(name: string, handler: (ctx: KoaContextWithOIDC, next: Function) => Promise<void> | void, params?: string | string[] | Set<string>, dupes?: string | string[] | Set<string>): void;
-  use(middleware: (ctx: Koa.Context, next: Function) => Promise<void> | void): void;
+  registerGrantType(
+    name: string,
+    handler: (ctx: KoaContextWithOIDC, next: () => Promise<void>) => Promise<void> | void,
+    params?: string | string[] | Set<string>,
+    dupes?: string | string[] | Set<string>
+  ): void;
+  use(middleware: (ctx: Koa.Context, next: () => Promise<void>) => Promise<void> | void): void;
 
   // tslint:disable:unified-signatures
   addListener(event: string, listener: (...args: any[]) => void): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -668,6 +668,7 @@ declare class OIDCContext {
   readonly accessToken?: AccessToken;
   readonly account?: Account;
   readonly client?: Client;
+  readonly session?: Session;
   readonly acr: string;
   readonly amr: string[];
   readonly body?: AnyObject;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1446,9 +1446,9 @@ export namespace interactionPolicy {
   function base(): DefaultPolicy;
 }
 
-// TODO: constructors
 export namespace errors {
   class OIDCProviderError extends Error {
+    constructor(status: number, message: string);
     error: string;
     error_description?: string;
     error_detail?: string;
@@ -1456,34 +1456,92 @@ export namespace errors {
     statusCode: number;
     status: number;
   }
-  class AccessDenied extends OIDCProviderError {}
-  class AuthorizationPending extends OIDCProviderError {}
-  class ConsentRequired extends OIDCProviderError {}
-  class ExpiredToken extends OIDCProviderError {}
-  class InteractionRequired extends OIDCProviderError {}
-  class InvalidClient extends OIDCProviderError {}
-  class InvalidClientAuth extends OIDCProviderError {}
-  class InvalidClientMetadata extends OIDCProviderError {}
-  class InvalidGrant extends OIDCProviderError {}
-  class InvalidRequest extends OIDCProviderError {}
-  class InvalidRequestObject extends OIDCProviderError {}
-  class InvalidRequestUri extends OIDCProviderError {}
-  class InvalidScope extends OIDCProviderError {}
-  class InvalidSoftwareStatement extends OIDCProviderError {}
-  class InvalidTarget extends OIDCProviderError {}
-  class InvalidToken extends OIDCProviderError {}
-  class LoginRequired extends OIDCProviderError {}
-  class RedirectUriMismatch extends OIDCProviderError {}
-  class RegistrationNotSupported extends OIDCProviderError {}
-  class RequestNotSupported extends OIDCProviderError {}
-  class RequestUriNotSupported extends OIDCProviderError {}
-  class SessionNotFound extends OIDCProviderError {}
-  class SlowDown extends OIDCProviderError {}
-  class TemporarilyUnavailable extends OIDCProviderError {}
-  class UnapprovedSoftwareStatement extends OIDCProviderError {}
-  class UnauthorizedClient extends OIDCProviderError {}
-  class UnsupportedGrantType extends OIDCProviderError {}
-  class UnsupportedResponseMode extends OIDCProviderError {}
-  class UnsupportedResponseType extends OIDCProviderError {}
-  class WebMessageUriMismatch extends OIDCProviderError {}
+  class AccessDenied extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class AuthorizationPending extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class ConsentRequired extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class ExpiredToken extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class InteractionRequired extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class InvalidClient extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class InvalidClientAuth extends OIDCProviderError {
+    constructor(detail: string);
+  }
+  class InvalidClientMetadata extends OIDCProviderError {
+    constructor(description: string);
+  }
+  class InvalidGrant extends OIDCProviderError {
+    constructor(detail: string);
+  }
+  class InvalidRequest extends OIDCProviderError {
+    constructor(description: string, code?: number);
+  }
+  class SessionNotFound extends InvalidRequest {}
+  class InvalidRequestObject extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class InvalidRequestUri extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class InvalidScope extends OIDCProviderError {
+    constructor(description: string, scope: string);
+  }
+  class InvalidSoftwareStatement extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class InvalidTarget extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class InvalidToken extends OIDCProviderError {
+    constructor(detail: string);
+  }
+  class LoginRequired extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class RedirectUriMismatch extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class RegistrationNotSupported extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class RequestNotSupported extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class RequestUriNotSupported extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class SlowDown extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class TemporarilyUnavailable extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class UnapprovedSoftwareStatement extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class UnauthorizedClient extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class UnsupportedGrantType extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class UnsupportedResponseMode extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class UnsupportedResponseType extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
+  class WebMessageUriMismatch extends OIDCProviderError {
+    constructor(description?: string, detail?: string);
+  }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1110,6 +1110,9 @@ export class Provider extends events.EventEmitter {
     }
   ): Promise<Session>;
 
+  registerGrantType(name: string, handler: (ctx: KoaContextWithOIDC, next: Function) => Promise<void> | void, params?: string | string[] | Set<string>, dupes?: string | string[] | Set<string>): void;
+  use(middleware: (ctx: Koa.Context, next: Function) => Promise<void> | void): void;
+
   // tslint:disable:unified-signatures
   addListener(event: string, listener: (...args: any[]) => void): this;
   addListener(event: 'access_token.destroyed', listener: (accessToken: AccessToken) => void): this;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -997,7 +997,7 @@ export interface Configuration {
 
   audiences?: (
     ctx: KoaContextWithOIDC,
-    sub: string,
+    sub: string | undefined,
     token: AccessToken | ClientCredentials,
     use: 'access_token' | 'client_credentials'
   ) => Promise<false | string | string[]> | false | string | string[];

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,7 +14,7 @@ import * as Koa from 'koa';
 export {};
 
 export type RetryFunction = (retry: number, error: Error) => number;
-export type FindAccount = (ctx: KoaContextWithOIDC, sub: string, token: BaseToken) => Promise<Account> | Account;
+export type FindAccount = (ctx: KoaContextWithOIDC, sub: string, token?: AuthorizationCode | AccessToken | DeviceCode) => Promise<Account> | Account;
 export type TokenFormat = 'opaque' | 'jwt' | 'jwt-ietf' | 'paseto';
 
 export type AccessTokenFormatFunction = (ctx: KoaContextWithOIDC, token: AccessToken) => TokenFormat;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -136,7 +136,7 @@ export interface ClientMetadata extends AnyClientMetadata {
   redirect_uris: string[];
 }
 
-export type ResponseType = 'code' | 'id_token' | 'code id_token' | 'code token' | 'code id_token token' | 'none';
+export type ResponseType = 'code' | 'id_token' | 'code id_token' | 'id_token token' | 'code token' | 'code id_token token' | 'none';
 export type PKCEMethods = 'S256' | 'plain';
 export type SubjectTypes = 'public' | 'pairwise';
 export type ClientAuthMethod = 'client_secret_basic' | 'client_secret_post' | 'client_secret_jwt' | 'private_key_jwt' | 'tls_client_auth' | 'self_signed_tls_client_auth' | 'none';

--- a/types/oidc-provider-tests.ts
+++ b/types/oidc-provider-tests.ts
@@ -460,6 +460,22 @@ provider.on('access_token.saved', (accessToken) => {
   accessToken.jti.substring(0);
 });
 
+provider.registerGrantType('urn:example', async (ctx, next) => {
+  ctx.oidc.route.substring(0);
+  return next();
+}, ['foo', 'bar'], ['foo']);
+
+provider.use((ctx, next) => {
+  ctx.href.substring(0);
+  return next();
+});
+
+provider.use(async (ctx, next) => {
+  ctx.href.substring(0);
+  await next();
+  //
+});
+
 (async () => {
   const client = await provider.Client.find('foo');
   if (client) {

--- a/types/oidc-provider-tests.ts
+++ b/types/oidc-provider-tests.ts
@@ -1,0 +1,467 @@
+// tslint:disable-next-line:no-relative-import-in-test
+import { Provider, interactionPolicy } from './index.d';
+
+new Provider('https://op.example.com');
+
+const provider = new Provider('https://op.example.com', {
+  acrValues: ['urn:example:bronze'],
+  adapter: class Adapter {
+    name: string;
+    constructor(name: string) {
+      this.name = name;
+    }
+
+    async upsert(id: string, payload: object, expiresIn: number) {}
+    async consume(id: string) {}
+    async destroy(id: string) {}
+    async revokeByGrantId(grantId: string) {}
+
+    async find(id: string) {
+      return {};
+    }
+    async findByUserCode(userCode: string) {
+      return {};
+    }
+    async findByUid(uid: string) {
+      return {};
+    }
+  },
+  claims: {
+    acr: null, foo: null, bar: ['bar'],
+  },
+  clientBasedCORS(ctx, origin, client) {
+    ctx.oidc.issuer.substring(0);
+    client.clientId.substring(0);
+    origin.substring(0);
+    return true;
+  },
+  clients: [
+    {
+      client_id: 'foo',
+      token_endpoint_auth_method: 'none',
+      redirect_uris: ['https://rp.example.com/cb'],
+    }
+  ],
+  clientDefaults: {
+    foo: 'bar',
+    id_token_signed_response_alg: 'EdDSA',
+    token_endpoint_auth_signing_alg: 'ES384',
+  },
+  clockTolerance: 60,
+  conformIdTokenClaims: true,
+  cookies: {
+    names: {
+      session: '_foo',
+    },
+    short: {
+      httpOnly: true,
+      sameSite: 'lax',
+    },
+    keys: [
+      'foo',
+      Buffer.from('bar'),
+    ],
+  },
+  discovery: {
+    foo: 'bar',
+    bar: [123],
+    baz: {
+      foo: 'bar',
+    },
+  },
+  extraParams: ['foo', 'bar', 'baz'],
+  extraAccessTokenClaims(ctx, token) {
+    ctx.oidc.issuer.substring(0);
+
+    return { foo: 'bar' };
+  },
+  formats: {
+    AccessToken: 'paseto',
+    ClientCredentials(ctx, clientCredentials) {
+      ctx.oidc.issuer.substring(0);
+      clientCredentials.iat.toFixed();
+      return 'opaque';
+    },
+    async jwtAccessTokenSigningAlg(ctx, token, client) {
+      ctx.oidc.issuer.substring(0);
+      token.iat.toFixed();
+      client.clientId.substring(0);
+      return 'ES384';
+    },
+    customizers: {
+      jwt(ctx, token, parts) {
+        ctx.oidc.issuer.substring(0);
+        token.iat.toFixed();
+        parts.header = { foo: 'bar' };
+        parts.payload.foo = 'bar';
+        return parts;
+      },
+      'jwt-ietf'(ctx, token, parts) {
+        ctx.oidc.issuer.substring(0);
+        token.iat.toFixed();
+        parts.header = { foo: 'bar' };
+        parts.payload.foo = 'bar';
+        return parts;
+      },
+      paseto(ctx, token, parts) {
+        ctx.oidc.issuer.substring(0);
+        token.iat.toFixed();
+        parts.footer = { foo: 'bar' };
+        parts.footer = Buffer.from('foo');
+        parts.footer = undefined;
+        parts.footer = 'foo';
+        parts.payload.foo = 'bar';
+        return parts;
+      }
+    },
+  },
+  httpOptions(options) {
+    if (options.headers) {
+      options.headers.foo = 'bar';
+    }
+    options.json = false;
+    options.timeout = 5000;
+    options.retry = 1;
+    return options;
+  },
+  async expiresWithSession(ctx, token) {
+    ctx.oidc.issuer.substring(0);
+    token.iat.toFixed();
+    return false;
+  },
+  async issueRefreshToken(ctx, client, token) {
+    ctx.oidc.issuer.substring(0);
+    client.clientId.substring(0);
+    token.iat.toFixed();
+    return false;
+  },
+  jwks: {
+    keys: [
+      {
+        kty: 'RSA',
+        d: 'foo',
+        n: 'foo',
+        e: 'AQAB',
+      },
+      {
+        kty: 'OKP',
+        x: 'foo',
+        d: 'foo',
+        crv: 'Ed25519',
+      }
+    ],
+  },
+  responseTypes: ['code', 'code id_token', 'none'],
+  pkceMethods: ['plain', 'S256'],
+  routes: {
+    authorization: '/auth',
+    check_session: '/session/check',
+    code_verification: '/device',
+    device_authorization: '/device/auth',
+    end_session: '/session/end',
+    introspection: '/token/introspection',
+    jwks: '/jwks',
+    registration: '/reg',
+    revocation: '/token/revocation',
+    token: '/token',
+    userinfo: '/me',
+    request_object: '/request',
+  },
+  scopes: ['foo', 'bar'],
+  dynamicScopes: [
+    /foo/,
+    /bar/
+  ],
+  subjectTypes: ['public', 'pairwise'],
+  tokenEndpointAuthMethods: ['self_signed_tls_client_auth'],
+  introspectionEndpointAuthMethods: ['none'],
+  revocationEndpointAuthMethods: ['client_secret_basic'],
+  ttl: {
+    CustomToken: 23,
+    AccessToken(ctx, accessToken) {
+      ctx.oidc.issuer.substring(0);
+      accessToken.iat.toFixed();
+      return 2;
+    },
+    AuthorizationCode: 3,
+    ClientCredentials: 3,
+    DeviceCode: 3,
+    IdToken: 3,
+    RefreshToken: 3,
+  },
+  extraClientMetadata: {
+    properties: ['foo', 'bar'],
+    validator(key, value, metadata, ctx) {
+      ctx.oidc.issuer.substring(0);
+      metadata.client_id.substring(0);
+      key.substring(0);
+      metadata.foo = 'bar';
+    }
+  },
+  async postLogoutSuccessSource(ctx) {
+    ctx.oidc.issuer.substring(0);
+  },
+  interactions: {
+    async url(ctx, interaction) {
+      ctx.oidc.issuer.substring(0);
+      interaction.iat.toFixed();
+      interaction.returnTo.substring(0);
+      JSON.stringify(interaction.params.foo);
+      JSON.stringify(interaction.prompt.name);
+      return 'foo';
+    },
+    policy: [
+      new interactionPolicy.Prompt(
+        { name: 'foo', requestable: true },
+        new interactionPolicy.Check('foo', 'bar', 'baz', (ctx) => false),
+        new interactionPolicy.Check('foo', 'bar', 'baz', async (ctx) => true, async (ctx) => ({ foo: 'bar' })),
+      ),
+      new interactionPolicy.Prompt(
+        { name: 'foo', requestable: true },
+        (ctx) => ({ foo: 'bar' }),
+        new interactionPolicy.Check('foo', 'bar', 'baz', (ctx) => false),
+        new interactionPolicy.Check('foo', 'bar', 'baz', async (ctx) => true, async (ctx) => ({ foo: 'bar' })),
+      )
+    ],
+  },
+  async findAccount(ctx, sub, token) {
+    ctx.oidc.issuer.substring(0);
+    sub.substring(0);
+    token.iat.toFixed();
+
+    return {
+      accountId: sub,
+      async claims() {
+        return {
+          sub,
+          foo: 'bar',
+        };
+      },
+    };
+  },
+  async rotateRefreshToken(ctx) {
+    ctx.oidc.issuer.substring(0);
+    return true;
+  },
+  async audiences(ctx, sub, token, use) {
+    ctx.oidc.issuer.substring(0);
+    sub.substring(0);
+    token.iat.toFixed();
+    use.substring(0);
+    return 'foo';
+  },
+  async logoutSource(ctx, form) {
+    ctx.oidc.issuer.substring(0);
+    form.substring(0);
+  },
+  async renderError(ctx, out, err) {
+    ctx.oidc.issuer.substring(0);
+    out.error.substring(0);
+    err.message.substring(0);
+  },
+  async pairwiseIdentifier(ctx, accountId, client) {
+    ctx.oidc.issuer.substring(0);
+    accountId.substring(0);
+    client.clientId.substring(0);
+    return 'foo';
+  },
+  features: {
+    devInteractions: { enabled: false },
+    claimsParameter: { enabled: false },
+    introspection: { enabled: false },
+    userinfo: { enabled: false },
+    jwtUserinfo: { enabled: false },
+    webMessageResponseMode: { enabled: false, ack: 2 },
+    revocation: { enabled: false },
+    sessionManagement: { enabled: false, ack: 2, keepHeaders: false },
+    jwtIntrospection: { enabled: false, ack: 2 },
+    jwtResponseModes: { enabled: false, ack: 2 },
+    pushedRequestObjects: { enabled: false, ack: 2 },
+    registration: {
+      enabled: true,
+      initialAccessToken: true,
+      policies: {
+        foo(ctx, metadata) {
+          ctx.oidc.issuer.substring(0);
+          metadata.client_id.substring(0);
+        }
+      },
+      idFactory() {
+        return 'foo';
+      },
+      secretFactory() {
+        return 'foo';
+      }
+    },
+    registrationManagement: {
+      enabled: false,
+      async rotateRegistrationAccessToken(ctx) {
+        ctx.oidc.issuer.substring(0);
+        return true;
+      },
+    },
+    resourceIndicators: {
+      enabled: true,
+      ack: 2,
+      async allowedPolicy(ctx, resources, client) {
+        ctx.oidc.issuer.substring(0);
+        if (Array.isArray(resources)) {
+          resources[0].substring(0);
+        } else {
+          resources.substring(0);
+        }
+        return true;
+      },
+    },
+    requestObjects: {
+      request: false,
+      requestUri: false,
+      requireUriRegistration: false,
+      mergingStrategy: {
+        name: 'lax',
+        whitelist: ['nonce'],
+      },
+    },
+    encryption: { enabled: false },
+    fapiRW: { enabled: false, ack: 2 },
+    clientCredentials: { enabled: false },
+    backchannelLogout: { enabled: false, ack: 2 },
+    ietfJWTAccessTokenProfile: { enabled: false, ack: 2 },
+    dPoP: { enabled: false, ack: 2, iatTolerance: 120 },
+    frontchannelLogout: {
+      ack: 2,
+      enabled: false,
+      async logoutPendingSource(ctx, frames, postLogoutRedirectUri) {
+        ctx.oidc.issuer.substring(0);
+        frames[0].substring(0);
+        if (postLogoutRedirectUri) {
+          postLogoutRedirectUri.substring(0);
+        }
+      }
+    },
+    deviceFlow: {
+      enabled: false,
+      charset: 'digits',
+      mask: '*** *** ***',
+      deviceInfo(ctx) {
+        ctx.oidc.issuer.substring(0);
+        return {};
+      },
+      async userCodeInputSource(ctx, form, out, err) {
+        ctx.oidc.issuer.substring(0);
+        form.substring(0);
+        if (out) {
+          out.error;
+        }
+        if (err) {
+          err.message.substring(0);
+        }
+      },
+      async userCodeConfirmSource(ctx, form, client, deviceInfo, userCode) {
+        ctx.oidc.issuer.substring(0);
+        form.substring(0);
+        client.clientId.substring(0);
+        JSON.stringify(deviceInfo.foo);
+        userCode.substring(0);
+      },
+      async successSource(ctx) {
+        ctx.oidc.issuer.substring(0);
+      }
+    },
+    mTLS: {
+      enabled: false,
+      certificateBoundAccessTokens: true,
+      selfSignedTlsClientAuth: true,
+      tlsClientAuth: true,
+      ack: 2,
+      getCertificate(ctx) {
+        ctx.oidc.issuer.substring(0);
+        return 'foo';
+      },
+      certificateAuthorized(ctx) {
+        ctx.oidc.issuer.substring(0);
+        return false;
+      },
+      certificateSubjectMatches(ctx, property, expected) {
+        ctx.oidc.issuer.substring(0);
+        property.substring(0);
+        expected.substring(0);
+        return false;
+      },
+    }
+  },
+  whitelistedJWA: {
+    tokenEndpointAuthSigningAlgValues: [
+      'HS256', 'RS256', 'PS256', 'ES256', 'EdDSA',
+    ],
+    introspectionEndpointAuthSigningAlgValues: [
+      'HS256', 'RS256', 'PS256', 'ES256', 'EdDSA',
+    ],
+    revocationEndpointAuthSigningAlgValues: [
+      'HS256', 'RS256', 'PS256', 'ES256', 'EdDSA',
+    ],
+    idTokenSigningAlgValues: [
+      'HS256', 'RS256', 'PS256', 'ES256', 'EdDSA', 'none',
+    ],
+    requestObjectSigningAlgValues: [
+      'HS256', 'RS256', 'PS256', 'ES256', 'EdDSA', 'none',
+    ],
+    userinfoSigningAlgValues: [
+      'HS256', 'RS256', 'PS256', 'ES256', 'EdDSA', 'none'
+    ],
+    introspectionSigningAlgValues: [
+      'HS256', 'RS256', 'PS256', 'ES256', 'EdDSA', 'none',
+    ],
+    authorizationSigningAlgValues: [
+      'HS256', 'RS256', 'PS256', 'ES256', 'EdDSA',
+    ],
+    idTokenEncryptionAlgValues: [
+      'A128KW', 'A256KW', 'ECDH-ES', 'ECDH-ES+A128KW', 'ECDH-ES+A256KW', 'RSA-OAEP',
+    ],
+    requestObjectEncryptionAlgValues: [
+      'A128KW', 'A256KW', 'ECDH-ES', 'ECDH-ES+A128KW', 'ECDH-ES+A256KW', 'RSA-OAEP',
+    ],
+    userinfoEncryptionAlgValues: [
+      'A128KW', 'A256KW', 'ECDH-ES', 'ECDH-ES+A128KW', 'ECDH-ES+A256KW', 'RSA-OAEP',
+    ],
+    introspectionEncryptionAlgValues: [
+      'A128KW', 'A256KW', 'ECDH-ES', 'ECDH-ES+A128KW', 'ECDH-ES+A256KW', 'RSA-OAEP',
+    ],
+    authorizationEncryptionAlgValues: [
+      'A128KW', 'A256KW', 'ECDH-ES', 'ECDH-ES+A128KW', 'ECDH-ES+A256KW', 'RSA-OAEP',
+    ],
+    idTokenEncryptionEncValues: [
+      'A128CBC-HS256', 'A128GCM', 'A256CBC-HS512', 'A256GCM',
+    ],
+    requestObjectEncryptionEncValues: [
+      'A128CBC-HS256', 'A128GCM', 'A256CBC-HS512', 'A256GCM',
+    ],
+    userinfoEncryptionEncValues: [
+      'A128CBC-HS256', 'A128GCM', 'A256CBC-HS512', 'A256GCM',
+    ],
+    introspectionEncryptionEncValues: [
+      'A128CBC-HS256', 'A128GCM', 'A256CBC-HS512', 'A256GCM',
+    ],
+    authorizationEncryptionEncValues: [
+      'A128CBC-HS256', 'A128GCM', 'A256CBC-HS512', 'A256GCM',
+    ],
+    dPoPSigningAlgValues: [
+      'RS256', 'PS256', 'ES256', 'EdDSA',
+    ],
+  },
+});
+
+provider.on('access_token.saved', (accessToken) => {
+  accessToken.jti.substring(0);
+});
+
+(async () => {
+  const client = await provider.Client.find('foo');
+  if (client) {
+    client.clientId.substring(0);
+  }
+  const accessToken = await provider.AccessToken.find('foo');
+  if (accessToken) {
+    accessToken.jti.substring(0);
+  }
+})();

--- a/types/oidc-provider-tests.ts
+++ b/types/oidc-provider-tests.ts
@@ -227,7 +227,9 @@ const provider = new Provider('https://op.example.com', {
   async findAccount(ctx, sub, token) {
     ctx.oidc.issuer.substring(0);
     sub.substring(0);
-    token.iat.toFixed();
+    if (token) {
+      token.iat.toFixed();
+    }
 
     return {
       accountId: sub,

--- a/types/oidc-provider-tests.ts
+++ b/types/oidc-provider-tests.ts
@@ -70,8 +70,9 @@ const provider = new Provider('https://op.example.com', {
     },
   },
   extraParams: ['foo', 'bar', 'baz'],
-  extraAccessTokenClaims(ctx, token) {
+  async extraAccessTokenClaims(ctx, token) {
     ctx.oidc.issuer.substring(0);
+    token.jti.substring(0);
 
     return { foo: 'bar' };
   },
@@ -247,7 +248,9 @@ const provider = new Provider('https://op.example.com', {
   },
   async audiences(ctx, sub, token, use) {
     ctx.oidc.issuer.substring(0);
-    sub.substring(0);
+    if (sub) {
+      sub.substring(0);
+    }
     token.iat.toFixed();
     use.substring(0);
     return 'foo';

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": [
+      "es6"
+    ],
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "baseUrl": "../",
+    "typeRoots": [
+      "../"
+    ],
+    "types": [],
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "files": [
+    "index.d.ts"
+  ]
+}

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -17,6 +17,7 @@
     "forceConsistentCasingInFileNames": true
   },
   "files": [
-    "index.d.ts"
+    "index.d.ts",
+    "oidc-provider-tests.ts"
   ]
 }

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,3 @@
+{
+  "extends": "dtslint/dtslint.json"
+}


### PR DESCRIPTION
After writing `.d.ts` typescript definitions for openid-client, @panva/jose, and paseto I took a stab at doing so for `oidc-provider`.

I kindly ask everyone to try them and provide feedback 👍 or 👎

Install with

```console
npm i panva/node-oidc-provider#ts
```