### PR TITLE
Remove Assertion of Request/Response for getInteraction()

### DIFF
--- a/lib/provider.js
+++ b/lib/provider.js
@@ -40,21 +40,7 @@ const models = require('./models');
 const ssHandler = require('./helpers/samesite_handler');
 const get = require('./helpers/_/get');
 
-function assertReqRes(req, res) {
-  assert(
-    req instanceof IncomingMessage || req instanceof Http2ServerRequest,
-    'first argument must be the request (http.IncomingMessage || http2.Http2ServerRequest), for express req, for koa ctx.req',
-  );
-  if (arguments.length === 2) {
-    assert(
-      res instanceof ServerResponse || res instanceof Http2ServerResponse,
-      'second argument must be the response (http.ServerResponse || http2.Http2ServerResponse), for express res, for koa ctx.res',
-    );
-  }
-}
-
 async function getInteraction(req, res) {
-  assertReqRes.apply(undefined, arguments); // eslint-disable-line prefer-spread, prefer-rest-params
   const ctx = this.app.createContext(req, res);
   const id = ssHandler.get(
     ctx.cookies,


### PR DESCRIPTION
Running assertions every request reduces performance and prevents requests/responses that match the shape required by the Provider (but not matching the specific classes) fail.

I encountered this issue whilst attempting to get oidc-provider to work with Fastify & https://github.com/fastify/aws-lambda-fastify on Lambda.

aws-lambda-fastify creates a request-like object it passes into Fastify, but this doesn't match the `instanceof` assertions in `getInteraction()`.

Discovering if the `oidc-provider` integration works with a particular set of requests or not should only be done once, during development and not every request.