### PR TITLE
fix(typescript): correct KoaContextWithOIDC definition, take 2

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -703,7 +703,12 @@ declare class OIDCContext {
   getAccessToken(opts?: { acceptDPoP?: boolean, acceptQueryParam?: boolean }): string;
 }
 
-export type KoaContextWithOIDC = Koa.ParameterizedContext<{}, { oidc: OIDCContext }>;
+export type KoaContextWithOIDC = Koa.ParameterizedContext<
+  Koa.DefaultState,
+  Koa.DefaultContext & {
+    oidc: OIDCContext;
+  }
+>;
 
 export const DYNAMIC_SCOPE_LABEL: symbol;
 


### PR DESCRIPTION
Sorry, my bad. I missed the default state and context in KoaContextWithOIDC, making it too restrictive to be extended. 