### PR TITLE
fix: set samesite compatibility cookie as transient when the session is

### DIFF
--- a/lib/shared/session.js
+++ b/lib/shared/session.js
@@ -22,7 +22,7 @@ module.exports = async function sessionHandler(ctx, next) {
   } finally {
     const sessionCookieName = ctx.oidc.provider.cookieName('session');
     const stateCookieName = ctx.oidc.provider.cookieName('state');
-    const longRegexp = new RegExp(`^(${sessionCookieName}|${stateCookieName}\\.[^=]+)(?:\\.sig)?=`);
+    const longRegexp = new RegExp(`^(${sessionCookieName}|${stateCookieName}\\.[^=]+)(?:\\.legacy)?(?:\\.sig)?=`);
 
     // refresh the session duration
     if ((!ctx.oidc.session.new || ctx.oidc.session.touched) && !ctx.oidc.session.destroyed) {


### PR DESCRIPTION
If the session is transient then legacy cookies should also be transient,
so that the session is correctly ended when the browser is closed.

NOTE: I didn't find any tests covering the session middleware, but if you point me in the right direction I can add some