### PR TITLE
Feature: allow arrow-function & class-methods as adapter factory

### DIFF
--- a/lib/helpers/initialize_adapter.js
+++ b/lib/helpers/initialize_adapter.js
@@ -1,7 +1,10 @@
+const util = require('util');
+
 const MemoryAdapter = require('../adapters/memory_adapter');
 
 const instance = require('./weak_cache');
 const attention = require('./attention');
+const { isConstructable } = require('./type_validators');
 
 module.exports = function initializeAdapter(adapter = MemoryAdapter) {
   if (adapter === MemoryAdapter) {
@@ -10,10 +13,12 @@ module.exports = function initializeAdapter(adapter = MemoryAdapter) {
     + ' between processes');
   }
 
-  if (!adapter.prototype || !adapter.prototype.constructor.name) {
-    throw new Error(
-      'Expected "adapter" to be a constructor, provide a valid adapter in Provider config.',
-    );
+  const constructable = isConstructable(adapter);
+  const executable = typeof adapter === 'function' && !util.types.isAsyncFunction(adapter);
+  const valid = constructable || executable;
+
+  if (!valid) {
+    throw new Error('Expected "adapter" to be a constructor or not async function, provide a valid adapter in Provider config.');
   }
 
   instance(this).Adapter = adapter;

--- a/lib/helpers/initialize_adapter.js
+++ b/lib/helpers/initialize_adapter.js
@@ -18,7 +18,7 @@ module.exports = function initializeAdapter(adapter = MemoryAdapter) {
   const valid = constructable || executable;
 
   if (!valid) {
-    throw new Error('Expected "adapter" to be a constructor or not async function, provide a valid adapter in Provider config.');
+    throw new Error('Expected "adapter" to be a constructor or a factory function, provide a valid adapter in Provider config.');
   }
 
   instance(this).Adapter = adapter;

--- a/lib/helpers/type_validators.js
+++ b/lib/helpers/type_validators.js
@@ -1,0 +1,12 @@
+const hasPrototype = (target) => target.prototype !== null && typeof target.prototype === 'object';
+
+const isContructor = (fn) => fn.constructor instanceof Function
+  && fn.constructor.name !== undefined;
+
+const isConstructable = (constructable) => constructable instanceof Function
+      && hasPrototype(constructable)
+      && isContructor(constructable.constructor);
+
+module.exports = {
+  isConstructable,
+};

--- a/lib/models/base_model.js
+++ b/lib/models/base_model.js
@@ -13,6 +13,7 @@ const snakeCase = require('../helpers/_/snake_case');
 const epochTime = require('../helpers/epoch_time');
 const pickBy = require('../helpers/_/pick_by');
 const instance = require('../helpers/weak_cache');
+const { isConstructable } = require('../helpers/type_validators');
 
 const hasFormat = require('./mixins/has_format');
 
@@ -23,7 +24,11 @@ module.exports = function getBaseModel(provider) {
     const obj = typeof ctx === 'function' ? ctx : ctx.constructor;
 
     if (!adapterCache.has(obj)) {
-      adapterCache.set(obj, new (instance(provider).Adapter)(obj.name));
+      if (isConstructable(instance(provider).Adapter)) {
+        adapterCache.set(obj, new (instance(provider).Adapter)(obj.name));
+      } else {
+        adapterCache.set(obj, instance(provider).Adapter(obj.name));
+      }
     }
 
     return adapterCache.get(obj);

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -16,6 +16,7 @@ const base64url = require('../helpers/base64url');
 const request = require('../helpers/request');
 const nanoid = require('../helpers/nanoid');
 const epochTime = require('../helpers/epoch_time');
+const { isConstructable } = require('../helpers/type_validators');
 const instance = require('../helpers/weak_cache');
 const constantEquals = require('../helpers/constant_equals');
 const { InvalidClient, InvalidClientMetadata } = require('../helpers/errors');
@@ -134,7 +135,13 @@ module.exports = function getClient(provider) {
   let adapter;
 
   function getAdapter() {
-    if (!adapter) adapter = new (instance(provider).Adapter)('Client');
+    if (!adapter) {
+      if (isConstructable(instance(provider).Adapter)) {
+        adapter = new (instance(provider).Adapter)('Client');
+      } else {
+        adapter = instance(provider).Adapter('Client');
+      }
+    }
     return adapter;
   }
 

--- a/test/helpers/initialize_adapter.test.js
+++ b/test/helpers/initialize_adapter.test.js
@@ -4,8 +4,8 @@ const initializeAdapter = require('../../lib/helpers/initialize_adapter');
 
 describe('initializeAdapter helper', () => {
   it('throws when adapter is not a constructor or not a function', () => {
-    expect(initializeAdapter.bind(undefined, {})).to.throw('Expected "adapter" to be a constructor or not async function, provide a valid adapter in Provider config.');
-    expect(initializeAdapter.bind(undefined, async () => {})).to.throw('Expected "adapter" to be a constructor or not async function, provide a valid adapter in Provider config.');
+    expect(initializeAdapter.bind(undefined, {})).to.throw('Expected "adapter" to be a constructor or a factory function, provide a valid adapter in Provider config.');
+    expect(initializeAdapter.bind(undefined, async () => {})).to.throw('Expected "adapter" to be a constructor or a factory function, provide a valid adapter in Provider config.');
   });
 
   it('should be success if argument is static method of class', () => {

--- a/test/helpers/initialize_adapter.test.js
+++ b/test/helpers/initialize_adapter.test.js
@@ -3,7 +3,20 @@ const { expect } = require('chai');
 const initializeAdapter = require('../../lib/helpers/initialize_adapter');
 
 describe('initializeAdapter helper', () => {
-  it('throws when adapter is not a constructor', () => {
-    expect(initializeAdapter.bind(undefined, {})).to.throw('Expected "adapter" to be a constructor, provide a valid adapter in Provider config.');
+  it('throws when adapter is not a constructor or not a function', () => {
+    expect(initializeAdapter.bind(undefined, {})).to.throw('Expected "adapter" to be a constructor or not async function, provide a valid adapter in Provider config.');
+    expect(initializeAdapter.bind(undefined, async () => {})).to.throw('Expected "adapter" to be a constructor or not async function, provide a valid adapter in Provider config.');
+  });
+
+  it('should be success if argument is static method of class', () => {
+    expect(
+      initializeAdapter.bind(undefined, (class { static method() {} }).method),
+    ).to.be.not.throw;
+  });
+
+  it('should be success if argument is arrow function', () => {
+    expect(
+      initializeAdapter.bind(undefined, () => {}).method,
+    ).to.be.not.throw;
   });
 });

--- a/test/helpers/type_validators.test.js
+++ b/test/helpers/type_validators.test.js
@@ -1,0 +1,19 @@
+/* eslint-disable prefer-arrow-callback */
+const { expect } = require('chai');
+
+const { isConstructable } = require('../../lib/helpers/type_validators');
+
+describe('type validators helper', () => {
+  it('should be falsy when argument is null', () => {
+    expect(isConstructable(null)).to.be.false;
+  });
+
+  it('should be falsy when argument is arrow function', () => {
+    expect(isConstructable(() => {})).to.be.false;
+  });
+
+  it('should be successfull executed if argument is constructable', () => {
+    expect(isConstructable(class {})).to.be.true;
+    expect(isConstructable(function () {})).to.be.true;
+  });
+});

--- a/test/provider/provider_instance.test.js
+++ b/test/provider/provider_instance.test.js
@@ -106,6 +106,9 @@ describe('provider instance', () => {
       await assert.rejects(provider.AccessToken.find('tokenValue'), {
         message: 'used this adapter',
       });
+      await assert.rejects(provider.Client.find('clientId'), {
+        message: 'used this adapter',
+      });
     });
 
     it('can be a class static function', async () => {
@@ -125,6 +128,9 @@ describe('provider instance', () => {
       await assert.rejects(provider.AccessToken.find('tokenValue'), {
         message: 'used this adapter',
       });
+      await assert.rejects(provider.Client.find('clientId'), {
+        message: 'used this adapter',
+      });
     });
 
     it('can be an arrow function', async () => {
@@ -136,6 +142,9 @@ describe('provider instance', () => {
         }),
       });
       await assert.rejects(provider.AccessToken.find('tokenValue'), {
+        message: 'used this adapter',
+      });
+      await assert.rejects(provider.Client.find('clientId'), {
         message: 'used this adapter',
       });
     });

--- a/test/provider/provider_instance.test.js
+++ b/test/provider/provider_instance.test.js
@@ -1,3 +1,7 @@
+/* eslint-disable max-classes-per-file */
+
+const { strict: assert } = require('assert');
+
 const { expect } = require('chai');
 const sinon = require('sinon');
 
@@ -84,6 +88,56 @@ describe('provider instance', () => {
     it('passes the options', () => {
       const provider = new Provider('http://localhost');
       expect(provider.urlFor('resume', { uid: 'foo' })).to.equal('http://localhost/auth/foo');
+    });
+  });
+
+  describe('adapters', () => {
+    const error = new Error('used this adapter');
+
+    it('can be a class', async () => {
+      const provider = new Provider('https://op.example.com', {
+        adapter: class {
+          // eslint-disable-next-line
+          async find() {
+            throw error;
+          }
+        },
+      });
+      await assert.rejects(provider.AccessToken.find('tokenValue'), {
+        message: 'used this adapter',
+      });
+    });
+
+    it('can be a class static function', async () => {
+      const provider = new Provider('https://op.example.com', {
+        adapter: (class {
+          // eslint-disable-next-line
+          static factory() {
+            // eslint-disable-next-line
+            return {
+              async find() {
+                throw error;
+              },
+            };
+          }
+        }).factory,
+      });
+      await assert.rejects(provider.AccessToken.find('tokenValue'), {
+        message: 'used this adapter',
+      });
+    });
+
+    it('can be an arrow function', async () => {
+      const provider = new Provider('https://op.example.com', {
+        adapter: () => ({
+          async find() {
+            throw error;
+          },
+        }),
+      });
+      await assert.rejects(provider.AccessToken.find('tokenValue'), {
+        message: 'used this adapter',
+      });
     });
   });
 });


### PR DESCRIPTION
Hi!
Now when implementing the "AdapterFactory" type from the package https://www.npmjs.com/package/@types/oidc-provider
a situation can happen where the types are correct, but at runtime we get an error.

I found a mention of this problem here https://github.com/panva/node-oidc-provider/pull/776#issuecomment-714742339

With this PR I add the ability to use arrow-functions and class methods as a factory and at the same time fix the non-obvious behavior when writing code in typescript 