### PR TITLE
Update index.d.ts

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -635,6 +635,7 @@ declare class Client {
 }
 
 declare class OIDCContext {
+  constructor(ctx: Koa.Context);
   readonly route: string;
   uid: string;
   readonly entities: {


### PR DESCRIPTION
Add constructor to  OIDCContext class.

For me this is necessary as I want to use it like this:

```
    app.use(async (ctx, next) => {
      if (!ctx.oidc) {
        Object.defineProperty(ctx, 'oidc', { value: new provider.OIDCContext(ctx) });
      }
```

which is impossible with the current typings.