### PR TITLE
Remove discovery

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,7 +105,6 @@ const Provider = require('oidc-provider');
 const configuration = {
   // ... see the available options in Configuration options section
   features: {
-    discovery: true,
     registration: { initialAccessToken: true },
   },
   format: { default: 'opaque' },


### PR DESCRIPTION
Remove discovery option as it throws error "features are no longer enabled/disabled with a boolean value, please see the docs"