### PR TITLE
fix(typescript): Interaction.prototype.session structure

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -181,10 +181,10 @@ declare class Interaction extends BaseModel {
   readonly kind: 'Interaction';
   iat: number;
   exp: number;
-  session?: Session | {
+  session?: {
     accountId: string;
+    uid: string;
     cookie: string;
-    jti?: string;
     acr?: string;
     amr?: string[];
   };


### PR DESCRIPTION
Interaction.session is always a plain object - its type was changed to
a union type including Session when the Interaction constructor was
updated to handle payload.session being an instance of Session, but in
such a case, the Session object is transformed to a plain object.

The jti property appears to have been an extraneous duplicate of the
cookie property - a Session object's jti property is mapped to the
cookie property of the plain object.

The uid property was simply missing from the type definition.