### PR TITLE
MR to resolve script error from form_post.js

### DIFF
--- a/lib/response_modes/form_post.js
+++ b/lib/response_modes/form_post.js
@@ -15,6 +15,7 @@ module.exports = function formPost(ctx, action, inputs) {
 
   ctx.body = `<!DOCTYPE html>
 <head>
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title>Submitting Callback</title>
   <script>
     document.addEventListener('DOMContentLoaded', function () { document.forms[0].submit() });


### PR DESCRIPTION
Background to this MR: 
When a web browser is embedded as control, it runs in IE7 document mode by default even though the latest version of IE is installed on machine. Because of this WPF desktop application is throwing script error to execute "addEventListener" function from form_post.js

Resolution:
The solution to this issue is to add below meta tag inside head tag at form_post.js file. This will tell browser to use latest version of IE installed on machine to run the document.
<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">

It would be very helpful it this change is available in 6.31.0 or may be newly published version like 6.31.0-a as we are using 6.31.0 version in our services.