### PR TITLE
Redirect uri domain matching

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1360,6 +1360,7 @@ _**default value**_:
 {
   enabled: false,
   requirePushedAuthorizationRequests: false
+  allowDynamicRedirectUris: false
 }
 ```
 
@@ -1368,7 +1369,11 @@ _**default value**_:
 
 #### requirePushedAuthorizationRequests
 
-Makes the use of PAR required for all authorization requests as an OP policy.  
+Makes the use of PAR required for all authorization requests as an OP policy.
+
+#### allowDynamicRedirectUris
+
+Allow dynamic paths in redirect URIs for PAR. Domain name must still match.  
 
 
 _**default value**_:

--- a/lib/actions/authorization/check_redirect_uri.js
+++ b/lib/actions/authorization/check_redirect_uri.js
@@ -1,12 +1,31 @@
 const { InvalidRedirectUri } = require('../../helpers/errors');
+const instance = require('../../helpers/weak_cache');
+
+const PAR = 'pushed_authorization_request';
+const AUTH = 'authorization';
 
 /*
  * Checks that provided redirect_uri is allowed in the client configuration
  *
+ * If pushed authorization requests enabled with dynamic redirect URIs,
+ * checks redirect URI has same domain as registered URI
+ *
  * @throws: invalid_redirect_uri
  */
 module.exports = function checkRedirectUri(ctx, next) {
-  if (!ctx.oidc.client.redirectUriAllowed(ctx.oidc.params.redirect_uri)) {
+  const {
+    pushedAuthorizationRequests: {
+      enabled, allowDynamicRedirectUris,
+    },
+  } = instance(ctx.oidc.provider).configuration('features');
+
+  const isPAR = ctx.oidc.route === PAR
+    || (ctx.oidc.route === AUTH && ctx.oidc.entities.PushedAuthorizationRequest);
+
+  const isDomainRedirectAllowed = enabled && allowDynamicRedirectUris
+    && isPAR;
+
+  if (!ctx.oidc.client.redirectUriAllowed(ctx.oidc.params.redirect_uri, isDomainRedirectAllowed)) {
     throw new InvalidRedirectUri();
   } else {
     ctx.oidc.redirectUriCheckPerformed = true;

--- a/lib/actions/discovery.js
+++ b/lib/actions/discovery.js
@@ -35,6 +35,7 @@ module.exports = function discovery(ctx, next) {
   if (pushedAuthorizationRequests.enabled) {
     ctx.body.pushed_authorization_request_endpoint = ctx.oidc.urlFor('pushed_authorization_request');
     ctx.body.require_pushed_authorization_requests = pushedAuthorizationRequests.requirePushedAuthorizationRequests ? true : undefined;
+    ctx.body.allow_dynamic_redirect_uris = pushedAuthorizationRequests.allowDynamicRedirectUris ? true : undefined;
   }
 
   if (requestObjects.request || requestObjects.requestUri || pushedAuthorizationRequests.enabled) {

--- a/lib/consts/client_attributes.js
+++ b/lib/consts/client_attributes.js
@@ -38,6 +38,7 @@ const DEFAULT = {
   post_logout_redirect_uris: [],
   require_auth_time: false,
   require_pushed_authorization_requests: false,
+  allow_dynamic_redirect_uris: false,
   require_signed_request_object: false,
   response_types: ['code'],
   subject_type: 'public',
@@ -57,6 +58,7 @@ const BOOL = [
   'backchannel_user_code_parameter',
   'require_auth_time',
   'require_pushed_authorization_requests',
+  'allow_dynamic_redirect_uris',
   'require_signed_request_object',
   'tls_client_certificate_bound_access_tokens',
 ];

--- a/lib/helpers/client_schema.js
+++ b/lib/helpers/client_schema.js
@@ -129,6 +129,7 @@ module.exports = function getSchema(provider) {
 
   if (features.pushedAuthorizationRequests.enabled) {
     RECOGNIZED_METADATA.push('require_pushed_authorization_requests');
+    RECOGNIZED_METADATA.push('allow_dynamic_redirect_uris');
   }
 
   if (features.encryption.enabled) {
@@ -643,8 +644,13 @@ module.exports = function getSchema(provider) {
 
     parPolicy() {
       const par = configuration.features.pushedAuthorizationRequests;
-      if (par.enabled && par.requirePushedAuthorizationRequests) {
-        this.require_pushed_authorization_requests = true;
+      if (par.enabled) {
+        if (par.requirePushedAuthorizationRequests) {
+          this.require_pushed_authorization_requests = true;
+        }
+        if (par.allowDynamicRedirectUris) {
+          this.allow_dynamic_redirect_uris = true;
+        }
       }
     }
 

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -127,11 +127,10 @@ function deriveEncryptionKey(secret, length) {
   return base64url.encodeBuffer(derived);
 }
 
-function matchDomain(parsedUri, registeredUris) {
-  return !!registeredUris.find((registeredUri) => {
-    const removedTrailingSlash = registeredUri.replace(/\/$/, ''); // strips trailing slash from registered URI
-    return parsedUri.origin === removedTrailingSlash;
-  });
+function matchDomain(parsedUri, parsedRegisteredUris) {
+  return !!parsedRegisteredUris.find(
+    (parsedRegisteredUri) => parsedUri.origin === parsedRegisteredUri.origin,
+  );
 }
 
 module.exports = function getClient(provider) {
@@ -506,8 +505,10 @@ module.exports = function getClient(provider) {
         return false;
       }
 
+      const parsedRegisteredUris = this.redirectUris.map((uri) => new URL(uri));
+
       const match = allowDomainMatch
-        ? matchDomain(parsed, this.redirectUris)
+        ? matchDomain(parsed, parsedRegisteredUris)
         : this.redirectUris.includes(value);
 
       if (

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -127,6 +127,13 @@ function deriveEncryptionKey(secret, length) {
   return base64url.encodeBuffer(derived);
 }
 
+function matchDomain(parsedUri, registeredUris) {
+  return !!registeredUris.find((registeredUri) => {
+    const removedTrailingSlash = registeredUri.replace(/\/$/, ''); // strips trailing slash from registered URI
+    return parsedUri.origin === removedTrailingSlash;
+  });
+}
+
 module.exports = function getClient(provider) {
   const staticCache = new Map();
   const dynamicCache = new QuickLRU({ maxSize: 100 });
@@ -491,7 +498,7 @@ module.exports = function getClient(provider) {
       return this.grantTypes.includes(type);
     }
 
-    redirectUriAllowed(value) {
+    redirectUriAllowed(value, allowDomainMatch) {
       let parsed;
       try {
         parsed = new URL(value);
@@ -499,7 +506,10 @@ module.exports = function getClient(provider) {
         return false;
       }
 
-      const match = this.redirectUris.includes(value);
+      const match = allowDomainMatch
+        ? matchDomain(parsed, this.redirectUris)
+        : this.redirectUris.includes(value);
+
       if (
         match
         || this.applicationType !== 'native'

--- a/test/configuration/client_metadata.test.js
+++ b/test/configuration/client_metadata.test.js
@@ -993,6 +993,28 @@ describe('Client metadata validation', () => {
         clientDefaults: { require_pushed_authorization_requests: true },
       });
     });
+
+    context('allow_dynamic_redirect_uris', function () {
+      const configuration = (value = false) => ({
+        features: {
+          pushedAuthorizationRequests: {
+            enabled: true,
+            allowDynamicRedirectUris: value,
+          },
+        },
+      });
+      mustBeBoolean(this.title, undefined, configuration());
+      mustBeBoolean(this.title, undefined, configuration(true));
+      defaultsTo(this.title, false, undefined, configuration());
+      defaultsTo(this.title, true, undefined, configuration(true));
+      defaultsTo(this.title, true, {
+        allow_dynamic_redirect_uris: false,
+      }, configuration(true));
+      defaultsTo(this.title, true, undefined, {
+        ...configuration(),
+        clientDefaults: { allow_dynamic_redirect_uris: true },
+      });
+    });
   });
 
   describe('features.ciba', () => {

--- a/test/pushed_authorization_requests/pushed_authorization_requests.config.js
+++ b/test/pushed_authorization_requests/pushed_authorization_requests.config.js
@@ -7,6 +7,7 @@ config.enabledJWA.requestObjectSigningAlgValues = config.enabledJWA.requestObjec
 
 merge(config.features, {
   pushedAuthorizationRequests: {
+    allowDynamicRedirectUris: false,
     requirePushedAuthorizationRequests: false,
     enabled: true,
   },
@@ -32,5 +33,14 @@ module.exports = {
     client_secret: 'secret',
     request_object_signing_alg: 'HS256',
     redirect_uris: ['https://rp.example.com/cb'],
-  }],
+  }, {
+    client_id: 'client-allow-par-dynamic-redirect',
+    client_secret: 'secret',
+    redirect_uris: ['https://rp.example.com'],
+  }, {
+    client_id: 'client-redirect-trailing-slash',
+    client_secret: 'secret',
+    redirect_uris: ['https://rp.example.com/'],
+  },
+  ],
 };

--- a/test/pushed_authorization_requests/pushed_authorization_requests.config.js
+++ b/test/pushed_authorization_requests/pushed_authorization_requests.config.js
@@ -41,6 +41,10 @@ module.exports = {
     client_id: 'client-redirect-trailing-slash',
     client_secret: 'secret',
     redirect_uris: ['https://rp.example.com/'],
+  }, {
+    client_id: 'client-redirect-with-path',
+    client_secret: 'secret',
+    redirect_uris: ['https://rp.example.com/test'],
   },
   ],
 };

--- a/test/pushed_authorization_requests/pushed_authorization_requests.test.js
+++ b/test/pushed_authorization_requests/pushed_authorization_requests.test.js
@@ -531,7 +531,7 @@ describe('Pushed Request Object', () => {
     });
   });
 
-  ['client-allow-par-dynamic-redirect', 'client-redirect-trailing-slash'].forEach((clientId) => {
+  ['client-allow-par-dynamic-redirect', 'client-redirect-trailing-slash', 'client-redirect-with-path'].forEach((clientId) => {
     const trailingSlash = clientId === 'client-redirect-trailing-slash' ? 'with' : 'without';
     describe(`when allow_dynamic_redirect_uris=true ${trailingSlash} trailing slash`, () => {
       before(function () {


### PR DESCRIPTION
Before the redirect URI domains were being compared by parsing the provided redirect URI, grabbing the `URL.origin` and comparing that to the whole redirect_uri string registered on client. Now it is also parsing the registered redirect_uri to also grab the URL.origin.

This change makes the matching of URIs a little bit more resilient to cases where a path has been given on the registered URL. So now oidc-provider will compare the origin e.g. https://localhost:3000 regardless of if there is a path or not. So if a redirect `https://localhost/some/path` is registered on the client, that domain will be considered as authorised so a different path could be provided e.g. `https://localhost/other/path`.

This also paves the way in the future for potential