### PR TITLE
Update request.js

### DIFF
--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -1,11 +1,12 @@
 const { Agent: HttpAgent } = require('http');
 const { Agent: HttpsAgent } = require('https');
+const { Agent: AgentBase} = require('agent-base');
 
 const got = require('got');
 const CacheableLookup = require('cacheable-lookup');
 const QuickLRU = require('quick-lru');
 
-const omitBy = require('./_/omit_by');
+const pickBy = require('./_/pick_by');
 const instance = require('./weak_cache');
 
 const cacheable = new CacheableLookup({
@@ -20,17 +21,18 @@ module.exports = async function request(options) {
   // eslint-disable-next-line no-param-reassign
   options.headers['user-agent'] = undefined;
   const { timeout, agent, lookup } = instance(this).configuration('httpOptions')(new URL(options.url));
-  const helperOptions = omitBy({ timeout, agent, lookup }, Boolean);
+  const helperOptions = pickBy({ timeout, agent, lookup }, Boolean);
 
   if (helperOptions.timeout !== undefined && typeof helperOptions.timeout !== 'number') {
     throw new TypeError('"timeout" http request option must be a number');
   }
 
   if (helperOptions.agent !== undefined && typeof helperOptions.agent !== 'number') {
-    if (!(agent instanceof HttpsAgent) && !(agent instanceof HttpAgent)) {
+    if (!(agent instanceof HttpsAgent) && !(agent instanceof HttpAgent) && !(agent instanceof AgentBase)) {
       throw new TypeError('"agent" http request option must be an instance of https.Agent or http.Agent depending on the protocol used');
     }
-    helperOptions.agent = { [options.url.protocol]: helperOptions.agent };
+    const protocol = options.url.protocol.endsWith(':') ? options.url.protocol.slice(0, -1) : options.url.protocol;
+    helperOptions.agent = { [protocol]: helperOptions.agent };
   }
 
   if (helperOptions.lookup !== undefined && typeof helperOptions.lookup !== 'function') {

--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -1,7 +1,3 @@
-const { Agent: HttpAgent } = require('http');
-const { Agent: HttpsAgent } = require('https');
-const { Agent: AgentBase} = require('agent-base');
-
 const got = require('got');
 const CacheableLookup = require('cacheable-lookup');
 const QuickLRU = require('quick-lru');
@@ -28,15 +24,11 @@ module.exports = async function request(options) {
   }
 
   if (helperOptions.agent !== undefined && typeof helperOptions.agent !== 'number') {
-    if (!(agent instanceof HttpsAgent) && !(agent instanceof HttpAgent) && !(agent instanceof AgentBase)) {
-      throw new TypeError('"agent" http request option must be an instance of https.Agent or http.Agent depending on the protocol used');
-    }
-    const protocol = options.url.protocol.endsWith(':') ? options.url.protocol.slice(0, -1) : options.url.protocol;
-    helperOptions.agent = { [protocol]: helperOptions.agent };
+    helperOptions.agent = { [options.url.protocol.slice(0, -1)]: helperOptions.agent };
   }
 
   if (helperOptions.lookup !== undefined && typeof helperOptions.lookup !== 'function') {
-    throw new TypeError('"agent" http request option must be a function');
+    throw new TypeError('"lookup" http request option must be a function');
   }
 
   return got({


### PR DESCRIPTION
Hi, 

For private_key_jwt authentication, our Provider, running behind the proxy, tries to retrieve the JWKS keys by the specified jwksUri configured endpoint. 

We pass the proxy agent through httpOptions, as described in the configuration, e.g.:

    httpOptions(urlstr) {
      const options = url.parse('http://proxy-fr-croissy.gemalto.com:8080');
      const agent = new HttpsProxyAgent(options);
      return {
        agent,
        timeout: 5000,
      };
    },

That unfortunatelly didn't work, and the debug undentified 3 issues:

1. const helperOptions = omitBy({ timeout, agent, lookup }, Boolean);
this code omits whatever is provided in httpOptions, so we had to change it to pickBy instead

2. if (!(agent instanceof HttpsAgent) && !(agent instanceof HttpAgent))
this condition is not satisfied when I pass an instance of HttpsProxyAgent from 'https-proxy-agent', as it extends the Agent from 'agent-base' package. So we had to update the condition.

3. url: new URL(options.url)
    helperOptions.agent = { [options.url.protocol]: helperOptions.agent };
options.url.protocol string is 'https:', but as the trailing extra column is causing a problem, we had to slice it.