### PR TITLE
fix(typescript): adapter methods typings and interface name typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "paseto": "^1.0.5",
     "sinon": "^9.0.0",
     "supertest": "^4.0.2",
-    "timekeeper": "^2.2.0"
+    "timekeeper": "^2.2.0",
+    "typescript": "^3.8.3"
   },
   "engines": {
     "node": "^10.13.0 || >=12.0.0"

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -796,11 +796,15 @@ export interface AdapterPayload {
   'x5t#S256'?: string;
 }
 
+export interface AdapterModel extends AdapterPayload {
+  consumed?: boolean;
+}
+
 export interface Adapter {
   upsert(id: string, payload: AdapterPayload, expiresIn: number): Promise<undefined | void>;
-  find(id: string): Promise<AdapterPayload | undefined | void>;
-  findByUserCode(userCode: string): Promise<AdapterPayload | undefined | void>;
-  findByUid(uid: string): Promise<AdapterPayload | undefined | void>;
+  find(id: string): Promise<AdapterModel | undefined | void>;
+  findByUserCode(userCode: string): Promise<AdapterModel | undefined | void>;
+  findByUid(uid: string): Promise<AdapterModel | undefined | void>;
   consume(id: string): Promise<undefined | void>;
   destroy(id: string): Promise<undefined | void>;
   revokeByGrantId(grantId: string): Promise<undefined | void>;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -749,6 +749,7 @@ export interface AdapterPayload {
   clientId?: string;
   codeChallenge?: string;
   codeChallengeMethod?: string;
+  consumed?: any;
   deviceInfo?: AnyObject;
   error?: string;
   errorDescription?: string;
@@ -796,15 +797,11 @@ export interface AdapterPayload {
   'x5t#S256'?: string;
 }
 
-export interface AdapterModel extends AdapterPayload {
-  consumed?: boolean;
-}
-
 export interface Adapter {
   upsert(id: string, payload: AdapterPayload, expiresIn: number): Promise<undefined | void>;
-  find(id: string): Promise<AdapterModel | undefined | void>;
-  findByUserCode(userCode: string): Promise<AdapterModel | undefined | void>;
-  findByUid(uid: string): Promise<AdapterModel | undefined | void>;
+  find(id: string): Promise<AdapterPayload | undefined | void>;
+  findByUserCode(userCode: string): Promise<AdapterPayload | undefined | void>;
+  findByUid(uid: string): Promise<AdapterPayload | undefined | void>;
   consume(id: string): Promise<undefined | void>;
   destroy(id: string): Promise<undefined | void>;
   revokeByGrantId(grantId: string): Promise<undefined | void>;
@@ -1011,7 +1008,7 @@ export interface Configuration {
   formats?: {
     AccessToken?: AccessTokenFormatFunction | TokenFormat;
     ClientCredentials?: ClientCredentialsFormatFunction | TokenFormat;
-    jwtAccessTokenSigningAlg?: (ctx: KoaContextWithOIDC, token: AccessToken | ClientCredentials, client: Client) => CanBePromise<AsymmetricSigningAlgoritm>;
+    jwtAccessTokenSigningAlg?: (ctx: KoaContextWithOIDC, token: AccessToken | ClientCredentials, client: Client) => CanBePromise<AsymmetricSigningAlgorithm>;
     customizers?: {
       jwt?: (ctx: KoaContextWithOIDC, token: AccessToken | ClientCredentials, parts: JWTStructured) => Promise<JWTStructured> | JWTStructured;
       'jwt-ietf'?: (ctx: KoaContextWithOIDC, token: AccessToken | ClientCredentials, parts: JWTStructured) => Promise<JWTStructured> | JWTStructured;
@@ -1103,7 +1100,7 @@ export interface Configuration {
     authorizationEncryptionAlgValues?: EncryptionAlgValues[];
     authorizationEncryptionEncValues?: EncryptionEncValues[];
     authorizationSigningAlgValues?: SigningAlgorithm[];
-    dPoPSigningAlgValues?: AsymmetricSigningAlgoritm[];
+    dPoPSigningAlgValues?: AsymmetricSigningAlgorithm[];
     idTokenEncryptionAlgValues?: EncryptionAlgValues[];
     idTokenEncryptionEncValues?: EncryptionEncValues[];
     idTokenSigningAlgValues?: SigningAlgorithmWithNone[];
@@ -1123,10 +1120,10 @@ export interface Configuration {
 }
 
 export type NoneAlg = 'none';
-export type AsymmetricSigningAlgoritm = 'PS256' | 'PS384' | 'PS512' | 'ES256' | 'ES256K' | 'ES384' | 'ES512' | 'EdDSA' | 'RS256' | 'RS384' | 'RS512';
+export type AsymmetricSigningAlgorithm = 'PS256' | 'PS384' | 'PS512' | 'ES256' | 'ES256K' | 'ES384' | 'ES512' | 'EdDSA' | 'RS256' | 'RS384' | 'RS512';
 export type SymmetricSigningAlgorithm = 'HS256' | 'HS384' | 'HS512';
-export type SigningAlgorithm = AsymmetricSigningAlgoritm | SymmetricSigningAlgorithm;
-export type SigningAlgorithmWithNone = AsymmetricSigningAlgoritm | SymmetricSigningAlgorithm | NoneAlg;
+export type SigningAlgorithm = AsymmetricSigningAlgorithm | SymmetricSigningAlgorithm;
+export type SigningAlgorithmWithNone = AsymmetricSigningAlgorithm | SymmetricSigningAlgorithm | NoneAlg;
 export type EncryptionAlgValues = 'RSA-OAEP' | 'RSA-OAEP-256' | 'RSA-OAEP-384' | 'RSA-OAEP-512' | 'RSA1_5' | 'ECDH-ES' |
   'ECDH-ES+A128KW' | 'ECDH-ES+A192KW' | 'ECDH-ES+A256KW' | 'A128KW' | 'A192KW' | 'A256KW' |
   'A128GCMKW' | 'A192GCMKW' | 'A256GCMKW' | 'PBES2-HS256+A128KW' | 'PBES2-HS384+A192KW' |

--- a/types/oidc-provider-tests.ts
+++ b/types/oidc-provider-tests.ts
@@ -1,5 +1,5 @@
 // tslint:disable-next-line:no-relative-import-in-test
-import { Provider, interactionPolicy, AsymmetricSigningAlgoritm, Adapter } from './index.d';
+import { Provider, interactionPolicy, AsymmetricSigningAlgorithm } from './index.d';
 
 new Provider('https://op.example.com');
 
@@ -40,7 +40,7 @@ new Provider('https://op.example.com', {
 
 const provider = new Provider('https://op.example.com', {
   acrValues: ['urn:example:bronze'],
-  adapter: class ProviderAdapter implements Adapter {
+  adapter: class Adapter {
     name: string;
     constructor(name: string) {
       this.name = name;
@@ -128,7 +128,7 @@ const provider = new Provider('https://op.example.com', {
       clientCredentials.iat.toFixed();
       return 'opaque';
     },
-    async jwtAccessTokenSigningAlg(ctx, token, client): Promise<AsymmetricSigningAlgoritm> {
+    async jwtAccessTokenSigningAlg(ctx, token, client): Promise<AsymmetricSigningAlgorithm> {
       ctx.oidc.issuer.substring(0);
       token.iat.toFixed();
       client.clientId.substring(0);

--- a/types/oidc-provider-tests.ts
+++ b/types/oidc-provider-tests.ts
@@ -1,5 +1,5 @@
 // tslint:disable-next-line:no-relative-import-in-test
-import { Provider, interactionPolicy, AsymmetricSigningAlgoritm } from './index.d';
+import { Provider, interactionPolicy, AsymmetricSigningAlgoritm, Adapter } from './index.d';
 
 new Provider('https://op.example.com');
 
@@ -40,7 +40,7 @@ new Provider('https://op.example.com', {
 
 const provider = new Provider('https://op.example.com', {
   acrValues: ['urn:example:bronze'],
-  adapter: class Adapter {
+  adapter: class ProviderAdapter implements Adapter {
     name: string;
     constructor(name: string) {
       this.name = name;
@@ -52,13 +52,19 @@ const provider = new Provider('https://op.example.com', {
     async revokeByGrantId(grantId: string) {}
 
     async find(id: string) {
-      return {};
+      return {
+        consumed: false
+      };
     }
     async findByUserCode(userCode: string) {
-      return {};
+      return {
+        consumed: false
+      };
     }
     async findByUid(uid: string) {
-      return {};
+      return {
+        consumed: false
+      };
     }
   },
   claims: {


### PR DESCRIPTION
The example provided in the docs shows the [sequelize adapter returning a `consumed` property if the token has been consumed](https://github.com/panva/node-oidc-provider/blob/30e439ac525d6d10361537046ef9682d736284ea/example/adapters/sequelize.js#L69-L94), but this property is not present in the typings. This causes a TypeScript error with the latest version of TypeScript (3.8.3).

The fix here is to return a new interface from the `find*` methods of the adapter class which includes this `consumed` property, along with all of the other possible properties from`AdapterPayload`.

Additionally, a devDependency on TypeScript was added to satisy a warning when running `npm install` (`dtslint` has a peerDependency on typescript).
