### PR TITLE
fix: await the result returned by resourceIndicators.useGrantedResource function, in resolve_resource.js

### DIFF
--- a/lib/helpers/resolve_resource.js
+++ b/lib/helpers/resolve_resource.js
@@ -11,7 +11,7 @@ module.exports = async (ctx, model, config, scopes = model.scopes) => {
       case !model.resource:
       case Array.isArray(model.resource) && model.resource.length === 0:
         break;
-      case model.resource && !!config.resourceIndicators.useGrantedResource(ctx, model):
+      case model.resource && !!(await config.resourceIndicators.useGrantedResource(ctx, model)):
       case !ctx.oidc.params.resource && (!config.userinfo.enabled || !scopes.has('openid')):
         resource = model.resource;
         break;

--- a/test/resource_indicators/resource_indicators.config.js
+++ b/test/resource_indicators/resource_indicators.config.js
@@ -38,7 +38,7 @@ merge(config, {
     },
     resourceIndicators: {
       enabled: true,
-      useGrantedResource(ctx) {
+      async useGrantedResource(ctx) {
         return ctx.oidc.body && ctx.oidc.body.usegranted;
       },
       getResourceServerInfo(ctx, resource) {


### PR DESCRIPTION
First, thank all the contributors for your effort in building this awesome project, which helps me a lot! During my usage, I found something that maybe a minor bug. 

The `features.resourceIndicators.useGrantedResource` function defined in the config can be async function. In fact, the default value for that is indeed an async function:
https://github.com/panva/node-oidc-provider/blob/2ba83954760017caca5fe0e96e8eee2d10061e9e/lib/helpers/defaults.js#L201-L206
However, when the function is called in `resolver_resource.js`, which is used to resolve the resource for a auth or token request, the value returned by `useGrantedResource` is not awaited:
https://github.com/panva/node-oidc-provider/blob/2ba83954760017caca5fe0e96e8eee2d10061e9e/lib/helpers/resolve_resource.js#L14
In my opinion, this is a bug, which makes the `useGrantedResource` configration have no effect, since !! a `Promise` will always equals to `true`.

Thank you for your review!