### PR TITLE
fix: add code_verifier param to authorization_code grant

### DIFF
--- a/lib/actions/grants/authorization_code.js
+++ b/lib/actions/grants/authorization_code.js
@@ -218,4 +218,4 @@ module.exports.handler = async function authorizationCodeHandler(ctx, next) {
   await next();
 };
 
-module.exports.parameters = new Set(['code', 'redirect_uri']);
+module.exports.parameters = new Set(['code', 'code_verifier', 'redirect_uri']);


### PR DESCRIPTION
The function referenced the param, but it was not available unless explicitly allowed.

I think this is right but I could be missing something. First time contribution.

Seems to apply to both v7 and v6.

Thanks!
Andrew