### PR TITLE
fix: convert cookie to array in case is a string

### DIFF
--- a/lib/shared/session.js
+++ b/lib/shared/session.js
@@ -49,7 +49,11 @@ module.exports = async function sessionHandler(ctx, next) {
     }
 
     if (ctx.response.get('set-cookie')) {
-      ctx.response.get('set-cookie').forEach((cookie, index, ary) => {
+      let cookiejar = ctx.response.get('set-cookie');
+      if(typeof ctx.response.get('set-cookie') === 'string') {
+        cookiejar = cookiejar.split(';')
+      }
+      cookiejar.forEach((cookie, index, ary) => {
         /* eslint-disable no-param-reassign */
         if (
           !cookie.includes('expires=Thu, 01 Jan 1970')


### PR DESCRIPTION
This fixes the error

```
TypeError: ctx.response.get(...).forEach is not a function
    at sessionHandler (/<redacted>/node_modules/oidc-provider/lib/shared/session.js:56:38)
    at async noCache (/<redacted>/node_modules/oidc-provider/lib/shared/no_cache.js:4:3)
    at async authorizationErrorHandler (/<redacted>/node_modules/oidc-provider/lib/shared/authorization_error_handler.js:53:7)
    at async ensureSessionSave (/<redacted>/node_modules/oidc-provider/lib/helpers/initialize_app.js:50:7)
    at async contextEnsureOidc (/<redacted>/node_modules/oidc-provider/lib/shared/context_ensure_oidc.js:4:5)
    at async /<redacted>/node_modules/oidc-provider/lib/helpers/initialize_app.js:245:5
    at async errorHandler (/<redacted>/node_modules/oidc-provider/lib/shared/error_handler.js:26:7)
```
This is because I was getting `ctx.response.get('set-cookie')` as a string.

I suspect is because I'm not using "[pillarjs/cookies](https://github.com/pillarjs/cookies)" it isn't documented anywhere that it should be used, nor is a peer-dependency.



