### PR TITLE
fix(typescript): correct KoaContextWithOIDC definition

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -701,7 +701,7 @@ declare class OIDCContext {
   getAccessToken(opts?: { acceptDPoP?: boolean, acceptQueryParam?: boolean }): string;
 }
 
-export type KoaContextWithOIDC = Koa.ParameterizedContext<{oidc: OIDCContext}>;
+export type KoaContextWithOIDC = Koa.ParameterizedContext<{}, { oidc: OIDCContext }>;
 
 export const DYNAMIC_SCOPE_LABEL: symbol;
 


### PR DESCRIPTION
Currently, an OIDCContext is assigned at ctx.oidc. However, it's incorrectly defined in the typescript definition due to the type parameter mispositioned in ParameterizedContext.

fix #659 