### PR TITLE
Update request.js

### DIFF
--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -37,7 +37,7 @@ module.exports = async function request(options) {
     retry: 0,
     throwHttpErrors: false,
     timeout: 2500,
-    lookup: cacheable.lookup,
+    // lookup: cacheable.lookup,
     ...helperOptions,
   });
 };


### PR DESCRIPTION
Hi Filip, 

Thanks for merging the pull request. 

I've noticed a small impact related to the DNS lookup though, and wanted to bring it to your attention. The previous code:

  const { timeout, agent, lookup } = instance(this).configuration('httpOptions')(new URL(options.url));
  const helperOptions = omitBy({ timeout, agent, lookup }, Boolean);

resulted in helperOptions.lookup = undefined, which was efectively overriding the lookup on 'options' object, e.g:

lookup: cacheable.lookup, 

Looks like cacheable.lookup has never been properly set, forcing the 'net' package to use dns.lookup instead, e.g:

  ...
  const lookup = options.lookup || dns.lookup;
  defaultTriggerAsyncIdScope(self[async_id_symbol], function() {
  ...

Now, thanks to the fix, the DNS lookup behavior will always default to cacheable.lookup, unless it is explicitly overridden in httpsOptions. Perhaps this is a proper behavior, but I've noticed cachable.lookup works a bit differently compared to dns.lookup, and apparently can impact some existing deployments when updated.

Perhaps it would be safer to disable defaulting to cacheable.lookup?