### PR TITLE
Provider configuration getter

### DIFF
--- a/lib/actions/authorization/assign_claims.js
+++ b/lib/actions/authorization/assign_claims.js
@@ -1,5 +1,4 @@
 const merge = require('../../helpers/_/merge');
-const instance = require('../../helpers/weak_cache');
 
 /*
  * Merges requested claims with auth_time as requested if max_age is provided or require_auth_time
@@ -10,7 +9,7 @@ const instance = require('../../helpers/weak_cache');
 module.exports = function assignClaims(ctx, next) {
   const { params } = ctx.oidc;
 
-  if (params.claims !== undefined && instance(ctx.oidc.provider).configuration('features.claimsParameter.enabled')) {
+  if (params.claims !== undefined && ctx.oidc.provider.configuration('features.claimsParameter.enabled')) {
     ctx.oidc.claims = JSON.parse(params.claims);
   }
 

--- a/lib/actions/authorization/check_claims.js
+++ b/lib/actions/authorization/check_claims.js
@@ -1,5 +1,4 @@
 const { InvalidRequest } = require('../../helpers/errors');
-const instance = require('../../helpers/weak_cache');
 const isPlainObject = require('../../helpers/_/is_plain_object');
 
 /*
@@ -19,7 +18,7 @@ module.exports = function checkClaims(ctx, next) {
   const { params } = ctx.oidc;
 
   if (params.claims !== undefined) {
-    const { features: { claimsParameter, userinfo } } = instance(ctx.oidc.provider).configuration();
+    const { features: { claimsParameter, userinfo } } = ctx.oidc.provider.configuration();
 
     if (claimsParameter.enabled) {
       if (params.response_type === 'none') {

--- a/lib/actions/authorization/check_client.js
+++ b/lib/actions/authorization/check_client.js
@@ -5,7 +5,6 @@ const {
 } = require('../../helpers/errors');
 const presence = require('../../helpers/validate_presence');
 const base64url = require('../../helpers/base64url');
-const instance = require('../../helpers/weak_cache');
 const { PUSHED_REQUEST_URN } = require('../../consts');
 
 const rejectRequestAndUri = require('./reject_request_and_uri');
@@ -21,7 +20,7 @@ const loadPushedAuthorizationRequest = require('./load_pushed_authorization_requ
  */
 module.exports = async function checkClient(ctx, next) {
   const { oidc: { params } } = ctx;
-  const { pushedAuthorizationRequests } = instance(ctx.oidc.provider).configuration('features');
+  const { pushedAuthorizationRequests } = ctx.oidc.provider.configuration('features');
 
   try {
     presence(ctx, 'client_id');

--- a/lib/actions/authorization/check_pkce.js
+++ b/lib/actions/authorization/check_pkce.js
@@ -1,5 +1,4 @@
 const { InvalidRequest } = require('../../helpers/errors');
-const instance = require('../../helpers/weak_cache');
 const checkFormat = require('../../helpers/pkce_format');
 
 /*
@@ -9,7 +8,7 @@ const checkFormat = require('../../helpers/pkce_format');
  */
 module.exports = function checkPKCE(ctx, next) {
   const { params } = ctx.oidc;
-  const { pkce } = instance(ctx.oidc.provider).configuration();
+  const { pkce } = ctx.oidc.provider.configuration();
 
   if (!params.code_challenge_method && params.code_challenge) {
     if (pkce.methods.includes('plain')) {

--- a/lib/actions/authorization/check_prompt.js
+++ b/lib/actions/authorization/check_prompt.js
@@ -1,5 +1,4 @@
 const { InvalidRequest } = require('../../helpers/errors');
-const instance = require('../../helpers/weak_cache');
 
 /*
  * Checks that all requested prompts are supported and validates prompt none is not combined with
@@ -10,7 +9,7 @@ const instance = require('../../helpers/weak_cache');
 module.exports = function checkPrompt(ctx, next) {
   if (ctx.oidc.params.prompt !== undefined) {
     const { prompts } = ctx.oidc;
-    const supported = instance(ctx.oidc.provider).configuration('prompts');
+    const supported = ctx.oidc.provider.configuration('prompts');
 
     for (const prompt of prompts) { // eslint-disable-line no-restricted-syntax
       if (!supported.has(prompt)) {

--- a/lib/actions/authorization/check_response_mode.js
+++ b/lib/actions/authorization/check_response_mode.js
@@ -47,7 +47,7 @@ module.exports = function checkResponseMode(ctx, next, forceCheck) {
     throw new InvalidRequest('response_mode not allowed for this response_type unless encrypted');
   }
 
-  if (params.response_type && instance(ctx.oidc.provider).configuration('features.fapiRW.enabled')) {
+  if (params.response_type && ctx.oidc.provider.configuration('features.fapiRW.enabled')) {
     if ((!params.request || forceCheck) && !params.response_type.includes('id_token') && !JWT) {
       throw new InvalidRequest('response_mode not allowed for this response_type in FAPI mode');
     }

--- a/lib/actions/authorization/check_response_type.js
+++ b/lib/actions/authorization/check_response_type.js
@@ -1,4 +1,3 @@
-const instance = require('../../helpers/weak_cache');
 const {
   UnsupportedResponseType,
   UnauthorizedClient,
@@ -13,7 +12,7 @@ const {
  */
 module.exports = function checkResponseType(ctx, next) {
   const { params } = ctx.oidc;
-  const supported = instance(ctx.oidc.provider).configuration('responseTypes');
+  const supported = ctx.oidc.provider.configuration('responseTypes');
 
   params.response_type = [...new Set(params.response_type.split(' '))].sort().join(' ');
 

--- a/lib/actions/authorization/check_scope.js
+++ b/lib/actions/authorization/check_scope.js
@@ -1,4 +1,3 @@
-const instance = require('../../helpers/weak_cache');
 const { InvalidScope } = require('../../helpers/errors');
 const { DYNAMIC_SCOPE_LABEL } = require('../../consts');
 
@@ -9,7 +8,7 @@ const { DYNAMIC_SCOPE_LABEL } = require('../../consts');
  * @throws: invalid_request
  */
 module.exports = function checkScope(PARAM_LIST, ctx, next) {
-  const { scopes: statics, dynamicScopes: dynamics } = instance(ctx.oidc.provider).configuration();
+  const { scopes: statics, dynamicScopes: dynamics } = ctx.oidc.provider.configuration();
   const { prompts, client } = ctx.oidc;
 
   let whitelist;

--- a/lib/actions/authorization/check_web_message_uri.js
+++ b/lib/actions/authorization/check_web_message_uri.js
@@ -1,5 +1,4 @@
 const { WebMessageUriMismatch } = require('../../helpers/errors');
-const instance = require('../../helpers/weak_cache');
 
 /*
  * Checks that provided web_message_uri is whitelisted by the client configuration
@@ -10,7 +9,7 @@ module.exports = function checkWebMessageUri(ctx, next) {
   const { oidc } = ctx;
   const { client, params } = oidc;
 
-  if (instance(ctx.oidc.provider).configuration('features.webMessageResponseMode.enabled')) {
+  if (ctx.oidc.provider.configuration('features.webMessageResponseMode.enabled')) {
     if (params.web_message_uri && !client.webMessageUriAllowed(params.web_message_uri)) {
       throw new WebMessageUriMismatch();
     } else {

--- a/lib/actions/authorization/device_authorization_response.js
+++ b/lib/actions/authorization/device_authorization_response.js
@@ -1,10 +1,9 @@
 const debug = require('debug')('oidc-provider:device_authorization');
 
 const { generate, normalize } = require('../../helpers/user_codes');
-const instance = require('../../helpers/weak_cache');
 
 module.exports = async function deviceAuthorizationResponse(ctx, next) {
-  const { charset, mask, deviceInfo } = instance(ctx.oidc.provider).configuration('features.deviceFlow');
+  const { charset, mask, deviceInfo } = ctx.oidc.provider.configuration('features.deviceFlow');
   const userCode = generate(charset, mask);
 
   const dc = new ctx.oidc.provider.DeviceCode({

--- a/lib/actions/authorization/device_user_flow_response.js
+++ b/lib/actions/authorization/device_user_flow_response.js
@@ -1,12 +1,10 @@
 const debug = require('debug')('oidc-provider:authentication:success');
 
-const instance = require('../../helpers/weak_cache');
-
 module.exports = async function deviceVerificationResponse(ctx, next) {
   const {
     expiresWithSession,
     features: { deviceFlow: { successSource }, resourceIndicators },
-  } = instance(ctx.oidc.provider).configuration();
+  } = ctx.oidc.provider.configuration();
   const code = ctx.oidc.deviceCode;
 
   const scope = ctx.oidc.acceptedScope();

--- a/lib/actions/authorization/fetch_request_uri.js
+++ b/lib/actions/authorization/fetch_request_uri.js
@@ -23,7 +23,7 @@ const rejectRequestAndUri = require('./reject_request_and_uri');
  * @throws: request_uri_not_supported
  */
 module.exports = async function fetchRequestUri(ctx, next) {
-  const { pushedAuthorizationRequests } = instance(ctx.oidc.provider).configuration('features');
+  const { pushedAuthorizationRequests } = ctx.oidc.provider.configuration('features');
   const { params } = ctx.oidc;
 
   rejectRequestAndUri(ctx, () => {});

--- a/lib/actions/authorization/index.js
+++ b/lib/actions/authorization/index.js
@@ -3,7 +3,6 @@ const bodyParser = require('../../shared/conditional_body');
 const rejectDupes = require('../../shared/reject_dupes');
 const paramsMiddleware = require('../../shared/assemble_params');
 const sessionMiddleware = require('../../shared/session');
-const instance = require('../../helpers/weak_cache');
 const { PARAM_LIST } = require('../../consts');
 const checkResource = require('../../shared/check_resource');
 const getTokenAuth = require('../../shared/token_auth');
@@ -63,7 +62,7 @@ module.exports = function authorizationAction(provider, endpoint) {
       webMessageResponseMode,
     },
     extraParams,
-  } = instance(provider).configuration();
+  } = provider.configuration();
 
   const whitelist = new Set(PARAM_LIST);
 

--- a/lib/actions/authorization/interactions.js
+++ b/lib/actions/authorization/interactions.js
@@ -9,7 +9,6 @@ const upperFirst = require('../../helpers/_/upper_first');
 const camelCase = require('../../helpers/_/camel_case');
 const ssHandler = require('../../helpers/samesite_handler');
 const errors = require('../../helpers/errors');
-const instance = require('../../helpers/weak_cache');
 
 /* eslint-disable no-restricted-syntax, no-await-in-loop */
 
@@ -18,7 +17,7 @@ module.exports = async function interactions(resumeRouteName, ctx, next) {
   let failedCheck;
   let prompt;
 
-  const { policy, url: interactionUrl } = instance(oidc.provider).configuration('interactions');
+  const { policy, url: interactionUrl } = oidc.provider.configuration('interactions');
 
   for (const { name, checks, details: promptDetails } of policy) {
     let results = (await Promise.all([...checks].map(async ({
@@ -93,7 +92,7 @@ module.exports = async function interactions(resumeRouteName, ctx, next) {
     throw err;
   }
 
-  const cookieOptions = instance(oidc.provider).configuration('cookies.short');
+  const cookieOptions = oidc.provider.configuration('cookies.short');
   const returnTo = oidc.urlFor(resumeRouteName, {
     uid: oidc.uid,
     ...(oidc.deviceCode ? { user_code: oidc.deviceCode.userCode } : undefined),

--- a/lib/actions/authorization/oidc_required.js
+++ b/lib/actions/authorization/oidc_required.js
@@ -1,4 +1,3 @@
-const instance = require('../../helpers/weak_cache');
 const presence = require('../../helpers/validate_presence');
 
 /*
@@ -21,11 +20,11 @@ module.exports = function oidcRequired(ctx, next) {
 
   // TODO: add the following once https://bitbucket.org/openid/fapi/issues/270/jarm-fapi-rw-openid-client-session-binding
   // is resolved and the FAPI suite updated
-  // else if (instance(ctx.oidc.provider).configuration('features.fapiRW.enabled')) {
+  // else if (ctx.oidc.provider.configuration('features.fapiRW.enabled')) {
   //   required.add('state');
   // }
 
-  if (instance(ctx.oidc.provider).configuration('features.fapiRW.enabled')) {
+  if (ctx.oidc.provider.configuration('features.fapiRW.enabled')) {
     required.add(ctx.oidc.requestParamScopes.has('openid') ? 'nonce' : 'state');
   }
 

--- a/lib/actions/authorization/process_response_types.js
+++ b/lib/actions/authorization/process_response_types.js
@@ -1,5 +1,3 @@
-const instance = require('../../helpers/weak_cache');
-
 async function tokenHandler(ctx) {
   const accountId = ctx.oidc.session.accountId();
   const scope = ctx.oidc.acceptedScope();
@@ -14,7 +12,7 @@ async function tokenHandler(ctx) {
     sid: ctx.oidc.session.sidFor(ctx.oidc.client.clientId),
   });
 
-  const { audiences, expiresWithSession } = instance(ctx.oidc.provider).configuration();
+  const { audiences, expiresWithSession } = ctx.oidc.provider.configuration();
 
   if (await expiresWithSession(ctx, token)) {
     token.expiresWithSession = true;
@@ -56,7 +54,7 @@ async function codeHandler(ctx) {
 
   const {
     expiresWithSession, features: { resourceIndicators },
-  } = instance(ctx.oidc.provider).configuration();
+  } = ctx.oidc.provider.configuration();
 
   if (await expiresWithSession(ctx, code)) {
     code.expiresWithSession = true;
@@ -90,7 +88,7 @@ async function idTokenHandler(ctx) {
 
   const {
     conformIdTokenClaims, features: { userinfo },
-  } = instance(ctx.oidc.provider).configuration();
+  } = ctx.oidc.provider.configuration();
 
   if (conformIdTokenClaims && userinfo.enabled) {
     if (ctx.oidc.params.response_type === 'id_token') {

--- a/lib/actions/authorization/reject_unsupported.js
+++ b/lib/actions/authorization/reject_unsupported.js
@@ -1,5 +1,4 @@
 const { RequestNotSupported, RequestUriNotSupported } = require('../../helpers/errors');
-const instance = require('../../helpers/weak_cache');
 
 /*
  * Rejects registration parameter as not supported.
@@ -7,7 +6,7 @@ const instance = require('../../helpers/weak_cache');
  * @throws: registration_not_supported
  */
 module.exports = function rejectUnsupported(ctx, next) {
-  const { requestObjects } = instance(ctx.oidc.provider).configuration('features');
+  const { requestObjects } = ctx.oidc.provider.configuration('features');
   const { params } = ctx.oidc;
 
   if (!requestObjects.request && params.request !== undefined && ctx.oidc.route !== 'pushed_authorization_request') {

--- a/lib/actions/authorization/respond.js
+++ b/lib/actions/authorization/respond.js
@@ -21,11 +21,11 @@ module.exports = async function respond(ctx, next) {
     out.state = params.state;
   }
 
-  if (instance(ctx.oidc.provider).configuration('features.sessionManagement.enabled')) {
+  if (ctx.oidc.provider.configuration('features.sessionManagement.enabled')) {
     out.session_state = processSessionState(ctx, params.redirect_uri);
   }
 
-  if (instance(ctx.oidc.provider).configuration('features.issAuthResp.enabled')) {
+  if (ctx.oidc.provider.configuration('features.issAuthResp.enabled')) {
     out.iss = ctx.oidc.provider.issuer;
   }
 

--- a/lib/actions/authorization/resume.js
+++ b/lib/actions/authorization/resume.js
@@ -5,14 +5,13 @@ const isPlainObject = require('../../helpers/_/is_plain_object');
 const camelCase = require('../../helpers/_/camel_case');
 const nanoid = require('../../helpers/nanoid');
 const errors = require('../../helpers/errors');
-const instance = require('../../helpers/weak_cache');
 const Params = require('../../helpers/params');
 const formPost = require('../../response_modes/form_post');
 const ssHandler = require('../../helpers/samesite_handler');
 const epochTime = require('../../helpers/epoch_time');
 
 module.exports = async function resumeAction(whitelist, resumeRouteName, ctx, next) {
-  const { maxAge, expires, ...cookieOptions } = instance(ctx.oidc.provider).configuration('cookies.short');
+  const { maxAge, expires, ...cookieOptions } = ctx.oidc.provider.configuration('cookies.short');
 
   const cookieId = ssHandler.get(
     ctx.oidc.cookies,

--- a/lib/actions/check_session.js
+++ b/lib/actions/check_session.js
@@ -1,4 +1,3 @@
-const instance = require('../helpers/weak_cache');
 const { json: parseBody } = require('../shared/selective_body');
 const noCache = require('../shared/no_cache');
 const paramsMiddleware = require('../shared/assemble_params');
@@ -9,7 +8,7 @@ const PARAM_LIST = new Set(['client_id', 'origin']);
 
 module.exports = {
   get: async function checkSessionIframe(ctx, next) {
-    const { keepHeaders, scriptNonce } = instance(ctx.oidc.provider).configuration('features.sessionManagement');
+    const { keepHeaders, scriptNonce } = ctx.oidc.provider.configuration('features.sessionManagement');
     const csp = ctx.response.get('Content-Security-Policy');
     if (!keepHeaders) {
       ctx.response.remove('X-Frame-Options');

--- a/lib/actions/code_verification.js
+++ b/lib/actions/code_verification.js
@@ -4,7 +4,6 @@ const sessionMiddleware = require('../shared/session');
 const paramsMiddleware = require('../shared/assemble_params');
 const bodyParser = require('../shared/conditional_body');
 const rejectDupes = require('../shared/reject_dupes');
-const instance = require('../helpers/weak_cache');
 const { InvalidClient, InvalidRequest } = require('../helpers/errors');
 const {
   NoCodeError, NotFoundError, ExpiredError, AlreadyUsedError, AbortedError,
@@ -22,7 +21,7 @@ module.exports = {
     async function renderCodeVerification(ctx, next) {
       const {
         features: { deviceFlow: { charset, userCodeInputSource } },
-      } = instance(ctx.oidc.provider).configuration();
+      } = ctx.oidc.provider.configuration();
 
       // TODO: generic xsrf middleware to remove this
       const secret = crypto.randomBytes(24).toString('hex');
@@ -58,7 +57,7 @@ module.exports = {
     },
 
     async function loadDeviceCodeByUserInput(ctx, next) {
-      const { userCodeConfirmSource, mask } = instance(ctx.oidc.provider).configuration('features.deviceFlow');
+      const { userCodeConfirmSource, mask } = ctx.oidc.provider.configuration('features.deviceFlow');
       const { user_code: userCode, confirm, abort } = ctx.oidc.params;
 
       if (!userCode) {

--- a/lib/actions/discovery.js
+++ b/lib/actions/discovery.js
@@ -1,11 +1,10 @@
 /* eslint-disable max-len */
 
 const defaults = require('../helpers/_/defaults');
-const instance = require('../helpers/weak_cache');
 const { DYNAMIC_SCOPE_LABEL } = require('../consts');
 
 module.exports = function discovery(ctx, next) {
-  const config = instance(ctx.oidc.provider).configuration();
+  const config = ctx.oidc.provider.configuration();
   const { features } = config;
 
   ctx.body = {

--- a/lib/actions/end_session.js
+++ b/lib/actions/end_session.js
@@ -4,7 +4,6 @@ const url = require('url');
 const { InvalidClient, InvalidRequest, OIDCProviderError } = require('../helpers/errors');
 const JWT = require('../helpers/jwt');
 const redirectUri = require('../helpers/redirect_uri');
-const instance = require('../helpers/weak_cache');
 const rejectDupes = require('../shared/reject_dupes');
 const bodyParser = require('../shared/conditional_body');
 const paramsMiddleware = require('../shared/assemble_params');
@@ -95,7 +94,7 @@ module.exports = {
         ctx.status = 200;
 
         const formHtml = `<form id="op.logoutForm" method="post" action="${action}"><input type="hidden" name="xsrf" value="${secret}"/></form>`;
-        await instance(ctx.oidc.provider).configuration('features.rpInitiatedLogout.logoutSource')(ctx, formHtml);
+        await ctx.oidc.provider.configuration('features.rpInitiatedLogout.logoutSource')(ctx, formHtml);
       } else {
         await formPost(ctx, action, {
           xsrf: secret,
@@ -131,7 +130,7 @@ module.exports = {
       const {
         features: { backchannelLogout, frontchannelLogout, sessionManagement },
         cookies: { long: { maxAge, expires, ...opts } },
-      } = instance(ctx.oidc.provider).configuration();
+      } = ctx.oidc.provider.configuration();
 
       const front = [];
 
@@ -276,7 +275,7 @@ module.exports = {
         }
         ctx.oidc.entity('Client', client);
       }
-      await instance(ctx.oidc.provider).configuration('features.rpInitiatedLogout.postLogoutSuccessSource')(ctx);
+      await ctx.oidc.provider.configuration('features.rpInitiatedLogout.postLogoutSuccessSource')(ctx);
     },
   ],
 };

--- a/lib/actions/grants/authorization_code.js
+++ b/lib/actions/grants/authorization_code.js
@@ -2,7 +2,6 @@ const uidToGrantId = require('debug')('oidc-provider:uid');
 
 const { InvalidGrant } = require('../../helpers/errors');
 const presence = require('../../helpers/validate_presence');
-const instance = require('../../helpers/weak_cache');
 const checkPKCE = require('../../helpers/pkce');
 const revokeGrant = require('../../helpers/revoke_grant');
 
@@ -14,7 +13,7 @@ module.exports.handler = async function authorizationCodeHandler(ctx, next) {
     audiences,
     conformIdTokenClaims,
     features: { userinfo, dPoP: { iatTolerance }, mTLS: { getCertificate } },
-  } = instance(ctx.oidc.provider).configuration();
+  } = ctx.oidc.provider.configuration();
 
   if (ctx.oidc.params.redirect_uri === undefined) {
     // It is permitted to omit the redirect_uri if only ONE is registered on the client

--- a/lib/actions/grants/client_credentials.js
+++ b/lib/actions/grants/client_credentials.js
@@ -1,4 +1,3 @@
-const instance = require('../../helpers/weak_cache');
 const { InvalidGrant } = require('../../helpers/errors');
 const { InvalidScope } = require('../../helpers/errors');
 const { DYNAMIC_SCOPE_LABEL } = require('../../consts');
@@ -10,7 +9,7 @@ module.exports.handler = async function clientCredentialsHandler(ctx, next) {
     scopes: statics,
     dynamicScopes: dynamics,
     features: { dPoP: { iatTolerance }, mTLS: { getCertificate } },
-  } = instance(ctx.oidc.provider).configuration();
+  } = ctx.oidc.provider.configuration();
 
   let whitelist;
   if (ctx.oidc.client.scope) {

--- a/lib/actions/grants/device_code.js
+++ b/lib/actions/grants/device_code.js
@@ -5,7 +5,6 @@ const upperFirst = require('../../helpers/_/upper_first');
 const camelCase = require('../../helpers/_/camel_case');
 const errors = require('../../helpers/errors');
 const presence = require('../../helpers/validate_presence');
-const instance = require('../../helpers/weak_cache');
 
 const { InvalidGrant, ExpiredToken, AuthorizationPending } = errors;
 
@@ -19,7 +18,7 @@ module.exports.handler = async function deviceCodeHandler(ctx, next) {
     conformIdTokenClaims,
     audiences,
     features: { userinfo, dPoP: { iatTolerance }, mTLS: { getCertificate } },
-  } = instance(ctx.oidc.provider).configuration();
+  } = ctx.oidc.provider.configuration();
 
   const code = await ctx.oidc.provider.DeviceCode.find(ctx.oidc.params.device_code, {
     ignoreExpiration: true,

--- a/lib/actions/grants/refresh_token.js
+++ b/lib/actions/grants/refresh_token.js
@@ -4,7 +4,6 @@ const get = require('../../helpers/_/get');
 const difference = require('../../helpers/_/difference');
 const { InvalidGrant, InvalidScope } = require('../../helpers/errors');
 const presence = require('../../helpers/validate_presence');
-const instance = require('../../helpers/weak_cache');
 const revokeGrant = require('../../helpers/revoke_grant');
 const { 'x5t#S256': thumbprint } = require('../../helpers/calculate_thumbprint');
 const formatters = require('../../helpers/formatters');
@@ -14,7 +13,7 @@ const gty = 'refresh_token';
 module.exports.handler = async function refreshTokenHandler(ctx, next) {
   presence(ctx, 'refresh_token');
 
-  const conf = instance(ctx.oidc.provider).configuration();
+  const conf = ctx.oidc.provider.configuration();
 
   const {
     audiences,

--- a/lib/actions/interaction.js
+++ b/lib/actions/interaction.js
@@ -6,7 +6,6 @@ const { inspect } = require('util');
 const attention = require('../helpers/attention');
 const { urlencoded: parseBody } = require('../shared/selective_body');
 const views = require('../views');
-const instance = require('../helpers/weak_cache');
 const noCache = require('../shared/no_cache');
 const { interactions: { url: defaultInteractionUri } } = require('../helpers/defaults')();
 
@@ -24,18 +23,19 @@ module.exports = function devInteractions(provider) {
   attention.warn('a quick start development-only feature devInteractions is enabled, \
 you are expected to disable these interactions and provide your own');
 
-  const configuration = instance(provider).configuration('interactions');
+  const configuration = provider.configuration('interactions');
 
   /* istanbul ignore if */
   if (configuration.url !== defaultInteractionUri) {
     attention.warn('you\'ve configured your own interactions.url but devInteractions are still enabled, \
 your configuration is not in effect');
   }
-  /* eslint-enable */
 
-  instance(provider).configuration('interactions').url = async function interactionUrl(ctx) {
+  /* eslint-disable no-param-reassign */
+  provider.configuration('interactions').url = async function interactionUrl(ctx) {
     return url.parse(ctx.oidc.urlFor('interaction', { uid: ctx.oidc.uid })).pathname;
   };
+  /* eslint-enable */
 
   return {
     render: [

--- a/lib/actions/introspection.js
+++ b/lib/actions/introspection.js
@@ -18,7 +18,7 @@ const JWT = 'application/token-introspection+jwt';
 module.exports = function introspectionAction(provider) {
   const { params: authParams, middleware: tokenAuth } = getTokenAuth(provider, 'introspection');
   const PARAM_LIST = new Set(['token', 'token_type_hint', ...authParams]);
-  const configuration = instance(provider).configuration();
+  const configuration = provider.configuration();
   const {
     pairwiseIdentifier, features: {
       introspection: { allowedPolicy },

--- a/lib/actions/registration.js
+++ b/lib/actions/registration.js
@@ -60,7 +60,7 @@ module.exports = {
     parseBody,
     async function validateInitialAccessToken(ctx, next) {
       const { oidc: { provider } } = ctx;
-      const { initialAccessToken } = instance(provider).configuration('features.registration');
+      const { initialAccessToken } = provider.configuration('features.registration');
       switch (initialAccessToken && typeof initialAccessToken) {
         case 'boolean': {
           const iat = await provider.InitialAccessToken.find(ctx.oidc.getAccessToken());
@@ -84,7 +84,7 @@ module.exports = {
     },
     async function registrationResponse(ctx, next) {
       const { oidc: { provider } } = ctx;
-      const { idFactory, secretFactory } = instance(provider).configuration('features.registration');
+      const { idFactory, secretFactory } = provider.configuration('features.registration');
       const properties = {};
       const clientId = idFactory(ctx);
 
@@ -114,7 +114,7 @@ module.exports = {
         && ctx.oidc.entities.InitialAccessToken.policies
       ) {
         const { policies } = ctx.oidc.entities.InitialAccessToken;
-        const implementations = instance(provider).configuration('features.registration.policies');
+        const implementations = provider.configuration('features.registration.policies');
         for (const policy of policies) { // eslint-disable-line no-restricted-syntax
           await implementations[policy](ctx, properties); // eslint-disable-line no-await-in-loop
         }
@@ -205,7 +205,7 @@ module.exports = {
       }, (value) => value === null || value === '');
 
       const { oidc: { provider } } = ctx;
-      const { secretFactory } = instance(provider).configuration('features.registration');
+      const { secretFactory } = provider.configuration('features.registration');
 
       const secretRequired = !ctx.oidc.client.clientSecret
         && provider.Client.needsSecret(properties);
@@ -224,7 +224,7 @@ module.exports = {
 
       if (ctx.oidc.entities.RegistrationAccessToken.policies) {
         const { policies } = ctx.oidc.entities.RegistrationAccessToken;
-        const implementations = instance(provider).configuration('features.registration.policies');
+        const implementations = provider.configuration('features.registration.policies');
         for (const policy of policies) { // eslint-disable-line no-restricted-syntax
           await implementations[policy](ctx, properties); // eslint-disable-line no-await-in-loop
         }
@@ -241,7 +241,7 @@ module.exports = {
         }),
       });
 
-      const management = instance(provider).configuration('features.registrationManagement');
+      const management = provider.configuration('features.registrationManagement');
       if (
         management.rotateRegistrationAccessToken === true
         || (typeof management.rotateRegistrationAccessToken === 'function' && await management.rotateRegistrationAccessToken(ctx))

--- a/lib/actions/token.js
+++ b/lib/actions/token.js
@@ -41,7 +41,7 @@ module.exports = function tokenAction(provider) {
     async function supportedGrantTypeCheck(ctx, next) {
       presence(ctx, 'grant_type');
 
-      const supported = instance(provider).configuration('grantTypes');
+      const supported = provider.configuration('grantTypes');
 
       if (!supported.has(ctx.oidc.params.grant_type)) {
         throw new UnsupportedGrantType();

--- a/lib/actions/userinfo.js
+++ b/lib/actions/userinfo.js
@@ -12,7 +12,6 @@ const rejectDupes = require('../shared/reject_dupes');
 const paramsMiddleware = require('../shared/assemble_params');
 const noCache = require('../shared/no_cache');
 const { 'x5t#S256': thumbprint } = require('../helpers/calculate_thumbprint');
-const instance = require('../helpers/weak_cache');
 
 const PARAM_LIST = new Set([
   'scope',
@@ -25,7 +24,7 @@ module.exports = [
   noCache,
 
   function setFapiInteractionId(ctx, next) {
-    if (instance(ctx.oidc.provider).configuration('features.fapiRW.enabled')) {
+    if (ctx.oidc.provider.configuration('features.fapiRW.enabled')) {
       const header = ctx.get('x-fapi-interaction-id');
       if (header) {
         ctx.set('x-fapi-interaction-id', header);
@@ -60,7 +59,7 @@ module.exports = [
             scope: err.scope,
           } : undefined),
           ...(scheme === 'DPoP' ? {
-            algs: instance(ctx.oidc.provider).configuration('dPoPSigningAlgValues').join(' '),
+            algs: ctx.oidc.provider.configuration('dPoPSigningAlgValues').join(' '),
           } : undefined),
         });
       }
@@ -91,7 +90,7 @@ module.exports = [
     }
 
     if (accessToken['x5t#S256']) {
-      const getCertificate = instance(ctx.oidc.provider).configuration('features.mTLS.getCertificate');
+      const getCertificate = ctx.oidc.provider.configuration('features.mTLS.getCertificate');
       const cert = getCertificate(ctx);
       if (!cert || accessToken['x5t#S256'] !== thumbprint(cert)) {
         throw new InvalidToken('failed x5t#S256 verification');
@@ -102,7 +101,7 @@ module.exports = [
 
     if (dPoP) {
       const unique = await ctx.oidc.provider.ReplayDetection.unique(
-        accessToken.clientId, dPoP.jti, dPoP.iat + instance(ctx.oidc.provider).configuration('features.dPoP.iatTolerance'),
+        accessToken.clientId, dPoP.jti, dPoP.iat + ctx.oidc.provider.configuration('features.dPoP.iatTolerance'),
       );
 
       ctx.assert(unique, new InvalidToken('DPoP Token Replay detected'));

--- a/lib/helpers/claims.js
+++ b/lib/helpers/claims.js
@@ -1,6 +1,5 @@
 const { strict: assert } = require('assert');
 
-const instance = require('./weak_cache');
 const pick = require('./_/pick');
 const merge = require('./_/merge');
 const isPlainObject = require('./_/is_plain_object');
@@ -8,7 +7,7 @@ const isPlainObject = require('./_/is_plain_object');
 module.exports = function getClaims(provider) {
   const {
     claims: claimConfig, claimsSupported, scopes, dynamicScopes, pairwiseIdentifier,
-  } = instance(provider).configuration();
+  } = provider.configuration();
 
   return class Claims {
     constructor(available, { ctx, client = ctx ? ctx.oidc.client : undefined }) {

--- a/lib/helpers/client_schema.js
+++ b/lib/helpers/client_schema.js
@@ -42,7 +42,7 @@ function checkClientAuth(schema) {
 }
 
 module.exports = function getSchema(provider) {
-  const configuration = instance(provider).configuration();
+  const configuration = provider.configuration();
   const { features } = configuration;
 
   const { scopes } = configuration;

--- a/lib/helpers/interaction_policy/prompts/login/claims_id_token_sub_value.js
+++ b/lib/helpers/interaction_policy/prompts/login/claims_id_token_sub_value.js
@@ -1,4 +1,3 @@
-const instance = require('../../../weak_cache');
 const Check = require('../../check');
 
 module.exports = () => new Check('claims_id_token_sub_value', 'requested subject could not be obtained', async (ctx) => {
@@ -14,7 +13,7 @@ module.exports = () => new Check('claims_id_token_sub_value', 'requested subject
   }
 
   if (oidc.client.sectorIdentifier) {
-    sub = await instance(oidc.provider).configuration('pairwiseIdentifier')(ctx, sub, oidc.client);
+    sub = await oidc.provider.configuration('pairwiseIdentifier')(ctx, sub, oidc.client);
   }
 
   if (oidc.claims.id_token.sub.value !== sub) {

--- a/lib/helpers/interaction_policy/prompts/login/id_token_hint.js
+++ b/lib/helpers/interaction_policy/prompts/login/id_token_hint.js
@@ -1,4 +1,3 @@
-const instance = require('../../../weak_cache');
 const Check = require('../../check');
 
 module.exports = () => new Check('id_token_hint', 'id_token_hint and authenticated subject do not match', async (ctx) => {
@@ -15,7 +14,7 @@ module.exports = () => new Check('id_token_hint', 'id_token_hint and authenticat
   }
 
   if (oidc.client.sectorIdentifier) {
-    sub = await instance(oidc.provider).configuration('pairwiseIdentifier')(ctx, sub, oidc.client);
+    sub = await oidc.provider.configuration('pairwiseIdentifier')(ctx, sub, oidc.client);
   }
 
   if (payload.sub !== sub) {

--- a/lib/helpers/oidc_context.js
+++ b/lib/helpers/oidc_context.js
@@ -23,7 +23,7 @@ module.exports = function getContext(provider) {
     acceptQueryParamAccessTokens,
     clockTolerance,
     features: { dPoP: dPoPConfig, fapiRW: { enabled: fapiEnabled } },
-  } = instance(provider).configuration();
+  } = provider.configuration();
   const { app } = provider;
 
   class OIDCContext extends events.EventEmitter {
@@ -126,7 +126,7 @@ module.exports = function getContext(provider) {
           {
             maxTokenAge: `${dPoPConfig.iatTolerance} seconds`,
             clockTolerance: `${clockTolerance} seconds`,
-            algorithms: instance(provider).configuration('dPoPSigningAlgValues'),
+            algorithms: provider.configuration('dPoPSigningAlgValues'),
             complete: true,
             typ: 'dpop+jwt',
           },
@@ -167,7 +167,7 @@ module.exports = function getContext(provider) {
           userinfo, id_token: idToken,
         } = JSON.parse(this.params.claims);
 
-        const claims = instance(provider).configuration('claimsSupported');
+        const claims = provider.configuration('claimsSupported');
         if (userinfo) {
           Object.entries(userinfo).forEach(([claim, value]) => {
             if (claims.has(claim) && (value === null || isPlainObject(value))) {
@@ -197,7 +197,7 @@ module.exports = function getContext(provider) {
       const requestParamScopes = new Set();
       if (this.params.scope) {
         const scopes = this.params.scope.split(' ');
-        const { scopes: statics, dynamicScopes: dynamics } = instance(provider).configuration();
+        const { scopes: statics, dynamicScopes: dynamics } = provider.configuration();
         scopes.forEach((scope) => {
           if (statics.has(scope)) {
             requestParamScopes.add(scope);

--- a/lib/helpers/process_session_state.js
+++ b/lib/helpers/process_session_state.js
@@ -2,7 +2,6 @@ const { randomBytes, createHash } = require('crypto');
 const { URL } = require('url');
 
 const base64url = require('./base64url');
-const instance = require('./weak_cache');
 const ssHandler = require('./samesite_handler');
 
 function processSessionState(ctx, redirectUri, salt) {
@@ -32,7 +31,7 @@ function processSessionState(ctx, redirectUri, salt) {
     oidc.cookies,
     stateCookieName,
     state,
-    { ...instance(oidc.provider).configuration('cookies.long'), httpOnly: false, signed: false },
+    { ...oidc.provider.configuration('cookies.long'), httpOnly: false, signed: false },
   );
 
   return salt ? `${sessionState}.${salt}` : sessionState;

--- a/lib/helpers/revoke_grant.js
+++ b/lib/helpers/revoke_grant.js
@@ -1,7 +1,5 @@
-const instance = require('./weak_cache');
-
 module.exports = async function revokeGrant(provider, client, grantId) {
-  const { grantTypes } = instance(provider).configuration();
+  const { grantTypes } = provider.configuration();
   const refreshToken = client ? client.grantTypeAllowed('refresh_token') : grantTypes.has('refresh_token');
   const authorizationCode = client ? client.grantTypeAllowed('authorization_code') : grantTypes.has('authorization_code');
   const deviceCode = client ? client.grantTypeAllowed('urn:ietf:params:oauth:grant-type:device_code') : grantTypes.has('urn:ietf:params:oauth:grant-type:device_code');

--- a/lib/models/base_token.js
+++ b/lib/models/base_token.js
@@ -21,7 +21,7 @@ module.exports = function getBaseToken(provider) {
     }
 
     static expiresIn(...args) {
-      const ttl = instance(provider).configuration(`ttl.${this.name}`);
+      const ttl = provider.configuration(`ttl.${this.name}`);
 
       if (typeof ttl === 'number') {
         return ttl;

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -325,17 +325,17 @@ module.exports = function getClient(provider) {
           if (client[`${endpoint}EndpointAuthSigningAlg`]) {
             algs.add(client[`${endpoint}EndpointAuthSigningAlg`]);
           } else {
-            (instance(provider).configuration(`${endpoint}EndpointAuthSigningAlgValues`) || [])
+            (provider.configuration(`${endpoint}EndpointAuthSigningAlgValues`) || [])
               .forEach(Set.prototype.add.bind(algs));
           }
         }
       });
 
-      instance(provider).configuration('requestObjectSigningAlgValues').forEach(Set.prototype.add.bind(algs));
-      instance(provider).configuration('requestObjectEncryptionAlgValues').forEach(Set.prototype.add.bind(algs));
+      provider.configuration('requestObjectSigningAlgValues').forEach(Set.prototype.add.bind(algs));
+      provider.configuration('requestObjectEncryptionAlgValues').forEach(Set.prototype.add.bind(algs));
 
-      if (instance(provider).configuration('requestObjectEncryptionAlgValues').includes('dir')) {
-        instance(provider).configuration('requestObjectEncryptionEncValues').forEach(Set.prototype.add.bind(algs));
+      if (provider.configuration('requestObjectEncryptionAlgValues').includes('dir')) {
+        provider.configuration('requestObjectEncryptionEncValues').forEach(Set.prototype.add.bind(algs));
       }
 
       [
@@ -554,7 +554,7 @@ module.exports = function getClient(provider) {
         return;
       }
 
-      const clockTolerance = instance(provider).configuration('clockTolerance');
+      const clockTolerance = provider.configuration('clockTolerance');
 
       if (epochTime() - clockTolerance >= this.clientSecretExpiresAt) {
         const err = new InvalidClient(message, `client_id ${this.clientId} client_secret expired at ${this.clientSecretExpiresAt}`);

--- a/lib/models/formats/index.js
+++ b/lib/models/formats/index.js
@@ -1,5 +1,3 @@
-const instance = require('../../helpers/weak_cache');
-
 const opaque = require('./opaque');
 const jwt = require('./jwt');
 const jwtIetf = require('./jwt_ietf');
@@ -14,7 +12,7 @@ module.exports = (provider) => {
   result.jwt = jwt(provider, result); // depends on opaque
   result.paseto = paseto(provider, result); // depends on opaque
 
-  if (instance(provider).configuration('features.ietfJWTAccessTokenProfile.enabled')) {
+  if (provider.configuration('features.ietfJWTAccessTokenProfile.enabled')) {
     result['jwt-ietf'] = jwtIetf(provider, result); // depends on opaque and jwt
   }
 

--- a/lib/models/formats/jwt.js
+++ b/lib/models/formats/jwt.js
@@ -61,7 +61,7 @@ module.exports = (provider, { opaque }) => {
           const client = this.client || await provider.Client.find(azp);
           assert(client && client.clientId === azp);
           if (client.sectorIdentifier) {
-            const pairwiseIdentifier = instance(provider).configuration('pairwiseIdentifier');
+            const pairwiseIdentifier = provider.configuration('pairwiseIdentifier');
             sub = await pairwiseIdentifier(ctx, sub, client);
           }
         }
@@ -90,7 +90,7 @@ module.exports = (provider, { opaque }) => {
           payload: tokenPayload,
         };
 
-        const customizer = instance(provider).configuration('formats.customizers.jwt');
+        const customizer = provider.configuration('formats.customizers.jwt');
         if (customizer) {
           await customizer(ctx, this, structuredToken);
         }

--- a/lib/models/formats/jwt_ietf.js
+++ b/lib/models/formats/jwt_ietf.js
@@ -1,6 +1,5 @@
 const { strict: assert } = require('assert');
 
-const instance = require('../../helpers/weak_cache');
 const JWT = require('../../helpers/jwt');
 const ctxRef = require('../ctx_ref');
 
@@ -36,7 +35,7 @@ module.exports = (provider, { opaque, jwt }) => ({
         const client = this.client || await provider.Client.find(clientId);
         assert(client && client.clientId === clientId);
         if (client.sectorIdentifier) {
-          const pairwiseIdentifier = instance(provider).configuration('pairwiseIdentifier');
+          const pairwiseIdentifier = provider.configuration('pairwiseIdentifier');
           sub = await pairwiseIdentifier(ctx, sub, client);
         }
       }
@@ -67,7 +66,7 @@ module.exports = (provider, { opaque, jwt }) => ({
         payload: tokenPayload,
       };
 
-      const customizer = instance(provider).configuration('formats.customizers.jwt-ietf');
+      const customizer = provider.configuration('formats.customizers.jwt-ietf');
       if (customizer) {
         await customizer(ctx, this, structuredToken);
       }

--- a/lib/models/formats/opaque.js
+++ b/lib/models/formats/opaque.js
@@ -1,7 +1,6 @@
 const pickBy = require('../../helpers/_/pick_by');
 const { assertPayload } = require('../../helpers/jwt');
 const epochTime = require('../../helpers/epoch_time');
-const instance = require('../../helpers/weak_cache');
 const nanoid = require('../../helpers/nanoid');
 const ctxRef = require('../ctx_ref');
 
@@ -27,7 +26,7 @@ module.exports = (provider) => ({
     };
 
     if (withExtra.has(this.kind)) {
-      payload.extra = await instance(provider).configuration('extraAccessTokenClaims')(ctxRef.get(this), this);
+      payload.extra = await provider.configuration('extraAccessTokenClaims')(ctxRef.get(this), this);
     }
 
     return [value, payload];
@@ -38,7 +37,7 @@ module.exports = (provider) => ({
   async verify(token, stored, { ignoreExpiration, foundByReference }) {
     assertPayload(stored, {
       ignoreExpiration,
-      clockTolerance: instance(provider).configuration('clockTolerance'),
+      clockTolerance: provider.configuration('clockTolerance'),
       ...(foundByReference ? undefined : { jti: token }),
     });
 

--- a/lib/models/formats/paseto.js
+++ b/lib/models/formats/paseto.js
@@ -60,7 +60,7 @@ module.exports = (provider, { opaque }) => {
           const client = this.client || await provider.Client.find(clientId);
           assert(client && client.clientId === clientId);
           if (client.sectorIdentifier) {
-            const pairwiseIdentifier = instance(provider).configuration('pairwiseIdentifier');
+            const pairwiseIdentifier = provider.configuration('pairwiseIdentifier');
             sub = await pairwiseIdentifier(ctx, sub, client);
           }
         }
@@ -92,7 +92,7 @@ module.exports = (provider, { opaque }) => {
           footer: undefined,
         };
 
-        const customizer = instance(provider).configuration('formats.customizers.paseto');
+        const customizer = provider.configuration('formats.customizers.paseto');
         if (customizer) {
           await customizer(ctx, this, structuredToken);
         }

--- a/lib/models/id_token.js
+++ b/lib/models/id_token.js
@@ -40,7 +40,7 @@ module.exports = function getIdToken(provider) {
     }
 
     static expiresIn(...args) {
-      const ttl = instance(provider).configuration(`ttl.${this.name}`);
+      const ttl = provider.configuration(`ttl.${this.name}`);
 
       if (typeof ttl === 'number') {
         return ttl;
@@ -213,7 +213,7 @@ module.exports = function getIdToken(provider) {
         ignoreExpiration: true,
         audience: client.clientId,
         issuer: provider.issuer,
-        clockTolerance: instance(provider).configuration('clockTolerance'),
+        clockTolerance: provider.configuration('clockTolerance'),
         algorithm: alg,
       };
 

--- a/lib/models/interaction.js
+++ b/lib/models/interaction.js
@@ -25,7 +25,7 @@ module.exports = (provider) => class Interaction extends hasFormat(provider, 'In
     }
   }
 
-  async save(ttl = instance(provider).configuration('cookies.short.maxAge') / 1000) {
+  async save(ttl = provider.configuration('cookies.short.maxAge') / 1000) {
     return super.save(ttl);
   }
 

--- a/lib/models/mixins/has_format.js
+++ b/lib/models/mixins/has_format.js
@@ -7,7 +7,7 @@ const CHANGEABLE = new Set(['AccessToken', 'ClientCredentials']);
 const DEFAULT = 'opaque';
 
 module.exports = (provider, type, superclass) => {
-  const config = instance(provider).configuration('formats');
+  const config = provider.configuration('formats');
   const formats = formatsGenerator(provider);
 
   let { [type]: FORMAT } = config;

--- a/lib/models/mixins/has_policies.js
+++ b/lib/models/mixins/has_policies.js
@@ -1,13 +1,11 @@
 const { strict: assert } = require('assert');
 
-const instance = require('../../helpers/weak_cache');
-
 function validate(provider, policies) {
   assert(Array.isArray(policies), 'policies must be an array');
   assert(policies.length, 'policies must not be empty');
   policies.forEach((policy) => {
     assert(typeof policy === 'string', 'policies must be strings');
-    assert(instance(provider).configuration(`features.registration.policies.${policy}`), `policy ${policy} not configured`);
+    assert(provider.configuration(`features.registration.policies.${policy}`), `policy ${policy} not configured`);
   });
 }
 

--- a/lib/models/session.js
+++ b/lib/models/session.js
@@ -99,7 +99,7 @@ module.exports = function getSession(provider) {
       const cookieSessionId = ssHandler.get(
         cookies,
         provider.cookieName('session'),
-        instance(provider).configuration('cookies.long'),
+        provider.configuration('cookies.long'),
       );
 
       let session;
@@ -126,7 +126,7 @@ module.exports = function getSession(provider) {
       return session;
     }
 
-    async save(ttl = instance(provider).configuration('cookies.long.maxAge') / 1000) {
+    async save(ttl = provider.configuration('cookies.long.maxAge') / 1000) {
       // one by one adapter ops to allow for uid to have a unique index
       if (this.oldId) {
         await this.adapter.destroy(this.oldId);

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -133,6 +133,10 @@ class Provider extends events.EventEmitter {
     delete configuration.clients;
   }
 
+  configuration(path) {
+    return instance(this).configuration(path);
+  }
+
   urlFor(name, opt) { return url.resolve(this.issuer, this.pathFor(name, opt)); }
 
   registerGrantType(name, handler, params, dupes) {

--- a/lib/response_modes/web_message.js
+++ b/lib/response_modes/web_message.js
@@ -1,11 +1,9 @@
 const jsesc = require('jsesc');
 
-const instance = require('../helpers/weak_cache');
-
 const statusCodes = new Set([200, 400, 500]);
 
 module.exports = function webMessage(ctx, redirectUri, response) {
-  const { scriptNonce } = instance(ctx.oidc.provider).configuration('features.webMessageResponseMode');
+  const { scriptNonce } = ctx.oidc.provider.configuration('features.webMessageResponseMode');
   ctx.type = 'html';
 
   if (!statusCodes.has(ctx.status)) {

--- a/lib/shared/authorization_error_handler.js
+++ b/lib/shared/authorization_error_handler.js
@@ -70,7 +70,7 @@ module.exports = (provider) => {
         Err, check, flag, method, recovery,
       }] of AD_ACTA_CHECKS) {
         if (
-          (!flag || instance(provider).configuration(flag))
+          (!flag || provider.configuration(flag))
           && !(err instanceof Err) && oidc.client
           && !oidc[check]
         ) {
@@ -97,10 +97,10 @@ module.exports = (provider) => {
         || !safe(params.redirect_uri)
         || rendered.has(err.message)
       ) {
-        const renderError = instance(provider).configuration('renderError');
+        const renderError = provider.configuration('renderError');
         await renderError(ctx, out, err);
       } else {
-        if (instance(provider).configuration('features.sessionManagement.enabled')) {
+        if (provider.configuration('features.sessionManagement.enabled')) {
           out.session_state = processSessionState.salted(ctx, params.redirect_uri);
         }
 

--- a/lib/shared/check_resource.js
+++ b/lib/shared/check_resource.js
@@ -1,11 +1,10 @@
 const { URL } = require('url');
 
-const instance = require('../helpers/weak_cache');
 const { InvalidTarget } = require('../helpers/errors');
 
 module.exports = async function checkResource(ctx, next) {
   const { oidc: { params, provider, client } } = ctx;
-  const { enabled, allowedPolicy } = instance(provider).configuration('features.resourceIndicators');
+  const { enabled, allowedPolicy } = provider.configuration('features.resourceIndicators');
 
   if (!enabled || params.resource === undefined) {
     return next();

--- a/lib/shared/cors.js
+++ b/lib/shared/cors.js
@@ -1,11 +1,10 @@
 const cors = require('@koa/cors');
 
 const { InvalidRequest } = require('../helpers/errors');
-const instance = require('../helpers/weak_cache');
 
 function checkClientCORS(ctx, client) {
   const origin = ctx.get('Origin');
-  const { clientBasedCORS } = instance(ctx.oidc.provider).configuration();
+  const { clientBasedCORS } = ctx.oidc.provider.configuration();
 
   const allowed = clientBasedCORS(ctx, origin, client);
 

--- a/lib/shared/error_handler.js
+++ b/lib/shared/error_handler.js
@@ -2,7 +2,6 @@ const crypto = require('crypto');
 
 const Debug = require('debug');
 
-const instance = require('../helpers/weak_cache');
 const formHtml = require('../helpers/user_code_form');
 const { ReRenderError } = require('../helpers/re_render_errors');
 const errOut = require('../helpers/err_out');
@@ -17,7 +16,7 @@ module.exports = function getErrorHandler(provider, eventName) {
   return async function errorHandler(ctx, next) {
     const {
       features: { deviceFlow: { charset, userCodeInputSource } },
-    } = instance(provider).configuration();
+    } = provider.configuration();
 
     try {
       await next();
@@ -43,7 +42,7 @@ module.exports = function getErrorHandler(provider, eventName) {
       } else if (ctx.accepts('json', 'html') === 'html') {
         // this ^^ makes */* requests respond with json (curl, xhr, request libraries), while in
         // browser requests end up rendering the html error instead
-        const renderError = instance(provider).configuration('renderError');
+        const renderError = provider.configuration('renderError');
         await renderError(ctx, out, err);
       } else {
         ctx.body = out;

--- a/lib/shared/session.js
+++ b/lib/shared/session.js
@@ -1,4 +1,3 @@
-const instance = require('../helpers/weak_cache');
 const ssHandler = require('../helpers/samesite_handler');
 
 module.exports = async function sessionHandler(ctx, next) {
@@ -38,7 +37,7 @@ module.exports = async function sessionHandler(ctx, next) {
         ctx.oidc.cookies,
         sessionCookieName,
         ctx.oidc.session.id,
-        instance(ctx.oidc.provider).configuration('cookies.long'),
+        ctx.oidc.provider.configuration('cookies.long'),
       );
       await ctx.oidc.session.save();
     }

--- a/lib/shared/token_auth.js
+++ b/lib/shared/token_auth.js
@@ -18,7 +18,7 @@ module.exports = function tokenAuth(provider, endpoint, jwtAuthEndpointIdentifie
   const tokenJwtAuth = getJWTAuthMiddleware(provider, jwtAuthEndpointIdentifier);
   const authParams = new Set(['client_id']);
 
-  instance(provider).configuration(`${endpoint}EndpointAuthMethods`).forEach((method) => {
+  provider.configuration(`${endpoint}EndpointAuthMethods`).forEach((method) => {
     switch (method) {
       case 'client_secret_post':
         authParams.add('client_secret');
@@ -184,7 +184,7 @@ module.exports = function tokenAuth(provider, endpoint, jwtAuthEndpointIdentifie
             ctx.oidc.client.checkClientSecretExpiration('could not authenticate the client - its client secret used for the client_assertion is expired');
             await tokenJwtAuth(
               ctx, ctx.oidc.client.keystore,
-              signingAlg ? [signingAlg] : instance(provider).configuration(`${endpoint}EndpointAuthSigningAlgValues`).filter((alg) => alg.startsWith('HS')),
+              signingAlg ? [signingAlg] : provider.configuration(`${endpoint}EndpointAuthSigningAlgValues`).filter((alg) => alg.startsWith('HS')),
             );
 
             break;
@@ -192,13 +192,13 @@ module.exports = function tokenAuth(provider, endpoint, jwtAuthEndpointIdentifie
           case 'private_key_jwt':
             await tokenJwtAuth(
               ctx, ctx.oidc.client.keystore,
-              signingAlg ? [signingAlg] : instance(provider).configuration(`${endpoint}EndpointAuthSigningAlgValues`).filter((alg) => !alg.startsWith('HS')),
+              signingAlg ? [signingAlg] : provider.configuration(`${endpoint}EndpointAuthSigningAlgValues`).filter((alg) => !alg.startsWith('HS')),
             );
 
             break;
 
           case 'tls_client_auth': {
-            const { mTLS: { getCertificate, certificateAuthorized, certificateSubjectMatches } } = instance(provider).configuration('features');
+            const { mTLS: { getCertificate, certificateAuthorized, certificateSubjectMatches } } = provider.configuration('features');
 
             const cert = getCertificate(ctx);
 
@@ -229,7 +229,7 @@ module.exports = function tokenAuth(provider, endpoint, jwtAuthEndpointIdentifie
             break;
           }
           case 'self_signed_tls_client_auth': {
-            const { mTLS: { getCertificate } } = instance(provider).configuration('features');
+            const { mTLS: { getCertificate } } = provider.configuration('features');
             const cert = getCertificate(ctx);
 
             if (!cert) {

--- a/lib/shared/token_jwt_auth.js
+++ b/lib/shared/token_jwt_auth.js
@@ -1,5 +1,4 @@
 const { InvalidClientAuth } = require('../helpers/errors');
-const instance = require('../helpers/weak_cache');
 const JWT = require('../helpers/jwt');
 
 module.exports = function getTokenJwtAuth(provider, endpoint) {
@@ -46,7 +45,7 @@ module.exports = function getTokenJwtAuth(provider, endpoint) {
 
     try {
       await JWT.verify(ctx.oidc.params.client_assertion, keystore, {
-        clockTolerance: instance(provider).configuration('clockTolerance'),
+        clockTolerance: provider.configuration('clockTolerance'),
         ignoreAzp: true,
       });
     } catch (err) {

--- a/test/authorization_code/code.grant.test.js
+++ b/test/authorization_code/code.grant.test.js
@@ -121,13 +121,13 @@ describe('grant_type=authorization_code', () => {
 
     context('', () => {
       before(function () {
-        const ttl = i(this.provider).configuration('ttl');
+        const ttl = this.provider.configuration('ttl');
         this.prev = ttl.AuthorizationCode;
         ttl.AuthorizationCode = 5;
       });
 
       after(function () {
-        i(this.provider).configuration('ttl').AuthorizationCode = this.prev;
+        this.provider.configuration('ttl').AuthorizationCode = this.prev;
       });
 
       it('validates code is not expired', function () {
@@ -378,13 +378,13 @@ describe('grant_type=authorization_code', () => {
 
     context('', () => {
       before(function () {
-        const ttl = i(this.provider).configuration('ttl');
+        const ttl = this.provider.configuration('ttl');
         this.prev = ttl.AuthorizationCode;
         ttl.AuthorizationCode = 5;
       });
 
       after(function () {
-        i(this.provider).configuration('ttl').AuthorizationCode = this.prev;
+        this.provider.configuration('ttl').AuthorizationCode = this.prev;
       });
 
       it('validates code is not expired', function () {

--- a/test/backchannel_logout/backchannel_logout.test.js
+++ b/test/backchannel_logout/backchannel_logout.test.js
@@ -38,8 +38,8 @@ describe('Back-Channel Logout 1.0', () => {
     it('uses custom http options when provided', async function () {
       const client = await this.provider.Client.find('client');
 
-      const pre = i(this.provider).configuration('httpOptions');
-      i(this.provider).configuration().httpOptions = (opts) => {
+      const pre = this.provider.configuration('httpOptions');
+      this.provider.configuration().httpOptions = (opts) => {
         Object.assign(opts.body, { foo: 'bar' });
         return opts;
       };
@@ -52,7 +52,7 @@ describe('Back-Channel Logout 1.0', () => {
         .reply(200);
 
       return client.backchannelLogout('subject', 'foo').then(() => {
-        i(this.provider).configuration().httpOptions = pre;
+        this.provider.configuration().httpOptions = pre;
       });
     });
 

--- a/test/claims/claims.test.js
+++ b/test/claims/claims.test.js
@@ -218,7 +218,7 @@ expire.setDate(expire.getDate() + 1);
           const cookies = [];
 
           const sess = new this.provider.Interaction('resume', {});
-          const keys = new KeyGrip(i(this.provider).configuration('cookies.keys'));
+          const keys = new KeyGrip(this.provider.configuration('cookies.keys'));
           if (grant) {
             const cookie = `_interaction_resume=resume; path=${this.suitePath('/auth/resume')}; expires=${expire.toGMTString()}; httponly`;
             cookies.push(cookie);
@@ -754,11 +754,11 @@ expire.setDate(expire.getDate() + 1);
 
       describe('when userinfo is disabled', () => {
         before(function () {
-          i(this.provider).configuration('features').userinfo.enabled = false;
+          this.provider.configuration('features').userinfo.enabled = false;
         });
 
         after(function () {
-          i(this.provider).configuration('features').userinfo.enabled = false;
+          this.provider.configuration('features').userinfo.enabled = false;
         });
 
         it('should not accept userinfo as a property', function () {

--- a/test/client_auth/client_auth.test.js
+++ b/test/client_auth/client_auth.test.js
@@ -52,9 +52,9 @@ describe('client authentication options', () => {
         ],
       });
 
-      expect(i(provider).configuration('tokenEndpointAuthSigningAlgValues')).to.be.undefined;
-      expect(i(provider).configuration('introspectionEndpointAuthSigningAlgValues')).to.be.undefined;
-      expect(i(provider).configuration('revocationEndpointAuthSigningAlgValues')).to.be.undefined;
+      expect(provider.configuration('tokenEndpointAuthSigningAlgValues')).to.be.undefined;
+      expect(provider.configuration('introspectionEndpointAuthSigningAlgValues')).to.be.undefined;
+      expect(provider.configuration('revocationEndpointAuthSigningAlgValues')).to.be.undefined;
     });
 
     it('pushes only symmetric algs when client_secret_jwt is enabled', () => {
@@ -74,9 +74,9 @@ describe('client authentication options', () => {
         'HS512',
       ];
 
-      expect(i(provider).configuration('tokenEndpointAuthSigningAlgValues')).to.eql(algs);
-      expect(i(provider).configuration('introspectionEndpointAuthSigningAlgValues')).to.eql(algs);
-      expect(i(provider).configuration('revocationEndpointAuthSigningAlgValues')).to.eql(algs);
+      expect(provider.configuration('tokenEndpointAuthSigningAlgValues')).to.eql(algs);
+      expect(provider.configuration('introspectionEndpointAuthSigningAlgValues')).to.eql(algs);
+      expect(provider.configuration('revocationEndpointAuthSigningAlgValues')).to.eql(algs);
     });
 
     it('pushes only asymmetric algs when private_key_jwt is enabled', () => {
@@ -104,9 +104,9 @@ describe('client authentication options', () => {
         runtimeSupport.EdDSA ? 'EdDSA' : false,
       ].filter(Boolean);
 
-      expect(i(provider).configuration('tokenEndpointAuthSigningAlgValues')).to.eql(algs);
-      expect(i(provider).configuration('introspectionEndpointAuthSigningAlgValues')).to.eql(algs);
-      expect(i(provider).configuration('revocationEndpointAuthSigningAlgValues')).to.eql(algs);
+      expect(provider.configuration('tokenEndpointAuthSigningAlgValues')).to.eql(algs);
+      expect(provider.configuration('introspectionEndpointAuthSigningAlgValues')).to.eql(algs);
+      expect(provider.configuration('revocationEndpointAuthSigningAlgValues')).to.eql(algs);
     });
 
     it('pushes all algs when both _jwt methods are enabled', () => {
@@ -138,9 +138,9 @@ describe('client authentication options', () => {
         runtimeSupport.EdDSA ? 'EdDSA' : false,
       ].filter(Boolean);
 
-      expect(i(provider).configuration('tokenEndpointAuthSigningAlgValues')).to.eql(algs);
-      expect(i(provider).configuration('introspectionEndpointAuthSigningAlgValues')).to.eql(algs);
-      expect(i(provider).configuration('revocationEndpointAuthSigningAlgValues')).to.eql(algs);
+      expect(provider.configuration('tokenEndpointAuthSigningAlgValues')).to.eql(algs);
+      expect(provider.configuration('introspectionEndpointAuthSigningAlgValues')).to.eql(algs);
+      expect(provider.configuration('revocationEndpointAuthSigningAlgValues')).to.eql(algs);
     });
   });
 
@@ -1096,7 +1096,7 @@ describe('client authentication options', () => {
     });
 
     after(function () {
-      i(this.provider).configuration().clockTolerance = 0;
+      this.provider.configuration().clockTolerance = 0;
     });
 
     it('accepts the auth', function () {
@@ -1118,7 +1118,7 @@ describe('client authentication options', () => {
     });
 
     it('accepts client assertions issued within acceptable system clock skew', function () {
-      i(this.provider).configuration().clockTolerance = 10;
+      this.provider.configuration().clockTolerance = 10;
       return JWT.sign({
         jti: nanoid(),
         aud: this.provider.issuer + this.suitePath('/token'),

--- a/test/configuration/interaction_url.test.js
+++ b/test/configuration/interaction_url.test.js
@@ -16,7 +16,7 @@ describe('pathFor related behaviors', () => {
       },
     });
 
-    const url = await i(provider).configuration('interactions.url')({
+    const url = await provider.configuration('interactions.url')({
       oidc: {
         uid: 'foobar',
       },

--- a/test/configuration/offline_access.test.js
+++ b/test/configuration/offline_access.test.js
@@ -5,17 +5,17 @@ const { Provider } = require('../../lib');
 describe('Provider declaring support for refresh_token grant type', () => {
   it('is enabled by default', () => {
     const provider = new Provider('https://op.example.com');
-    expect(i(provider).configuration().grantTypes).to.contain('refresh_token');
+    expect(provider.configuration().grantTypes).to.contain('refresh_token');
   });
 
   it('isnt enabled when offline_access isnt amongst the scopes', () => {
     const provider = new Provider('https://op.example.com', { scopes: ['openid'] });
-    expect(i(provider).configuration().grantTypes).not.to.contain('refresh_token');
+    expect(provider.configuration().grantTypes).not.to.contain('refresh_token');
   });
 
   it('is enabled when offline_access isnt amongst the scopes', () => {
     const provider = new Provider('https://op.example.com', { scopes: ['openid', 'offline_access'] });
-    expect(i(provider).configuration().grantTypes).to.contain('refresh_token');
+    expect(provider.configuration().grantTypes).to.contain('refresh_token');
   });
 
   it('is enabled when issueRefreshToken configuration function is configured', () => {
@@ -25,6 +25,6 @@ describe('Provider declaring support for refresh_token grant type', () => {
         return true;
       },
     });
-    expect(i(provider).configuration().grantTypes).to.contain('refresh_token');
+    expect(provider.configuration().grantTypes).to.contain('refresh_token');
   });
 });

--- a/test/configuration/omit_algs.test.js
+++ b/test/configuration/omit_algs.test.js
@@ -44,6 +44,6 @@ describe('Provider declaring supported algorithms', () => {
       },
     });
 
-    expect(i(provider).configuration('idTokenSigningAlgValues')).to.eql(['HS256', 'RS256']);
+    expect(provider.configuration('idTokenSigningAlgValues')).to.eql(['HS256', 'RS256']);
   });
 });

--- a/test/configuration/response_types.test.js
+++ b/test/configuration/response_types.test.js
@@ -7,7 +7,7 @@ describe('response_types Provider configuration', () => {
     const provider = new Provider('https://op.example.com', { // eslint-disable-line no-new
       responseTypes: ['token id_token code', 'token id_token'],
     });
-    expect(i(provider).configuration('responseTypes')).to.eql(['code id_token token', 'id_token token']);
+    expect(provider.configuration('responseTypes')).to.eql(['code id_token token', 'id_token token']);
   });
 
   it('throws when invalid types are configured', () => {

--- a/test/configuration/scopes_claims.test.js
+++ b/test/configuration/scopes_claims.test.js
@@ -10,7 +10,7 @@ describe('custom claims', () => {
       },
     });
 
-    expect(i(provider).configuration('claims').get('openid')).to.eql({
+    expect(provider.configuration('claims').get('openid')).to.eql({
       sub: null,
       foo: null,
     });
@@ -23,7 +23,7 @@ describe('custom claims', () => {
       },
     });
 
-    expect(i(provider).configuration('claims').get('openid')).to.eql({
+    expect(provider.configuration('claims').get('openid')).to.eql({
       sub: null,
       foo: null,
     });
@@ -45,8 +45,8 @@ describe('custom claims', () => {
       claims,
     });
 
-    expect(i(provider).configuration('scopes')).to.contain('insurance', 'payment');
-    expect(i(provider).configuration('dynamicScopes')).to.contain(foo, bar);
+    expect(provider.configuration('scopes')).to.contain('insurance', 'payment');
+    expect(provider.configuration('dynamicScopes')).to.contain(foo, bar);
   });
 
   it('removes the acr claim if no acrs are configured', () => {
@@ -54,6 +54,6 @@ describe('custom claims', () => {
       acrValues: [],
     });
 
-    expect(i(provider).configuration('claimsSupported')).not.to.contain('acr');
+    expect(provider.configuration('claimsSupported')).not.to.contain('acr');
   });
 });

--- a/test/core/basic/code.authorization.test.js
+++ b/test/core/basic/code.authorization.test.js
@@ -137,12 +137,12 @@ describe('BASIC code', () => {
     describe(`${verb} ${route} interactions`, () => {
       before(function () { return this.logout(); });
       before(function () {
-        this.policy = i(this.provider).configuration('interactions').policy;
-        i(this.provider).configuration('interactions').policy = [];
+        this.policy = this.provider.configuration('interactions').policy;
+        this.provider.configuration('interactions').policy = [];
       });
 
       after(function () {
-        i(this.provider).configuration('interactions').policy = this.policy;
+        this.provider.configuration('interactions').policy = this.policy;
       });
 
       it('no account id was resolved and no interactions requested', async function () {
@@ -544,7 +544,7 @@ describe('BASIC code', () => {
 
         it('missing mandatory parameter redirect_uri', function () {
           const emitSpy = sinon.spy();
-          const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+          const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
           this.provider.once('authorization.error', emitSpy);
           const auth = new this.AuthorizationRequest({
             response_type,
@@ -655,7 +655,7 @@ describe('BASIC code', () => {
 
       // section-4.1.2.1 RFC6749
       it('missing mandatory parameter client_id', function () {
-        const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+        const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
         const auth = new this.AuthorizationRequest({
           response_type,
           scope,
@@ -679,7 +679,7 @@ describe('BASIC code', () => {
 
       // section-4.1.2.1 RFC6749
       it('unrecognized client_id provided', function () {
-        const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+        const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
         const auth = new this.AuthorizationRequest({
           response_type,
           scope,
@@ -702,7 +702,7 @@ describe('BASIC code', () => {
 
       describe('section-4.1.2.1 RFC6749', () => {
         it('validates redirect_uri ad acta [regular error]', function () {
-          const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+          const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
           const spy = sinon.spy();
           this.provider.on('authorization.error', spy);
           const auth = new this.AuthorizationRequest({
@@ -734,7 +734,7 @@ describe('BASIC code', () => {
         });
 
         it('validates redirect_uri ad acta [server error]', function () {
-          const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+          const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
           const authErrorSpy = sinon.spy();
           const serverErrorSpy = sinon.spy();
           this.provider.on('authorization.error', authErrorSpy);
@@ -899,7 +899,7 @@ describe('BASIC code', () => {
 
       it('redirect_uri mismatch', function () {
         const emitSpy = sinon.spy();
-        const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+        const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
         this.provider.once('authorization.error', emitSpy);
         const auth = new this.AuthorizationRequest({
           response_type,

--- a/test/cors/cors.test.js
+++ b/test/cors/cors.test.js
@@ -45,16 +45,16 @@ describe('CORS setup', () => {
 
   describe('error handling', () => {
     before(function () {
-      this.default = i(this.provider).configuration('clientBasedCORS');
+      this.default = this.provider.configuration('clientBasedCORS');
     });
 
     after(function () {
-      const conf = i(this.provider).configuration();
+      const conf = this.provider.configuration();
       conf.clientBasedCORS = this.default;
     });
 
     it('500s when clientBasedCORS returns non-boolean', async function () {
-      i(this.provider).configuration().clientBasedCORS = () => Promise.resolve(true);
+      this.provider.configuration().clientBasedCORS = () => Promise.resolve(true);
       const { status, headers } = await req.call(
         this,
         'get',
@@ -283,12 +283,12 @@ describe('CORS setup', () => {
 
   describe('with clientBasedCORS false', () => {
     before(function () {
-      const conf = i(this.provider).configuration();
+      const conf = this.provider.configuration();
       conf.clientBasedCORS = () => false;
     });
 
     after(function () {
-      const conf = i(this.provider).configuration();
+      const conf = this.provider.configuration();
       conf.clientBasedCORS = () => true;
     });
 

--- a/test/custom_grants/custom_grants.test.js
+++ b/test/custom_grants/custom_grants.test.js
@@ -15,20 +15,20 @@ describe('custom token endpoint grant types', () => {
 
   before('allows for grant types to be added', function () {
     register(this.provider, 'lotto', 'name');
-    expect(i(this.provider).configuration('grantTypes').has('lotto')).to.be.true;
+    expect(this.provider.configuration('grantTypes').has('lotto')).to.be.true;
   });
 
   it('does not need to be passed extra parameters', function () {
     register(this.provider, 'lotto-2');
-    expect(i(this.provider).configuration('grantTypes').has('lotto-2')).to.be.true;
+    expect(this.provider.configuration('grantTypes').has('lotto-2')).to.be.true;
   });
 
   it('can be passed null or a string', function () {
     register(this.provider, 'lotto-3', null);
     register(this.provider, 'lotto-4', 'name');
 
-    expect(i(this.provider).configuration('grantTypes').has('lotto-3')).to.be.true;
-    expect(i(this.provider).configuration('grantTypes').has('lotto-4')).to.be.true;
+    expect(this.provider.configuration('grantTypes').has('lotto-3')).to.be.true;
+    expect(this.provider.configuration('grantTypes').has('lotto-4')).to.be.true;
   });
 
   describe('when added', () => {

--- a/test/device_code/code_verification_endpoint.test.js
+++ b/test/device_code/code_verification_endpoint.test.js
@@ -67,7 +67,7 @@ describe('POST code_verification endpoint w/o verification', () => {
   });
 
   it('renders a confirmation page', async function () {
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeConfirmSource');
+    const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeConfirmSource');
     const deviceInfo = {
       ip: '127.0.0.1',
       ua: 'foo',
@@ -98,7 +98,7 @@ describe('POST code_verification endpoint w/o verification', () => {
   it('re-renders on no submitted code', async function () {
     const errSpy = sinon.spy();
     this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+    const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
 
     await this.agent.post(route)
       .send({ xsrf })
@@ -119,7 +119,7 @@ describe('POST code_verification endpoint w/o verification', () => {
   it('re-renders on not found code', async function () {
     const errSpy = sinon.spy();
     this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+    const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
 
     await this.agent.post(route)
       .send({
@@ -143,7 +143,7 @@ describe('POST code_verification endpoint w/o verification', () => {
   it('re-renders on found but expired code', async function () {
     const errSpy = sinon.spy();
     this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+    const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
     await new this.provider.DeviceCode({
       userCode: 'FOOEXPIRED',
     }).save();
@@ -171,7 +171,7 @@ describe('POST code_verification endpoint w/o verification', () => {
   it('re-renders on found but already user code', async function () {
     const errSpy = sinon.spy();
     this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+    const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
     await new this.provider.DeviceCode({
       userCode: 'FOOCONSUMED',
       accountId: 'account',
@@ -199,7 +199,7 @@ describe('POST code_verification endpoint w/o verification', () => {
   it('re-renders on invalid client', async function () {
     const errSpy = sinon.spy();
     this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+    const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
     await new this.provider.DeviceCode({
       userCode: 'FOONOTFOUNDCLIENT',
       clientId: 'client',
@@ -228,7 +228,7 @@ describe('POST code_verification endpoint w/o verification', () => {
   it('re-renders on !ctx.oidc.session.state', async function () {
     const errSpy = sinon.spy();
     this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+    const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
     await new this.provider.DeviceCode({
       userCode: 'FOOCSRF1',
     }).save();
@@ -257,7 +257,7 @@ describe('POST code_verification endpoint w/o verification', () => {
   it('re-renders on invalid csrf', async function () {
     const errSpy = sinon.spy();
     this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+    const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
     await new this.provider.DeviceCode({
       userCode: 'FOOCSRF2',
     }).save();
@@ -302,7 +302,7 @@ describe('POST code_verification endpoint w/ verification', () => {
 
   bootstrap.passInteractionChecks('native_client_prompt', 'claims_missing', () => {
     it('accepts an abort command', async function () {
-      const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+      const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
 
       let code = await new this.provider.DeviceCode({
         grantId: this.getSession({ instantiate: true }).grantIdFor('client'),
@@ -336,7 +336,7 @@ describe('POST code_verification endpoint w/ verification', () => {
     });
 
     it('renders a confirmation and assigns', async function () {
-      const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+      const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'successSource');
 
       let code = await new this.provider.DeviceCode({
         grantId: this.getSession({ instantiate: true }).grantIdFor('client'),
@@ -374,7 +374,7 @@ describe('POST code_verification endpoint w/ verification', () => {
     });
 
     it('renders a confirmation and assigns (incl. sid because of client configuration)', async function () {
-      const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+      const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'successSource');
 
       let code = await new this.provider.DeviceCode({
         grantId: this.getSession({ instantiate: true }).grantIdFor('client-backchannel'),
@@ -402,7 +402,7 @@ describe('POST code_verification endpoint w/ verification', () => {
     });
 
     it('renders a confirmation and assigns (incl. sid because of claims)', async function () {
-      const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+      const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'successSource');
 
       let code = await new this.provider.DeviceCode({
         grantId: this.getSession({ instantiate: true }).grantIdFor('client'),
@@ -431,7 +431,7 @@ describe('POST code_verification endpoint w/ verification', () => {
     });
 
     it('allows for punctuation to be included and characters to be downcased', async function () {
-      const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+      const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'successSource');
 
       let code = await new this.provider.DeviceCode({
         grantId: this.getSession({ instantiate: true }).grantIdFor('client'),

--- a/test/device_code/device_code_grant.test.js
+++ b/test/device_code/device_code_grant.test.js
@@ -222,13 +222,13 @@ describe('grant_type=urn:ietf:params:oauth:grant-type:device_code', () => {
 
     context('', () => {
       before(function () {
-        const ttl = i(this.provider).configuration('ttl');
+        const ttl = this.provider.configuration('ttl');
         this.prev = ttl.DeviceCode;
         ttl.DeviceCode = 0;
       });
 
       after(function () {
-        i(this.provider).configuration('ttl').DeviceCode = this.prev;
+        this.provider.configuration('ttl').DeviceCode = this.prev;
       });
 
       it('validates code is not expired', async function () {

--- a/test/device_code/device_resume.test.js
+++ b/test/device_code/device_resume.test.js
@@ -40,7 +40,7 @@ describe('device interaction resume /device/:user_code/:uid/', () => {
 
     const session = new this.provider.Session({ jti: 'sess', ...sessionData });
     const interaction = new this.provider.Interaction(grantId, { session });
-    const keys = new KeyGrip(i(this.provider).configuration('cookies.keys'));
+    const keys = new KeyGrip(this.provider.configuration('cookies.keys'));
     const code = new this.provider.DeviceCode({
       params,
       clientId: 'client',
@@ -82,7 +82,7 @@ describe('device interaction resume /device/:user_code/:uid/', () => {
   bootstrap.passInteractionChecks('native_client_prompt', () => {
     context('general', () => {
       it('needs the resume cookie to be present, else renders an err', async function () {
-        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+        const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
 
         await setup.call(this, {
           scope: 'openid',
@@ -116,7 +116,7 @@ describe('device interaction resume /device/:user_code/:uid/', () => {
       });
 
       it('needs to find the session to resume', async function () {
-        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+        const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
 
         const auth = new this.AuthorizationRequest({
           response_type: 'code',
@@ -142,7 +142,7 @@ describe('device interaction resume /device/:user_code/:uid/', () => {
       });
 
       it('needs to find the code to resume', async function () {
-        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+        const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
 
         const auth = new this.AuthorizationRequest({
           response_type: 'code',
@@ -168,7 +168,7 @@ describe('device interaction resume /device/:user_code/:uid/', () => {
       });
 
       it('checks code is not expired', async function () {
-        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+        const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
 
         const auth = new this.AuthorizationRequest({
           response_type: 'code',
@@ -194,7 +194,7 @@ describe('device interaction resume /device/:user_code/:uid/', () => {
       });
 
       it('checks code is not used already (1/2)', async function () {
-        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+        const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
 
         const auth = new this.AuthorizationRequest({
           response_type: 'code',
@@ -220,7 +220,7 @@ describe('device interaction resume /device/:user_code/:uid/', () => {
       });
 
       it('checks code is not used already (2/2)', async function () {
-        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+        const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
 
         const auth = new this.AuthorizationRequest({
           response_type: 'code',
@@ -246,7 +246,7 @@ describe('device interaction resume /device/:user_code/:uid/', () => {
       });
 
       it('checks for mismatches in resume and code grants', async function () {
-        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+        const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
 
         const auth = new this.AuthorizationRequest({
           response_type: 'code',
@@ -275,7 +275,7 @@ describe('device interaction resume /device/:user_code/:uid/', () => {
 
     context('login results', () => {
       it('should process newly established permanent sessions (default)', async function () {
-        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+        const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'successSource');
 
         await setup.call(this, {
           scope: 'openid',
@@ -302,7 +302,7 @@ describe('device interaction resume /device/:user_code/:uid/', () => {
       });
 
       it('should process newly established permanent sessions (explicit)', async function () {
-        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+        const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'successSource');
 
         await setup.call(this, {
           scope: 'openid',
@@ -330,7 +330,7 @@ describe('device interaction resume /device/:user_code/:uid/', () => {
       });
 
       it('should process newly established temporary sessions', async function () {
-        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+        const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'successSource');
 
         await setup.call(this, {
           scope: 'openid',
@@ -403,7 +403,7 @@ describe('device interaction resume /device/:user_code/:uid/', () => {
 
     context('consent results', () => {
       it('when scope includes offline_access', async function () {
-        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+        const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'successSource');
 
         await setup.call(this, {
           scope: 'openid offline_access',
@@ -430,7 +430,7 @@ describe('device interaction resume /device/:user_code/:uid/', () => {
 
     context('interaction errors', () => {
       it('should abort an interaction when given an error result object', async function () {
-        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
+        const spy = sinon.spy(this.provider.configuration('features.deviceFlow'), 'userCodeInputSource');
 
         await setup.call(this, {
           scope: 'openid',

--- a/test/discovery/openid_configuration.test.js
+++ b/test/discovery/openid_configuration.test.js
@@ -24,8 +24,8 @@ describe(route, () => {
   });
 
   it('is configurable with extra properties', function () {
-    i(this.provider).configuration('discovery').service_documentation = 'https://docs.example.com';
-    i(this.provider).configuration('discovery').authorization_endpoint = 'this will not be used';
+    this.provider.configuration('discovery').service_documentation = 'https://docs.example.com';
+    this.provider.configuration('discovery').authorization_endpoint = 'this will not be used';
 
     return this.agent.get(route)
       .expect((response) => {

--- a/test/dynamic_token_ttl/dynamic_token_ttl.test.js
+++ b/test/dynamic_token_ttl/dynamic_token_ttl.test.js
@@ -11,16 +11,16 @@ describe('dynamic ttl', () => {
   before(bootstrap(__dirname));
   bootstrap.skipConsent();
   before(function () {
-    this.prev = cloneDeep(i(this.provider).configuration('ttl'));
+    this.prev = cloneDeep(this.provider.configuration('ttl'));
   });
   afterEach(function () {
-    i(this.provider).configuration().ttl = this.prev;
+    this.provider.configuration().ttl = this.prev;
   });
   before(function () { return this.login(); });
 
   it('client credentials', async function () {
     const ClientCredentials = sinon.fake.returns(123);
-    i(this.provider).configuration('ttl').ClientCredentials = ClientCredentials;
+    this.provider.configuration('ttl').ClientCredentials = ClientCredentials;
 
     await this.agent.post('/token')
       .send({
@@ -40,7 +40,7 @@ describe('dynamic ttl', () => {
 
   it('device flow init', async function () {
     const DeviceCode = sinon.fake.returns(123);
-    i(this.provider).configuration('ttl').DeviceCode = DeviceCode;
+    this.provider.configuration('ttl').DeviceCode = DeviceCode;
 
     let device_code;
     await this.agent.post('/device/auth')
@@ -68,9 +68,9 @@ describe('dynamic ttl', () => {
     const IdToken = sinon.fake.returns(123);
     const AccessToken = sinon.fake.returns(1234);
     const RefreshToken = sinon.fake.returns(12345);
-    i(this.provider).configuration('ttl').IdToken = IdToken;
-    i(this.provider).configuration('ttl').AccessToken = AccessToken;
-    i(this.provider).configuration('ttl').RefreshToken = RefreshToken;
+    this.provider.configuration('ttl').IdToken = IdToken;
+    this.provider.configuration('ttl').AccessToken = AccessToken;
+    this.provider.configuration('ttl').RefreshToken = RefreshToken;
 
     await this.agent.post('/token')
       .send({
@@ -98,9 +98,9 @@ describe('dynamic ttl', () => {
     const IdToken = sinon.fake.returns(123);
     const AccessToken = sinon.fake.returns(1234);
     const AuthorizationCode = sinon.fake.returns(12);
-    i(this.provider).configuration('ttl').IdToken = IdToken;
-    i(this.provider).configuration('ttl').AccessToken = AccessToken;
-    i(this.provider).configuration('ttl').AuthorizationCode = AuthorizationCode;
+    this.provider.configuration('ttl').IdToken = IdToken;
+    this.provider.configuration('ttl').AccessToken = AccessToken;
+    this.provider.configuration('ttl').AuthorizationCode = AuthorizationCode;
 
     const auth = new this.AuthorizationRequest({
       response_type: 'code id_token token',
@@ -134,9 +134,9 @@ describe('dynamic ttl', () => {
     const IdToken = sinon.fake.returns(123);
     const AccessToken = sinon.fake.returns(1234);
     const RefreshToken = sinon.fake.returns(12345);
-    i(this.provider).configuration('ttl').IdToken = IdToken;
-    i(this.provider).configuration('ttl').AccessToken = AccessToken;
-    i(this.provider).configuration('ttl').RefreshToken = RefreshToken;
+    this.provider.configuration('ttl').IdToken = IdToken;
+    this.provider.configuration('ttl').AccessToken = AccessToken;
+    this.provider.configuration('ttl').RefreshToken = RefreshToken;
 
     const auth = new this.AuthorizationRequest({
       response_type: 'code',
@@ -208,9 +208,9 @@ describe('dynamic ttl', () => {
     const IdToken = sinon.fake.returns(123);
     const AccessToken = sinon.fake.returns(1234);
     const RefreshToken = sinon.fake.returns(12345);
-    i(this.provider).configuration('ttl').IdToken = IdToken;
-    i(this.provider).configuration('ttl').AccessToken = AccessToken;
-    i(this.provider).configuration('ttl').RefreshToken = RefreshToken;
+    this.provider.configuration('ttl').IdToken = IdToken;
+    this.provider.configuration('ttl').AccessToken = AccessToken;
+    this.provider.configuration('ttl').RefreshToken = RefreshToken;
 
     await this.agent.post('/token')
       .send({

--- a/test/end_session/end_session.test.js
+++ b/test/end_session/end_session.test.js
@@ -131,7 +131,7 @@ describe('logout endpoint', () => {
             };
 
             const emitSpy = sinon.spy();
-            const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+            const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
             this.provider.once('end_session.error', emitSpy);
 
             return this.wrap({ route, verb, params })
@@ -154,7 +154,7 @@ describe('logout endpoint', () => {
             };
 
             const emitSpy = sinon.spy();
-            const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+            const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
             this.provider.once('end_session.error', emitSpy);
 
             return this.wrap({ route, verb, params })
@@ -202,7 +202,7 @@ describe('logout endpoint', () => {
               };
 
               const emitSpy = sinon.spy();
-              const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+              const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
               this.provider.once('end_session.error', emitSpy);
 
               return this.wrap({ route, verb, params })
@@ -266,7 +266,7 @@ describe('logout endpoint', () => {
 
         it('without id_token_hint or client_id post_logout_redirect_uri may not be provided', function () {
           const emitSpy = sinon.spy();
-          const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+          const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
           this.provider.once('end_session.error', emitSpy);
           const params = {
             post_logout_redirect_uri: 'https://client.example.com/callback/logout',
@@ -288,7 +288,7 @@ describe('logout endpoint', () => {
 
         it('validates post_logout_redirect_uri allowed on client', function () {
           const emitSpy = sinon.spy();
-          const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+          const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
           this.provider.once('end_session.error', emitSpy);
           const params = {
             id_token_hint: this.idToken,
@@ -311,7 +311,7 @@ describe('logout endpoint', () => {
 
         it('rejects invalid JWTs', function () {
           const emitSpy = sinon.spy();
-          const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+          const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
           this.provider.once('end_session.error', emitSpy);
           const params = {
             id_token_hint: 'not.a.jwt',
@@ -333,7 +333,7 @@ describe('logout endpoint', () => {
 
         it('rejects JWTs with unrecognized client', async function () {
           const emitSpy = sinon.spy();
-          const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+          const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
           this.provider.once('end_session.error', emitSpy);
           const params = {
             id_token_hint: await JWT.sign({
@@ -358,7 +358,7 @@ describe('logout endpoint', () => {
 
         it('rejects JWTs with bad signatures', async function () {
           const emitSpy = sinon.spy();
-          const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+          const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
           this.provider.once('end_session.error', emitSpy);
           const params = {
             id_token_hint: await JWT.sign({
@@ -386,7 +386,7 @@ describe('logout endpoint', () => {
     describe('POST end_session_confirm', () => {
       it('checks session.state is set', function () {
         const emitSpy = sinon.spy();
-        const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+        const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
         this.provider.once('end_session_confirm.error', emitSpy);
         return this.agent.post('/session/end/confirm')
           .set('Accept', 'text/html')
@@ -405,7 +405,7 @@ describe('logout endpoint', () => {
 
       it('checks session.state.secret (xsrf is right)', function () {
         const emitSpy = sinon.spy();
-        const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+        const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
         this.provider.once('end_session_confirm.error', emitSpy);
         this.getSession().state = { secret: '123' };
 
@@ -526,13 +526,13 @@ describe('logout endpoint', () => {
           secret: '123', postLogoutRedirectUri: '/', clientId: 'client', state: 'foobar',
         };
 
-        i(this.provider).configuration().cookies.long.domain = '.oidc.dev';
+        this.provider.configuration().cookies.long.domain = '.oidc.dev';
 
         return this.agent.post('/session/end/confirm')
           .send({ xsrf: '123', logout: 'yes' })
           .type('form')
           .expect(() => {
-            delete i(this.provider).configuration().cookies.long.domain;
+            delete this.provider.configuration().cookies.long.domain;
           })
           .expect(302)
           .expect('location', '/?state=foobar');
@@ -550,7 +550,7 @@ describe('logout endpoint', () => {
           .send({ xsrf: '123' })
           .type('form')
           .expect(() => {
-            delete i(this.provider).configuration().cookies.long.domain;
+            delete this.provider.configuration().cookies.long.domain;
           })
           .expect(302);
       });
@@ -558,7 +558,7 @@ describe('logout endpoint', () => {
 
     describe('GET end_session_success', () => {
       it('calls the postLogoutSuccessSource helper', function () {
-        const renderSpy = sinon.spy(i(this.provider).configuration('features.rpInitiatedLogout'), 'postLogoutSuccessSource');
+        const renderSpy = sinon.spy(this.provider.configuration('features.rpInitiatedLogout'), 'postLogoutSuccessSource');
         return this.agent.get('/session/end/success')
           .set('Accept', 'text/html')
           .expect(200)
@@ -570,7 +570,7 @@ describe('logout endpoint', () => {
       });
 
       it('has the client loaded when present', function () {
-        const renderSpy = sinon.spy(i(this.provider).configuration('features.rpInitiatedLogout'), 'postLogoutSuccessSource');
+        const renderSpy = sinon.spy(this.provider.configuration('features.rpInitiatedLogout'), 'postLogoutSuccessSource');
         return this.agent.get('/session/end/success?client_id=client')
           .set('Accept', 'text/html')
           .expect(200)
@@ -583,7 +583,7 @@ describe('logout endpoint', () => {
 
       it('throws when the client is not found', function () {
         const emitSpy = sinon.spy();
-        const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+        const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
         this.provider.once('end_session_success.error', emitSpy);
         return this.agent.get('/session/end/success?client_id=foobar')
           .set('Accept', 'text/html')

--- a/test/formats/jwt.test.js
+++ b/test/formats/jwt.test.js
@@ -200,12 +200,12 @@ if (FORMAT === 'jwt') {
 
     describe('customizers', () => {
       afterEach(function () {
-        i(this.provider).configuration('formats.customizers').jwt = undefined;
+        this.provider.configuration('formats.customizers').jwt = undefined;
       });
 
       it('allows the payload to be extended', async function () {
         const accessToken = new this.provider.AccessToken(fullPayload);
-        i(this.provider).configuration('formats.customizers').jwt = (ctx, token, jwt) => {
+        this.provider.configuration('formats.customizers').jwt = (ctx, token, jwt) => {
           expect(token).to.equal(accessToken);
           expect(jwt).to.have.property('payload');
           expect(jwt).to.have.property('header', undefined);
@@ -224,7 +224,7 @@ if (FORMAT === 'jwt') {
     describe('invalid signing alg resolved', () => {
       ['none', 'HS256', 'HS384', 'HS512'].forEach((alg) => {
         it(`throws an Error when ${alg} is resolved`, async function () {
-          i(this.provider).configuration('formats').jwtAccessTokenSigningAlg = async () => alg;
+          this.provider.configuration('formats').jwtAccessTokenSigningAlg = async () => alg;
           const token = new this.provider.AccessToken(fullPayload);
           try {
             await token.save();
@@ -237,7 +237,7 @@ if (FORMAT === 'jwt') {
       });
 
       it('throws an Error when unsupported provider keystore alg is resolved', async function () {
-        i(this.provider).configuration('formats').jwtAccessTokenSigningAlg = async () => 'ES384';
+        this.provider.configuration('formats').jwtAccessTokenSigningAlg = async () => 'ES384';
         const token = new this.provider.AccessToken(fullPayload);
         try {
           await token.save();

--- a/test/formats/jwt_ietf.test.js
+++ b/test/formats/jwt_ietf.test.js
@@ -201,12 +201,12 @@ if (FORMAT === 'jwt-ietf') {
 
     describe('customizers', () => {
       afterEach(function () {
-        i(this.provider).configuration('formats.customizers')['jwt-ietf'] = undefined;
+        this.provider.configuration('formats.customizers')['jwt-ietf'] = undefined;
       });
 
       it('allows the payload to be extended', async function () {
         const accessToken = new this.provider.AccessToken(fullPayload);
-        i(this.provider).configuration('formats.customizers')['jwt-ietf'] = (ctx, token, jwt) => {
+        this.provider.configuration('formats.customizers')['jwt-ietf'] = (ctx, token, jwt) => {
           expect(token).to.equal(accessToken);
           expect(jwt).to.have.property('payload');
           expect(jwt).to.have.property('header', undefined);
@@ -225,7 +225,7 @@ if (FORMAT === 'jwt-ietf') {
     describe('invalid signing alg resolved', () => {
       ['none', 'HS256', 'HS384', 'HS512'].forEach((alg) => {
         it(`throws an Error when ${alg} is resolved`, async function () {
-          i(this.provider).configuration('formats').jwtAccessTokenSigningAlg = async () => alg;
+          this.provider.configuration('formats').jwtAccessTokenSigningAlg = async () => alg;
           const token = new this.provider.AccessToken(fullPayload);
           try {
             await token.save();
@@ -238,7 +238,7 @@ if (FORMAT === 'jwt-ietf') {
       });
 
       it('throws an Error when unsupported provider keystore alg is resolved', async function () {
-        i(this.provider).configuration('formats').jwtAccessTokenSigningAlg = async () => 'ES384';
+        this.provider.configuration('formats').jwtAccessTokenSigningAlg = async () => 'ES384';
         const token = new this.provider.AccessToken(fullPayload);
         try {
           await token.save();

--- a/test/formats/paseto.test.js
+++ b/test/formats/paseto.test.js
@@ -198,12 +198,12 @@ if (FORMAT === 'paseto') {
 
     describe('customizers', () => {
       afterEach(function () {
-        i(this.provider).configuration('formats.customizers').paseto = undefined;
+        this.provider.configuration('formats.customizers').paseto = undefined;
       });
 
       it('allows the payload to be extended', async function () {
         const accessToken = new this.provider.AccessToken(fullPayload);
-        i(this.provider).configuration('formats.customizers').paseto = (ctx, token, paseto) => {
+        this.provider.configuration('formats.customizers').paseto = (ctx, token, paseto) => {
           expect(token).to.equal(accessToken);
           expect(paseto).to.have.property('payload');
           paseto.payload.customized = true;
@@ -213,7 +213,7 @@ if (FORMAT === 'paseto') {
         const { payload } = await pasetoLib.V2.verify(paseto, key, { complete: true });
         expect(payload).to.have.property('customized', true);
 
-        i(this.provider).configuration('formats.customizers').paseto = (ctx, token, t) => {
+        this.provider.configuration('formats.customizers').paseto = (ctx, token, t) => {
           expect(t).to.have.property('footer', undefined);
           t.footer = { customized: true };
         };
@@ -223,7 +223,7 @@ if (FORMAT === 'paseto') {
         expect(footer).to.be.instanceOf(Buffer);
         expect(JSON.parse(footer)).to.have.property('customized', true);
 
-        i(this.provider).configuration('formats.customizers').paseto = (ctx, token, t) => {
+        this.provider.configuration('formats.customizers').paseto = (ctx, token, t) => {
           t.footer = Buffer.from('foobar');
         };
 
@@ -232,7 +232,7 @@ if (FORMAT === 'paseto') {
         expect(footer).to.be.instanceOf(Buffer);
         expect(footer.toString()).to.eql('foobar');
 
-        i(this.provider).configuration('formats.customizers').paseto = (ctx, token, t) => {
+        this.provider.configuration('formats.customizers').paseto = (ctx, token, t) => {
           t.footer = 'foobarbaz';
         };
 

--- a/test/interaction/interaction.test.js
+++ b/test/interaction/interaction.test.js
@@ -356,7 +356,7 @@ describe('resume after consent', () => {
       params: grant,
       session,
     });
-    const keys = new KeyGrip(i(this.provider).configuration('cookies.keys'));
+    const keys = new KeyGrip(this.provider.configuration('cookies.keys'));
 
     expect(grant).to.be.ok;
 

--- a/test/pkce/pkce.test.js
+++ b/test/pkce/pkce.test.js
@@ -168,11 +168,11 @@ describe('PKCE RFC7636', () => {
 
     describe('only S256 is supported', () => {
       before(function () {
-        i(this.provider).configuration().pkce.methods = ['S256'];
+        this.provider.configuration().pkce.methods = ['S256'];
       });
 
       after(function () {
-        i(this.provider).configuration().pkce.methods = ['plain', 'S256'];
+        this.provider.configuration().pkce.methods = ['plain', 'S256'];
       });
 
       it('fails when client does not provide challenge method', function () {
@@ -433,11 +433,11 @@ describe('PKCE RFC7636', () => {
 
     describe('only S256 is supported', () => {
       before(function () {
-        i(this.provider).configuration().pkce.methods = ['S256'];
+        this.provider.configuration().pkce.methods = ['S256'];
       });
 
       after(function () {
-        i(this.provider).configuration().pkce.methods = ['plain', 'S256'];
+        this.provider.configuration().pkce.methods = ['plain', 'S256'];
       });
 
       it('passes if S256 is used', async function () {

--- a/test/pushed_authorization_requests/pushed_authorization_requests.test.js
+++ b/test/pushed_authorization_requests/pushed_authorization_requests.test.js
@@ -24,7 +24,7 @@ describe('Pushed Request Object', () => {
           expect(response.body).not.to.have.property('require_pushed_authorization_requests');
         });
 
-      i(this.provider).configuration('features.pushedAuthorizationRequests').requirePushedAuthorizationRequests = true;
+      this.provider.configuration('features.pushedAuthorizationRequests').requirePushedAuthorizationRequests = true;
 
       return this.agent.get('/.well-known/openid-configuration')
         .expect((response) => {
@@ -35,7 +35,7 @@ describe('Pushed Request Object', () => {
     });
 
     after(function () {
-      i(this.provider).configuration('features.pushedAuthorizationRequests').requirePushedAuthorizationRequests = false;
+      this.provider.configuration('features.pushedAuthorizationRequests').requirePushedAuthorizationRequests = false;
     });
   });
 
@@ -286,7 +286,7 @@ describe('Pushed Request Object', () => {
           });
 
           it('handles expired or invalid pushed authorization request object (when no client_id in the request)', async function () {
-            const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+            const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
 
             const auth = new this.AuthorizationRequest({
               client_id: undefined,

--- a/test/refresh/refresh.grant.test.js
+++ b/test/refresh/refresh.grant.test.js
@@ -110,13 +110,13 @@ describe('grant_type=refresh_token', () => {
   describe('validates', () => {
     context('', () => {
       before(function () {
-        const ttl = i(this.provider).configuration('ttl');
+        const ttl = this.provider.configuration('ttl');
         this.prev = ttl.RefreshToken;
         ttl.RefreshToken = 5;
       });
 
       after(function () {
-        i(this.provider).configuration('ttl').RefreshToken = this.prev;
+        this.provider.configuration('ttl').RefreshToken = this.prev;
       });
 
       it('validates the refresh token is not expired', function () {
@@ -316,11 +316,11 @@ describe('grant_type=refresh_token', () => {
 
   describe('rotateRefreshToken=true', () => {
     before(function () {
-      i(this.provider).configuration().rotateRefreshToken = true;
+      this.provider.configuration().rotateRefreshToken = true;
     });
 
     after(function () {
-      i(this.provider).configuration().rotateRefreshToken = false;
+      this.provider.configuration().rotateRefreshToken = false;
     });
 
     it('populates ctx.oidc.entities', function (done) {
@@ -453,12 +453,12 @@ describe('grant_type=refresh_token', () => {
 
   describe('rotateRefreshToken is a function (returns true)', () => {
     beforeEach(function () {
-      i(this.provider).configuration().rotateRefreshToken = sinon.mock().returns(true);
+      this.provider.configuration().rotateRefreshToken = sinon.mock().returns(true);
     });
 
     afterEach(function () {
-      const spy = i(this.provider).configuration().rotateRefreshToken;
-      i(this.provider).configuration().rotateRefreshToken = false;
+      const spy = this.provider.configuration().rotateRefreshToken;
+      this.provider.configuration().rotateRefreshToken = false;
       expect(spy.calledOnce).to.be.true;
     });
 
@@ -591,12 +591,12 @@ describe('grant_type=refresh_token', () => {
 
   describe('rotateRefreshToken is a function (returns false)', () => {
     beforeEach(function () {
-      i(this.provider).configuration().rotateRefreshToken = sinon.mock().returns(false);
+      this.provider.configuration().rotateRefreshToken = sinon.mock().returns(false);
     });
 
     afterEach(function () {
-      const spy = i(this.provider).configuration().rotateRefreshToken;
-      i(this.provider).configuration().rotateRefreshToken = false;
+      const spy = this.provider.configuration().rotateRefreshToken;
+      this.provider.configuration().rotateRefreshToken = false;
       expect(spy.calledOnce).to.be.true;
     });
 

--- a/test/registration_management/registration_management.test.js
+++ b/test/registration_management/registration_management.test.js
@@ -209,14 +209,14 @@ describe('OAuth 2.0 Dynamic Client Registration Management Protocol', () => {
 
     describe('rotateRegistrationAccessToken', () => {
       before(function () {
-        const conf = i(this.provider).configuration();
+        const conf = this.provider.configuration();
         conf.features.registrationManagement = {
           enabled: true, rotateRegistrationAccessToken: true,
         };
       });
 
       after(function () {
-        const conf = i(this.provider).configuration();
+        const conf = this.provider.configuration();
         conf.features.registrationManagement = { enabled: true };
       });
 

--- a/test/registration_policies/registration_policies.test.js
+++ b/test/registration_policies/registration_policies.test.js
@@ -42,7 +42,7 @@ describe('client registration policies', () => {
     });
 
     it('runs the policies when a client is getting created', async function () {
-      const spy = sinon.spy(i(this.provider).configuration('features.registration.policies'), 'empty-policy');
+      const spy = sinon.spy(this.provider.configuration('features.registration.policies'), 'empty-policy');
       const value = await new this.provider.InitialAccessToken({ policies: ['empty-policy'] }).save();
 
       await this.agent.post('/reg')
@@ -54,7 +54,7 @@ describe('client registration policies', () => {
     });
 
     it('allows for policies to set property defaults', async function () {
-      i(this.provider).configuration('features.registration.policies')['set-default'] = (ctx, properties) => {
+      this.provider.configuration('features.registration.policies')['set-default'] = (ctx, properties) => {
         if (!('id_token_signed_response_alg' in properties)) {
           properties.id_token_signed_response_alg = 'HS256';
         }
@@ -80,7 +80,7 @@ describe('client registration policies', () => {
     });
 
     it('allows for policies to force property values', async function () {
-      i(this.provider).configuration('features.registration.policies')['force-default'] = (ctx, properties) => {
+      this.provider.configuration('features.registration.policies')['force-default'] = (ctx, properties) => {
         properties.id_token_signed_response_alg = 'HS256';
       };
 
@@ -96,7 +96,7 @@ describe('client registration policies', () => {
     });
 
     it('allows for policies to validate property values', async function () {
-      i(this.provider).configuration('features.registration.policies')['throw-error'] = () => {
+      this.provider.configuration('features.registration.policies')['throw-error'] = () => {
         throw new Provider.errors.InvalidClientMetadata('foo');
       };
 
@@ -128,7 +128,7 @@ describe('client registration policies', () => {
     });
 
     it('can be done to push different policies to rat', async function () {
-      i(this.provider).configuration('features.registration.policies')['change-rat-policy'] = async (ctx) => {
+      this.provider.configuration('features.registration.policies')['change-rat-policy'] = async (ctx) => {
         ctx.oidc.entities.RegistrationAccessToken.policies = ['empty-policy'];
       };
 
@@ -229,7 +229,7 @@ describe('client registration policies', () => {
       this.TestAdapter.for('RegistrationAccessToken').syncUpdate(this.getTokenJti(this.rat), {
         policies: ['empty-policy'],
       });
-      const spy = sinon.spy(i(this.provider).configuration('features.registration.policies'), 'empty-policy');
+      const spy = sinon.spy(this.provider.configuration('features.registration.policies'), 'empty-policy');
 
       await this.agent.put(this.url)
         .auth(this.rat, { type: 'bearer' })
@@ -241,7 +241,7 @@ describe('client registration policies', () => {
     });
 
     it('allows for policies to set property defaults', async function () {
-      i(this.provider).configuration('features.registration.policies')['set-default'] = (ctx, properties) => {
+      this.provider.configuration('features.registration.policies')['set-default'] = (ctx, properties) => {
         if (!('client_name' in properties)) {
           properties.client_name = 'foobar';
         }
@@ -273,7 +273,7 @@ describe('client registration policies', () => {
     });
 
     it('allows for policies to force property values', async function () {
-      i(this.provider).configuration('features.registration.policies')['force-value'] = (ctx, properties) => {
+      this.provider.configuration('features.registration.policies')['force-value'] = (ctx, properties) => {
         properties.client_name = 'foobar';
       };
       this.TestAdapter.for('RegistrationAccessToken').syncUpdate(this.getTokenJti(this.rat), {
@@ -294,7 +294,7 @@ describe('client registration policies', () => {
     });
 
     it('allows for policies to validate property values', async function () {
-      i(this.provider).configuration('features.registration.policies')['throw-error'] = () => {
+      this.provider.configuration('features.registration.policies')['throw-error'] = () => {
         throw new Provider.errors.InvalidClientMetadata('foo');
       };
       this.TestAdapter.for('RegistrationAccessToken').syncUpdate(this.getTokenJti(this.rat), {
@@ -314,12 +314,12 @@ describe('client registration policies', () => {
 
     describe('rotateRegistrationAccessToken', () => {
       before(function () {
-        const conf = i(this.provider).configuration();
+        const conf = this.provider.configuration();
         conf.features.registrationManagement = { rotateRegistrationAccessToken: true };
       });
 
       after(function () {
-        const conf = i(this.provider).configuration();
+        const conf = this.provider.configuration();
         conf.features.registrationManagement = { rotateRegistrationAccessToken: false };
       });
 

--- a/test/request/jwt_request.test.js
+++ b/test/request/jwt_request.test.js
@@ -52,7 +52,7 @@ describe('request parameter features', () => {
           expect(response.body).not.to.have.property('require_signed_request_object');
         });
 
-      i(this.provider).configuration('features.requestObjects').requireSignedRequestObject = true;
+      this.provider.configuration('features.requestObjects').requireSignedRequestObject = true;
 
       await this.agent.get('/.well-known/openid-configuration')
         .expect(200)
@@ -63,7 +63,7 @@ describe('request parameter features', () => {
     });
 
     after(function () {
-      i(this.provider).configuration('features.requestObjects').requireSignedRequestObject = false;
+      this.provider.configuration('features.requestObjects').requireSignedRequestObject = false;
     });
   });
 
@@ -93,13 +93,13 @@ describe('request parameter features', () => {
         });
       });
       after(function () {
-        i(this.provider).configuration().clockTolerance = 0;
+        this.provider.configuration().clockTolerance = 0;
         return this.logout();
       });
 
       describe('merging strategies', () => {
         beforeEach(function () {
-          const ro = i(this.provider).configuration().features.requestObjects;
+          const ro = this.provider.configuration().features.requestObjects;
           this.orig = {
             mergingStrategy: ro.mergingStrategy.name,
             whitelist: [...ro.mergingStrategy.whitelist],
@@ -107,14 +107,14 @@ describe('request parameter features', () => {
         });
 
         afterEach(function () {
-          const ro = i(this.provider).configuration().features.requestObjects;
+          const ro = this.provider.configuration().features.requestObjects;
           ro.mergingStrategy.name = this.orig.mergingStrategy;
           ro.mergingStrategy.whitelist = new Set(this.orig.whitelist);
         });
 
         describe('strict', () => {
           it('does not use anything from the OAuth 2.0 parameters', async function () {
-            i(this.provider).configuration().features.requestObjects.mergingStrategy.name = 'strict';
+            this.provider.configuration().features.requestObjects.mergingStrategy.name = 'strict';
 
             const spy = sinon.spy();
             this.provider.once('authorization.success', spy);
@@ -153,7 +153,7 @@ describe('request parameter features', () => {
 
         describe('lax', () => {
           it('uses anything not found in the Request Object', async function () {
-            i(this.provider).configuration().features.requestObjects.mergingStrategy.name = 'lax';
+            this.provider.configuration().features.requestObjects.mergingStrategy.name = 'lax';
 
             const spy = sinon.spy();
             this.provider.once('authorization.success', spy);
@@ -192,9 +192,9 @@ describe('request parameter features', () => {
 
         describe('whitelist', () => {
           it('uses anything not found in the Request Object', async function () {
-            i(this.provider).configuration()
+            this.provider.configuration()
               .features.requestObjects.mergingStrategy.name = 'whitelist';
-            i(this.provider).configuration()
+            this.provider.configuration()
               .features.requestObjects.mergingStrategy.whitelist = new Set([
                 'ui_locales',
               ]);
@@ -536,7 +536,7 @@ describe('request parameter features', () => {
         const key = (await this.provider.Client.find('client-with-HS-sig')).keystore.get({
           alg: 'HS256',
         });
-        i(this.provider).configuration().clockTolerance = 10;
+        this.provider.configuration().clockTolerance = 10;
         return JWT.sign({
           iat: Math.ceil(Date.now() / 1000) + 5,
           client_id: 'client-with-HS-sig',

--- a/test/session_management/check_session_endpoint.test.js
+++ b/test/session_management/check_session_endpoint.test.js
@@ -12,12 +12,12 @@ describe('check_session_iframe', () => {
     });
   });
   before(function () {
-    const { scriptNonce: orig } = i(this.provider).configuration('features.sessionManagement');
+    const { scriptNonce: orig } = this.provider.configuration('features.sessionManagement');
     this.orig = orig;
   });
 
   afterEach(function () {
-    i(this.provider).configuration('features.sessionManagement').scriptNonce = this.orig;
+    this.provider.configuration('features.sessionManagement').scriptNonce = this.orig;
   });
 
   it('responds with frameable html', async function () {
@@ -30,7 +30,7 @@ describe('check_session_iframe', () => {
         expect(response.text).not.to.contain('nonce="foo"');
       });
 
-    i(this.provider).configuration('features.sessionManagement').scriptNonce = (ctx) => {
+    this.provider.configuration('features.sessionManagement').scriptNonce = (ctx) => {
       expect(ctx.oidc).to.be.ok;
       return 'foo';
     };

--- a/test/session_management/end_session.test.js
+++ b/test/session_management/end_session.test.js
@@ -77,13 +77,13 @@ describe('[session_management]', () => {
     it('follows a domain if configured', function () {
       this.getSession().state = { secret: '123', postLogoutRedirectUri: '/', clientId: 'client' };
 
-      i(this.provider).configuration().cookies.long.domain = '.oidc.dev';
+      this.provider.configuration().cookies.long.domain = '.oidc.dev';
 
       return this.agent.post('/session/end/confirm')
         .send({ xsrf: '123', logout: 'yes' })
         .type('form')
         .expect(() => {
-          delete i(this.provider).configuration().cookies.long.domain;
+          delete this.provider.configuration().cookies.long.domain;
         })
         .expect(302)
         .expect((response) => {
@@ -97,13 +97,13 @@ describe('[session_management]', () => {
         secret: '123', postLogoutRedirectUri: '/', clientId: 'client', state: 'foobar',
       };
 
-      i(this.provider).configuration().cookies.long.domain = '.oidc.dev';
+      this.provider.configuration().cookies.long.domain = '.oidc.dev';
 
       return this.agent.post('/session/end/confirm')
         .send({ xsrf: '123', logout: 'yes' })
         .type('form')
         .expect(() => {
-          delete i(this.provider).configuration().cookies.long.domain;
+          delete this.provider.configuration().cookies.long.domain;
         })
         .expect(302)
         .expect('location', '/?state=foobar')

--- a/test/sessions/sessions.test.js
+++ b/test/sessions/sessions.test.js
@@ -44,13 +44,13 @@ describe('session exp handling', () => {
 
   describe('clockTolerance', () => {
     afterEach(function () {
-      i(this.provider).configuration().clockTolerance = 0;
+      this.provider.configuration().clockTolerance = 0;
     });
 
     it('respects clockTolerance option', async function () {
       await this.login();
       const session = this.getSession();
-      i(this.provider).configuration().clockTolerance = 10;
+      this.provider.configuration().clockTolerance = 10;
       session.exp = epochTime() - 5;
 
       sinon.spy(this.TestAdapter.for('Session'), 'destroy');
@@ -72,7 +72,7 @@ describe('session exp handling', () => {
     it('generates a new session id when an expired session is found by the adapter', async function () {
       await this.login();
       const session = this.getSession();
-      i(this.provider).configuration().clockTolerance = 10;
+      this.provider.configuration().clockTolerance = 10;
       session.exp = epochTime() - 10;
       const oldSessionId = this.getSessionId();
 

--- a/test/signatures/signatures.test.js
+++ b/test/signatures/signatures.test.js
@@ -136,7 +136,7 @@ describe('signatures', () => {
     beforeEach(async function () {
       const ac = new this.provider.AuthorizationCode({
         accountId: 'accountIdentity',
-        acr: i(this.provider).configuration('acrValues[0]'),
+        acr: this.provider.configuration('acrValues[0]'),
         authTime: epochTime(),
         clientId: 'client-sig-none',
         grantId: nanoid(),
@@ -223,7 +223,7 @@ describe('signatures', () => {
     beforeEach(async function () {
       const ac = new this.provider.AuthorizationCode({
         accountId: 'accountIdentity',
-        acr: i(this.provider).configuration('acrValues[0]'),
+        acr: this.provider.configuration('acrValues[0]'),
         authTime: epochTime(),
         clientId: 'client-sig-HS256',
         grantId: nanoid(),

--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -31,7 +31,7 @@ global.i = require('../lib/helpers/weak_cache');
 Object.defineProperties(Provider.prototype, {
   enable: {
     value(feature, options = {}) {
-      const config = i(this).configuration(`features.${feature}`);
+      const config = this.configuration(`features.${feature}`);
       if (!config) {
         throw new Error(`invalid feature: ${feature}`);
       }
@@ -128,7 +128,7 @@ module.exports = function testHelper(dir, {
       const account = nanoid();
       this.loggedInAccountId = account;
 
-      const keys = new KeyGrip(i(provider).configuration('cookies.keys'));
+      const keys = new KeyGrip(provider.configuration('cookies.keys'));
       const session = new (provider.Session)({ jti: sessionId, loginTs, account });
       const sessionCookie = `_session=${sessionId}; path=/; expires=${expire.toGMTString()}; httponly`;
       const cookies = [sessionCookie];
@@ -154,7 +154,7 @@ module.exports = function testHelper(dir, {
           rejectedClaims,
         };
 
-        if (i(provider).configuration('features.sessionManagement.enabled')) {
+        if (provider.configuration('features.sessionManagement.enabled')) {
           const cookie = `_state.${cl.client_id}=${session.stateFor(cl.client_id)}; path=/; expires=${expire.toGMTString()}`;
           cookies.push(cookie);
           [pre, ...post] = cookie.split(';');
@@ -496,7 +496,7 @@ module.exports.passInteractionChecks = (...reasons) => {
 
   context('', () => {
     before(function () {
-      const { policy } = i(this.provider).configuration('interactions');
+      const { policy } = this.provider.configuration('interactions');
 
       const iChecks = flatten(policy.map((i) => i.checks));
 

--- a/test/web_message/web_message.test.js
+++ b/test/web_message/web_message.test.js
@@ -102,7 +102,7 @@ describe('configuration features.webMessageResponseMode', () => {
     context('error handling', () => {
       it('verifies web_message_uri is whitelisted', function () {
         const emitSpy = sinon.spy();
-        const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+        const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
         this.provider.once('authorization.error', emitSpy);
 
         const auth = new this.AuthorizationRequest({
@@ -128,7 +128,7 @@ describe('configuration features.webMessageResponseMode', () => {
       });
 
       it('validates web_message_uri ad acta [regular error]', function () {
-        const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+        const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
         const spy = sinon.spy();
         this.provider.on('authorization.error', spy);
         const auth = new this.AuthorizationRequest({
@@ -160,7 +160,7 @@ describe('configuration features.webMessageResponseMode', () => {
       });
 
       it('validates web_message_uri ad acta [server error]', function () {
-        const renderSpy = sinon.spy(i(this.provider).configuration(), 'renderError');
+        const renderSpy = sinon.spy(this.provider.configuration(), 'renderError');
         const authErrorSpy = sinon.spy();
         const serverErrorSpy = sinon.spy();
         this.provider.on('authorization.error', authErrorSpy);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1218,6 +1218,7 @@ export class Provider extends events.EventEmitter {
   ): void;
   use: Koa['use'];
 
+  configuration(): Configuration;
   configuration<T>(path: string): T;
 
   // tslint:disable:unified-signatures

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1218,6 +1218,8 @@ export class Provider extends events.EventEmitter {
   ): void;
   use: Koa['use'];
 
+  configuration<T>(path: string): T;
+
   // tslint:disable:unified-signatures
   addListener(event: string, listener: (...args: any[]) => void): this;
   addListener(event: 'access_token.destroyed', listener: (accessToken: AccessToken) => void): this;

--- a/types/oidc-provider-tests.ts
+++ b/types/oidc-provider-tests.ts
@@ -576,6 +576,7 @@ provider.on('authorization.accepted', (ctx) => {
   ctx.oidc.cookies.set('key', 'value', { signed: true, sameSite: 'strict' });
 });
 
+provider.configuration();
 provider.configuration<Configuration['clockTolerance']>('clockTolerance');
 
 provider.on('interaction.started', (ctx, prompt) => {

--- a/types/oidc-provider-tests.ts
+++ b/types/oidc-provider-tests.ts
@@ -1,4 +1,4 @@
-import { Provider, interactionPolicy, AsymmetricSigningAlgorithm } from './index.d';
+import { Provider, interactionPolicy, AsymmetricSigningAlgorithm, Configuration } from './index.d';
 
 new Provider('https://op.example.com');
 
@@ -575,6 +575,8 @@ provider.on('authorization.accepted', (ctx) => {
 
   ctx.oidc.cookies.set('key', 'value', { signed: true, sameSite: 'strict' });
 });
+
+provider.configuration<Configuration['clockTolerance']>('clockTolerance');
 
 provider.on('interaction.started', (ctx, prompt) => {
   ctx.oidc.route.substring(0);


### PR DESCRIPTION
This PR proposal contains a lot of changed files, but most of them are just alignments of the existing code and could be easily reverted and excluded from the PR. There is only one important part in the `lib/provider.js` file:

```js
configuration(path) {
  return instance(this).configuration(path);
}
```
It exposes simplified interface for a configuration read. Why? It allows to simplify code, resign from `helpers/weak_cache` dependency, what is especially helpful for for the TypeScript users and the external lib extensions. (OIDC context is frequently passed to configuration callbacks)

@panva What do you think? :)