### PR TITLE
Allow issuer without trailing /

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -178,7 +178,7 @@ class Provider extends events.EventEmitter {
     this.#PushedAuthorizationRequest = models.getPushedAuthorizationRequest(this);
     this.#OIDCContext = getContext(this);
     const { pathname } = url.parse(this.issuer);
-    this.#mountPath = pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+    this.#mountPath = pathname != null && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname || "";
     instance(this).requestUriCache = new RequestUriCache(this);
 
     initializeAdapter.call(this, configuration.adapter);


### PR DESCRIPTION
When issuer does not have trailing `/`, `pathname` is null.