### PR TITLE
fix: skip_consent recipe causing "TypeError: Cannot read property 'ex…

### DIFF
--- a/recipes/skip_consent.md
+++ b/recipes/skip_consent.md
@@ -25,8 +25,11 @@ const oidcConfiguration = {
       // this aligns the Grant ttl with that of the current session
       // if the same Grant is used for multiple sessions, or is set
       // to never expire, you probably do not want this in your code
-      if (ctx.oidc.account && grant.exp < ctx.oidc.session.exp) {
-        grant.exp = ctx.oidc.session.exp;
+      if (ctx.oidc.account) {
+        // Change sessionTtl to match the value set for oidc's "Session.ttl" in your configuration
+        const sessionTtl = 14 * 24 * 60 * 60; // 14 days in seconds, the default session ttl
+        const epochCurrentTime = Math.floor(Date.now() / 1000);
+        grant.exp = epochCurrentTime + sessionTtl;
 
         await grant.save();
       }


### PR DESCRIPTION
…p' of undefined"

At the end of the request processing, session.exp is set to 'currentTime + sessionTtl' in sessionHandler. This result in grant.exp to be set to previous session.exp, not future session.exp.

This end in various bugs :

1. `TypeError: Cannot read property 'exp' of undefined` (line 28) as grantId is still referenced in Session but unreachable because it has expired
2. grant.exp might be equal to ctx.oidc.session.exp but as ctx.oidc.session.exp will be updated later on the test `grant.exp < ctx.oidc.session.exp` is irrelevant.

To fix this, I propose to remove the irrelevant test and to set grant.exp to 'currentTime + sessionTtl'