### PR TITLE
bug with skip_consent grant length not matching session

### DIFF
--- a/recipes/skip_consent.md
+++ b/recipes/skip_consent.md
@@ -40,3 +40,5 @@ This will get you as far as not asking for any consent unless the application is
 application (e.g. iOS, Android, CLI, Device Flow). It is recommended to still show a consent
 screen to those with the application details to those since they are public clients and their
 redirect_uri ownership can rarely be validated.
+
+bug with this?


### PR DESCRIPTION
If you reauthenticate an active session using max_age 0, the _session cookie id changes and the old session row is deleted
in the database but somehow the existing grant gets copied onto the new session. The grant's expiry isn't updated, however.
You end up with a session length longer than the grant's length. In the case of skipped consent, this ends up with the interaction policy eventually landing you on the interaction start handler with prompt 'consent' (once your grant has expired but your session is still valid). that won't be implemented (because you are trying to skip it) so things error.