### PR TITLE
fix: correct jwtIntrospection draft ack version

### DIFF
--- a/lib/helpers/features.js
+++ b/lib/helpers/features.js
@@ -46,10 +46,10 @@ const DRAFTS = new Map(Object.entries({
     version: [2, 'draft-02'],
   },
   jwtIntrospection: {
-    name: 'JWT Response for OAuth Token Introspection - draft 08',
+    name: 'JWT Response for OAuth Token Introspection - draft 09',
     type: 'IETF OAuth Working Group draft',
-    url: 'https://tools.ietf.org/html/draft-ietf-oauth-jwt-introspection-response-08',
-    version: [8, 'draft-08'],
+    url: 'https://tools.ietf.org/html/draft-ietf-oauth-jwt-introspection-response-09',
+    version: ['draft-09'],
   },
   jwtResponseModes: {
     name: 'JWT Secured Authorization Response Mode for OAuth 2.0 - draft 02',


### PR DESCRIPTION
Adds the expected acknowledgement for `draft-09` for the `jwtIntrospection`.

This enables users of this library to acknowledge the proper jwt introspection draft version that this library is currently using, it further prevents users who have acknowledged `draft-08` previously from unexpectedly breaking their application when updating the library.

This MR fixes #734 