### PR TITLE
example: update skip_consent recipe

### DIFF
--- a/recipes/skip_consent.md
+++ b/recipes/skip_consent.md
@@ -22,7 +22,10 @@ const oidcConfiguration = {
       // to prevent consent prompt being requested when grant expires
       const grant = await ctx.oidc.provider.Grant.find(grantId);
 
-      if (ctx.oidc?.session?.accountId && grant.exp !== ctx.oidc.session.exp) {
+      // this aligns the Grant ttl with that of the current session
+      // if the same Grant is used for multiple sessions, or is set
+      // to never expire, you probably do not want this in your code
+      if (ctx.oidc.account && grant.exp < ctx.oidc.session.exp) {
         grant.exp = ctx.oidc.session.exp;
 
         await grant.save();

--- a/recipes/skip_consent.md
+++ b/recipes/skip_consent.md
@@ -3,7 +3,7 @@
 - built for version: ^7.0.0
 - no guarantees this is bug-free, no support will be provided for this, you've been warned, you're on
 your own
-- it is not recommended to have consent-free flows for the obvious issues this poses for native 
+- it is not recommended to have consent-free flows for the obvious issues this poses for native
 applications
 
 Sometimes your use-case doesn't need a consent screen.
@@ -18,7 +18,17 @@ const oidcConfiguration = {
       && ctx.oidc.result.consent.grantId) || ctx.oidc.session.grantIdFor(ctx.oidc.client.clientId);
 
     if (grantId) {
-      return ctx.oidc.provider.Grant.find(grantId);
+      // keep grant expiry aligned with session expiry
+      // to prevent consent prompt being requested when grant expires
+      const grant = await ctx.oidc.provider.Grant.find(grantId);
+
+      if (ctx.oidc?.session?.accountId && grant.exp !== ctx.oidc.session.exp) {
+        grant.exp = ctx.oidc.session.exp;
+
+        await grant.save();
+      }
+
+      return grant;
     } else if (isFirstParty(ctx.oidc.client)) {
       const grant = new ctx.oidc.provider.Grant({
         clientId: ctx.oidc.client.clientId,
@@ -36,7 +46,7 @@ const oidcConfiguration = {
 const provider = new Provider(ISSUER, oidcConfiguration); // finally, configure your provider
 ```
 
-This will get you as far as not asking for any consent unless the application is a native 
+This will get you as far as not asking for any consent unless the application is a native
 application (e.g. iOS, Android, CLI, Device Flow). It is recommended to still show a consent
 screen to those with the application details to those since they are public clients and their
 redirect_uri ownership can rarely be validated.


### PR DESCRIPTION
…sion expiry

* currently if a session gets re-established without an explicit logout, the grantId gets copied onto the new session but its expiry does not get updated
* this means the grant can expire before the session and the interactionPolicy will try and prompt for consent
* this code snippet inspects the expiry on the session and updates the grant to match if the values differ