### PR TITLE
fix: invalidation code not sent

### DIFF
--- a/lib/helpers/client_schema.js
+++ b/lib/helpers/client_schema.js
@@ -593,11 +593,11 @@ module.exports = function getSchema(provider) {
 
             if (this.grant_types.includes('implicit')) {
               if (protocol === 'http:') {
-                this.invalidate(`${label} for web clients using implicit flow MUST only register URLs using the https scheme', 'implicit-force-https`);
+                this.invalidate(`${label} for web clients using implicit flow MUST only register URLs using the https scheme`, 'implicit-force-https');
               }
 
               if (hostname === 'localhost') {
-                this.invalidate(`${label} for web clients using implicit flow must not be using localhost', 'implicit-forbid-localhost`);
+                this.invalidate(`${label} for web clients using implicit flow must not be using localhost`, 'implicit-forbid-localhost');
               }
             }
             break;


### PR DESCRIPTION
This PR fixed a bug introduced in [this commit](https://github.com/panva/node-oidc-provider/commit/3fca22bb5dc8dc529c08c596109988a35e110f74) which prevents using the invalidation code.