### PR TITLE
Increase MAX_TTL of PAR object

### DIFF
--- a/lib/actions/authorization/pushed_authorization_request_response.js
+++ b/lib/actions/authorization/pushed_authorization_request_response.js
@@ -4,7 +4,7 @@ const { PUSHED_REQUEST_URN } = require('../../consts');
 const epochTime = require('../../helpers/epoch_time');
 const JWT = require('../../helpers/jwt');
 
-const MAX_TTL = 60;
+const MAX_TTL = 600;
 
 module.exports = async function pushedAuthorizationRequestResponse(ctx, next) {
   let request;


### PR DESCRIPTION
Hey,
I would like to increase the TTL of the PAR response and I found that this is hard-coded. As per specification (https://www.rfc-editor.org/rfc/rfc9126.html) this value could be up to 600 (or more, if desired). Can we make this adjustment while this feature is not added to the configuration file?
Thanks