### PR TITLE
docs: update the claims section

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1961,7 +1961,10 @@ async function audiences(ctx, sub, token, use) {
 
 ### claims
 
-Describes the claims that the OpenID Provider MAY be able to supply values for. It is also used to define which claims fall under what scope (configure `{ scopeName: ['claim', 'another-claim'] }`) as well as to expose additional claims that are available to RPs via the `claims` authorization parameter (configure as `{ claimName: null }`).   
+Defines the claims that the OpenID Provider MAY be able to supply values for.   
+ It defines 2 different things:
+ - which additional claims are available to RPs (configure as `{ claimName: null }`)
+ - which claims fall under what scope (configure `{ scopeName: ['claim', 'another-claim'] }`)   
   
 
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1961,8 +1961,8 @@ async function audiences(ctx, sub, token, use) {
 
 ### claims
 
-Defines the claims that the OpenID Provider MAY be able to supply values for.   
- It defines 2 different things:
+Describes the claims that the OpenID Provider MAY be able to supply values for.   
+ It is used to achieve two different things related to claims:
  - which additional claims are available to RPs (configure as `{ claimName: null }`)
  - which claims fall under what scope (configure `{ scopeName: ['claim', 'another-claim'] }`)   
   

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -485,11 +485,11 @@ function getDefaults() {
     /*
      * claims
      *
-     * description: Describes the claims that the OpenID Provider MAY be able to
-     *   supply values for. It is also used to define which claims fall under what scope (configure
-     *   `{ scopeName: ['claim', 'another-claim'] }`) as well as to expose additional claims that
-     *   are available to RPs via the `claims` authorization parameter (configure as
-     *   `{ claimName: null }`).
+     * description: Defines the claims that the OpenID Provider MAY be able to supply values for.
+     *
+     * It defines 2 different things:
+     * - which additional claims are available to RPs (configure as `{ claimName: null }`)
+     * - which claims fall under what scope (configure `{ scopeName: ['claim', 'another-claim'] }`)
      *
      * example: OpenID Connect 1.0 Standard Claims
      *

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -485,9 +485,9 @@ function getDefaults() {
     /*
      * claims
      *
-     * description: Defines the claims that the OpenID Provider MAY be able to supply values for.
+     * description: Describes the claims that the OpenID Provider MAY be able to supply values for.
      *
-     * It defines 2 different things:
+     * It is used to achieve two different things related to claims:
      * - which additional claims are available to RPs (configure as `{ claimName: null }`)
      * - which claims fall under what scope (configure `{ scopeName: ['claim', 'another-claim'] }`)
      *


### PR DESCRIPTION
This is not the ultimate wording, but at least it clearly shows that `claims` does actually 2 kind of different things with a different syntax