### PR TITLE
Add sub claim in client credentials grant

### DIFF
--- a/lib/models/client_credentials.js
+++ b/lib/models/client_credentials.js
@@ -14,6 +14,7 @@ module.exports = (provider) => class ClientCredentials extends apply([
       'aud',
       'extra',
       'scope',
+      'accountId'
     ];
   }
 };


### PR DESCRIPTION
Hi All,

We have a requirement to add 'sub' claim in the jwt token for client credentials grant type.
The value of the 'sub' claim will be the clientId.

The specification mentions below details for client credentials grant:
"For client authentication, the subject MUST be the "client_id" of the OAuth client."

The specification link for the same is as below:
https://datatracker.ietf.org/doc/html/rfc7523#section-3

Could you please review and merge this MR. Please let us know if any review comments.

Thanks & Regards,
Vaibhav Medhekar