### PR TITLE
feat: rpInitiatedLogout.onConfirmed

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -440,6 +440,7 @@ location / {
   - [requestObjects](#featuresrequestobjects)
   - [resourceIndicators ❗](#featuresresourceindicators)
   - [revocation](#featuresrevocation)
+  - [rpInitiatedLogout](#featuresrpinitiatedlogout)
   - [userinfo](#featuresuserinfo)
 - [acrValues](#acrvalues)
 - [allowOmittingSingleRegisteredRedirectUri](#allowomittingsingleregisteredredirecturi)
@@ -1866,6 +1867,7 @@ _**default value**_:
   enabled: true,
   logoutSource: [AsyncFunction: logoutSource], // see expanded details below
   postLogoutSuccessSource: [AsyncFunction: postLogoutSuccessSource] // see expanded details below
+  onConfirmed: [AsyncFunction: onConfirmed] // see expanded details below
 }
 ```
 
@@ -1925,6 +1927,21 @@ async function postLogoutSuccessSource(ctx) {
       </div>
     </body>
     </html>`;
+}
+```
+
+#### onConfirmed
+
+Callback executed after Logout is confirmed by user. Receives request `ctx` to for example clear login cookies not set by oidc-provider.
+
+
+_**default value**_: `undefined`
+
+_**example**_:
+```js
+async function onConfirmed(ctx) {
+  // Clear cookie
+  ctx.cookies.set('cookie-not-managed-by-oidc-provider')
 }
 ```
 

--- a/lib/actions/end_session.js
+++ b/lib/actions/end_session.js
@@ -184,6 +184,11 @@ module.exports = {
           null,
           opts,
         );
+
+        const onLogoutConfirmed = instance(ctx.oidc.provider).configuration('features.rpInitiatedLogout.onConfirmed')
+        if (typeof onLogoutConfirmed === 'function') {
+          await onLogoutConfirmed(ctx)
+        }
       } else if (state.clientId) {
         const grantId = session.grantIdFor(state.clientId);
         if (grantId && !session.authorizationFor(state.clientId).persistsLogout) {

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -1305,6 +1305,14 @@ function getDefaults() {
          *   prompt for the User-Agent.
          */
         logoutSource,
+
+        /*
+         * features.rpInitiatedLogout.onConfirmed
+         *
+         * description: callback executed when RP-Initiated Logout is confirmed by user. Receives
+         *   request ctx to for example clear session cookies not set by oidc-provider.
+         */
+        onConfirmed: undefined,
       },
 
       /*


### PR DESCRIPTION
This PR adds an `onConfirmed` property for the `rpInitiatedLogout` provider configuration.

`rpInitiatedLogout.onConfirmed` allows library users to add functionality once the RP-Initated logout is confirmed (e.g. to clear login-related cookies that were not set by oidc-provider itself).

I did notice an `end_session.success` event [gets emitted](https://github.com/ubipo/node-oidc-provider/blob/85fb9d768acd4bdc9fa3f583261508eadcd4563a/lib/actions/end_session.js#L216) in the `endSession` handler, but that doesn't allow for async handlers.