### PR TITLE
fix(typescript): findAccount may return undefined

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,7 +14,7 @@ export {};
 
 export type CanBePromise<T> = Promise<T> | T;
 export type RetryFunction = (retry: number, error: Error) => number;
-export type FindAccount = (ctx: KoaContextWithOIDC, sub: string, token?: AuthorizationCode | AccessToken | DeviceCode) => CanBePromise<Account>;
+export type FindAccount = (ctx: KoaContextWithOIDC, sub: string, token?: AuthorizationCode | AccessToken | DeviceCode) => CanBePromise<Account | undefined | null>;
 export type TokenFormat = 'opaque' | 'jwt' | 'jwt-ietf' | 'paseto';
 
 export type AccessTokenFormatFunction = (ctx: KoaContextWithOIDC, token: AccessToken) => TokenFormat;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -14,7 +14,7 @@ export {};
 
 export type CanBePromise<T> = Promise<T> | T;
 export type RetryFunction = (retry: number, error: Error) => number;
-export type FindAccount = (ctx: KoaContextWithOIDC, sub: string, token?: AuthorizationCode | AccessToken | DeviceCode) => CanBePromise<Account | undefined | null>;
+export type FindAccount = (ctx: KoaContextWithOIDC, sub: string, token?: AuthorizationCode | AccessToken | DeviceCode) => CanBePromise<Account | undefined>;
 export type TokenFormat = 'opaque' | 'jwt' | 'jwt-ietf' | 'paseto';
 
 export type AccessTokenFormatFunction = (ctx: KoaContextWithOIDC, token: AccessToken) => TokenFormat;

--- a/types/oidc-provider-tests.ts
+++ b/types/oidc-provider-tests.ts
@@ -325,15 +325,17 @@ const provider = new Provider('https://op.example.com', {
       token.iat.toFixed();
     }
 
-    return {
-      accountId: sub,
-      async claims() {
-        return {
-          sub,
-          foo: 'bar',
-        };
-      },
-    };
+    if (Math.random() > 0.5) {
+      return {
+        accountId: sub,
+        async claims() {
+          return {
+            sub,
+            foo: 'bar',
+          };
+        },
+      };
+    }
   },
   async rotateRefreshToken(ctx) {
     ctx.oidc.issuer.substring(0);


### PR DESCRIPTION
All findAccount call sites handle the possibility that a falsy value is
returned, indicating that no account was found.