### PR TITLE
fix: loopback redirectUriAllowed protocol check

### DIFF
--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -457,7 +457,7 @@ module.exports = function getClient(provider) {
       if (
         match
         || this.applicationType !== 'native'
-        || !parsed.protocol === 'http:'
+        || parsed.protocol !== 'http:'
         || !LOOPBACKS.has(parsed.hostname)
       ) {
         return match;


### PR DESCRIPTION
The condition `!parsed.protocol === 'http:'` always returns `false`. The `!` operator has a higher precedence than the `===` operator. `parsed.protocol` is a string, so negating it would be `false`. Then, it's clear that `false === 'http:'` is always `false`.

It seems that the intended check was `parsed.protocol !== 'http:'`.