### PR TITLE
fix: correctly check access token audience when issuing ID tokens

### DIFF
--- a/lib/actions/grants/authorization_code.js
+++ b/lib/actions/grants/authorization_code.js
@@ -190,7 +190,7 @@ module.exports.handler = async function authorizationCodeHandler(ctx, next) {
       auth_time: code.authTime,
     }, { ctx });
 
-    if (conformIdTokenClaims && userinfo.enabled && !accessToken.aud) {
+    if (conformIdTokenClaims && userinfo.enabled && !at.aud) {
       token.scope = 'openid';
     } else {
       token.scope = grant.getOIDCScopeFiltered(code.scopes);

--- a/lib/actions/grants/ciba.js
+++ b/lib/actions/grants/ciba.js
@@ -197,7 +197,7 @@ module.exports.handler = async function cibaHandler(ctx, next) {
       },
     }, { ctx });
 
-    if (conformIdTokenClaims && userinfo.enabled && !accessToken.aud) {
+    if (conformIdTokenClaims && userinfo.enabled && !at.aud) {
       token.scope = 'openid';
     } else {
       token.scope = grant.getOIDCScopeFiltered(request.scopes);

--- a/lib/actions/grants/device_code.js
+++ b/lib/actions/grants/device_code.js
@@ -196,7 +196,7 @@ module.exports.handler = async function deviceCodeHandler(ctx, next) {
       },
     }, { ctx });
 
-    if (conformIdTokenClaims && userinfo.enabled && !accessToken.aud) {
+    if (conformIdTokenClaims && userinfo.enabled && !at.aud) {
       token.scope = 'openid';
     } else {
       token.scope = grant.getOIDCScopeFiltered(code.scopes);

--- a/lib/actions/grants/refresh_token.js
+++ b/lib/actions/grants/refresh_token.js
@@ -207,7 +207,7 @@ module.exports.handler = async function refreshTokenHandler(ctx, next) {
       auth_time: refreshToken.authTime,
     }), { ctx });
 
-    if (conformIdTokenClaims && userinfo.enabled && !accessToken.aud) {
+    if (conformIdTokenClaims && userinfo.enabled && !at.aud) {
       token.scope = 'openid';
     } else {
       token.scope = grant.getOIDCScopeFiltered(scope);


### PR DESCRIPTION
Fixes an issue where ID tokens would not include account claims, even if the access token was not usable for the userInfo endpoint (contained an aud value).

Currently, if you use the resourceIndicators feature and issue an access token in JWT format, then the returned ID token will not contain any account claims. This is despite the fact that the JWT access token is not usable on the userInfo endpoint.

Problem is caused by the code checking the access token for an `aud` value. It's checking the generated token string rather then the original token object.