### PR TITLE
fix: updated signed to trusted in interaction model

### DIFF
--- a/lib/models/interaction.js
+++ b/lib/models/interaction.js
@@ -62,7 +62,7 @@ module.exports = (provider) => class Interaction extends hasFormat(provider, 'In
       'prompt',
       'result',
       'returnTo',
-      'signed',
+      'trusted',
       'grantId',
       'lastSubmission',
       'deviceCode',


### PR DESCRIPTION
The key for signed params was changed from `signed` to `trusted`, however unfortunately the interaction model wasn't updated and so the trusted/signed params list isn't being persisted in the interaction session.