### PR TITLE
refactor(typescript): use Koa.ParameterizedContext in typings

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -697,9 +697,7 @@ declare class OIDCContext {
   getAccessToken(opts?: { acceptDPoP?: boolean, acceptQueryParam?: boolean }): string;
 }
 
-export interface KoaContextWithOIDC extends Koa.Context {
-  oidc: OIDCContext;
-}
+export type KoaContextWithOIDC = Koa.ParameterizedContext<{oidc: OIDCContext}>;
 
 export const DYNAMIC_SCOPE_LABEL: symbol;
 


### PR DESCRIPTION
I'm using the Koa example to bootstrap a new project and found that this change makes my life a lot easier when using TypeScript and Koa.