### PR TITLE
perf: replace native asserts

### DIFF
--- a/lib/actions/authorization/check_client.js
+++ b/lib/actions/authorization/check_client.js
@@ -1,5 +1,3 @@
-const { strict: assert } = require('assert');
-
 const {
   InvalidClient, InvalidRequestObject,
 } = require('../../helpers/errors');
@@ -52,7 +50,9 @@ module.exports = async function checkClient(ctx, next) {
     let clientId;
 
     try {
-      assert(parts.length === 3 || parts.length === 5);
+      if (parts.length !== 3 && parts.length !== 5) {
+        throw new Error();
+      }
       parts.forEach((part, i, { length }) => {
         if (length === 3 && i === 1) { // JWT Payload
           decoded = JSON.parse(base64url.decodeToBuffer(part));

--- a/lib/actions/authorization/fetch_request_uri.js
+++ b/lib/actions/authorization/fetch_request_uri.js
@@ -1,5 +1,4 @@
 const { URL } = require('url');
-const { strict: assert } = require('assert');
 
 const { InvalidRequestUri } = require('../../helpers/errors');
 const instance = require('../../helpers/weak_cache');
@@ -32,7 +31,7 @@ module.exports = async function fetchRequestUri(ctx, next) {
     let protocol;
     try {
       ({ protocol } = new URL(params.request_uri));
-      assert(allowedSchemes.has(protocol));
+      if (!allowedSchemes.has(protocol)) throw new Error();
     } catch (err) {
       throw new InvalidRequestUri('invalid request_uri scheme');
     }
@@ -63,7 +62,7 @@ module.exports = async function fetchRequestUri(ctx, next) {
         const cache = instance(ctx.oidc.provider).requestUriCache;
         params.request = await cache.resolve(params.request_uri);
       }
-      assert(params.request);
+      if (!params.request) throw new Error();
       params.request_uri = undefined;
     } catch (err) {
       throw new InvalidRequestUri('could not load or parse request_uri', err.message);

--- a/lib/helpers/claims.js
+++ b/lib/helpers/claims.js
@@ -1,5 +1,3 @@
-const { strict: assert } = require('assert');
-
 const instance = require('./weak_cache');
 const pick = require('./_/pick');
 const merge = require('./_/merge');
@@ -12,11 +10,12 @@ module.exports = function getClaims(provider) {
 
   return class Claims {
     constructor(available, { ctx, client = ctx ? ctx.oidc.client : undefined }) {
-      assert.equal(
-        typeof available, 'object',
-        'expected claims to be an object, are you sure claims() method resolves with or returns one?',
-      );
-      assert(client instanceof provider.Client, 'second argument must be a Client instance');
+      if (!isPlainObject(available)) {
+        throw new TypeError('expected claims to be an object, are you sure claims() method resolves with or returns one?');
+      }
+      if (!(client instanceof provider.Client)) {
+        throw new TypeError('second argument must be a Client instance');
+      }
       this.available = available;
       this.client = client;
       this.ctx = ctx;
@@ -24,7 +23,9 @@ module.exports = function getClaims(provider) {
     }
 
     scope(value = '') {
-      assert(!Object.keys(this.filter).length, 'scope cannot be assigned after mask has been set');
+      if (Object.keys(this.filter).length) {
+        throw new Error('scope cannot be assigned after mask has been set');
+      }
       value.split(' ').forEach((scope) => {
         this.mask(claimConfig[scope]);
       });

--- a/lib/helpers/constant_equals.js
+++ b/lib/helpers/constant_equals.js
@@ -1,4 +1,3 @@
-const { strict: assert } = require('assert');
 const { timingSafeEqual } = require('crypto');
 
 function paddedBuffer(string, length) {
@@ -8,9 +7,12 @@ function paddedBuffer(string, length) {
 }
 
 function constantEquals(a, b, minComp = 0) {
-  assert(Number.isSafeInteger(minComp), 'minComp must be an Integer');
-  assert.equal(typeof a, 'string', 'arguments must be strings');
-  assert.equal(typeof b, 'string', 'arguments must be strings');
+  if (!Number.isSafeInteger(minComp)) {
+    throw new TypeError('minComp must be an Integer');
+  }
+  if (typeof a !== 'string' || typeof b !== 'string') {
+    throw new TypeError('arguments must be strings');
+  }
   const length = Math.max(a.length, b.length, minComp);
   return timingSafeEqual(paddedBuffer(a, length), paddedBuffer(b, length));
 }

--- a/lib/models/base_model.js
+++ b/lib/models/base_model.js
@@ -94,9 +94,11 @@ module.exports = function getBaseModel(provider) {
       }
 
       const stored = await this.adapter.find(value);
+      if (!stored) {
+        return undefined;
+      }
 
       try {
-        assert(stored);
         const payload = await this.verify(stored, { ignoreExpiration });
 
         return this.instantiate(payload);

--- a/lib/models/formats/dynamic.js
+++ b/lib/models/formats/dynamic.js
@@ -1,5 +1,3 @@
-const { strict: assert } = require('assert');
-
 const instance = require('../../helpers/weak_cache');
 const ctxRef = require('../ctx_ref');
 
@@ -7,13 +5,17 @@ module.exports = (provider, formats) => ({
   generateTokenId(...args) {
     const resolver = instance(provider).dynamic[this.constructor.name];
     const format = resolver(ctxRef.get(this), this);
-    assert(formats[format] && format !== 'dynamic', 'invalid format resolved');
+    if (!formats[format] || format === 'dynamic') {
+      throw new Error('invalid format resolved');
+    }
     this.format = format;
     return formats[format].generateTokenId.apply(this, args);
   },
   async getValueAndPayload(...args) {
     const { format } = this;
-    assert(formats[format] && format !== 'dynamic', 'invalid format resolved');
+    if (!formats[format] || format === 'dynamic') {
+      throw new Error('invalid format resolved');
+    }
     return formats[format].getValueAndPayload.apply(this, args);
   },
 });

--- a/lib/models/id_token.js
+++ b/lib/models/id_token.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-unused-expressions */
-const { strict: assert } = require('assert');
 const { format } = require('util');
 
 const { generate: tokenHash } = require('oidc-token-hash');
 
+const isPlainObject = require('../helpers/_/is_plain_object');
 const merge = require('../helpers/_/merge');
 const epochTime = require('../helpers/epoch_time');
 const JWT = require('../helpers/jwt');
@@ -30,10 +30,9 @@ const messages = {
 module.exports = function getIdToken(provider) {
   return class IdToken {
     constructor(available, { ctx, client = ctx ? ctx.oidc.client : undefined }) {
-      assert.equal(
-        typeof available, 'object',
-        'expected claims to be an object, are you sure claims() method resolves with or returns one?',
-      );
+      if (!isPlainObject(available)) {
+        throw new TypeError('expected claims to be an object, are you sure claims() method resolves with or returns one?');
+      }
       this.extra = {};
       this.available = available;
       this.client = client;

--- a/lib/models/mixins/is_session_bound.js
+++ b/lib/models/mixins/is_session_bound.js
@@ -1,5 +1,3 @@
-const { strict: assert } = require('assert');
-
 module.exports = (provider) => (superclass) => class extends superclass {
   static get IN_PAYLOAD() {
     return [
@@ -19,15 +17,19 @@ module.exports = (provider) => (superclass) => class extends superclass {
     }
 
     const session = await provider.Session.findByUid(token.sessionUid);
-    try {
-      assert(session, 'its related session was not found');
 
-      // session is still for the same account
-      assert.equal(token.accountId, session.accountId, 'token and session principal are now different');
+    // related session was not found
+    if (!session) {
+      return undefined;
+    }
 
-      // session is still the same grantId
-      assert.equal(token.grantId, session.grantIdFor(token.clientId), 'client\'s token and session grantId are now different');
-    } catch (err) {
+    // token and session principal are now different
+    if (token.accountId !== session.accountId) {
+      return undefined;
+    }
+
+    // token and session grantId are now different
+    if (token.grantId !== session.grantIdFor(token.clientId)) {
       return undefined;
     }
 

--- a/lib/models/session.js
+++ b/lib/models/session.js
@@ -1,7 +1,5 @@
 /* eslint-disable prefer-rest-params */
 
-const { strict: assert } = require('assert');
-
 const nanoid = require('../helpers/nanoid');
 const epochTime = require('../helpers/epoch_time');
 const instance = require('../helpers/weak_cache');
@@ -43,8 +41,10 @@ module.exports = (provider) => class Session extends hasFormat(provider, 'Sessio
 
   static async findByUid(uid) {
     const stored = await this.adapter.findByUid(uid);
+    if (!stored) {
+      return undefined;
+    }
     try {
-      assert(stored);
       const payload = await this.verify(stored);
       return this.instantiate(payload);
     } catch (err) {


### PR DESCRIPTION
Node's native `assert()` can be very heavy, especially in a large project with a source map as it creates a full stack trace on failure.

Closes #1204