### PR TITLE
fix(typescript): interaction result may be undefined

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -190,7 +190,7 @@ declare class Interaction extends BaseModel {
   };
   params: AnyObject;
   prompt: PromptDetail;
-  result: InteractionResults;
+  result?: InteractionResults;
   returnTo: string;
   signed?: string[];
   uid: string;


### PR DESCRIPTION
Fix result typing which can be undefined when getting the interaction from `interactionDetails()` 