### PR TITLE
fix(typescript): export Client so backchannel.error handler can be typed

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -565,7 +565,7 @@ declare class ClientKeystore {
   toJWKS(private?: boolean): jose.JSONWebKeySet;
 }
 
-declare class Client {
+export class Client {
   responseTypeAllowed(type: ResponseType): boolean;
   grantTypeAllowed(type: string): boolean;
   redirectUriAllowed(redirectUri: string): boolean;


### PR DESCRIPTION
The 'backchannel.error' handler receives various props include client. The other props are either primitives or the type definition is readily available.

A small code example.

import Provider, { errors, KoaContextWithOIDC } from 'oidc-provider'

const prvdr = new Provider(`${config.publicUrl}/oidc`, {...})

prvdr.on('backchannel.error', (ctx: KoaContextWithOIDC, err: Error, client: Client, accountId: string, sid: string) => {...})

The type Client isnt exported so to get it I had to use this workaround as described at https://github.com/panva/node-oidc-provider/issues/569#issuecomment-551058463.

type Client = InstanceType<Provider['Client']>

If Client was exported it could be used directly from the module