### PR TITLE
Custom confirmation parameter - Device Flow

### DIFF
--- a/lib/actions/code_verification.js
+++ b/lib/actions/code_verification.js
@@ -127,8 +127,13 @@ export const post = [
       const action = ctx.oidc.urlFor('code_verification');
       await userCodeConfirmSource(
         ctx,
-        formHtml.confirm(action, ctx.oidc.session.state.secret, userCode, useBooleanConfirmation,
-          confirmParamName),
+        formHtml.confirm(
+          action,
+          ctx.oidc.session.state.secret,
+          userCode,
+          useBooleanConfirmation,
+          confirmParamName,
+        ),
         client,
         code.deviceInfo,
         denormalize(normalized, mask),

--- a/lib/actions/code_verification.js
+++ b/lib/actions/code_verification.js
@@ -48,7 +48,20 @@ export const get = [
 export const post = [
   sessionMiddleware,
   parseBody,
-  paramsMiddleware.bind(undefined, new Set(['xsrf', 'user_code', 'confirm', 'abort'])),
+
+  async function codeVerificationParams(ctx, next) {
+    const { useBooleanConfirmation, confirmParamName } = instance(ctx.oidc.provider).configuration('features.deviceFlow');
+
+    const allowParamList = new Set(['xsrf', 'user_code']);
+
+    allowParamList.add(confirmParamName);
+    if (!useBooleanConfirmation) {
+      allowParamList.add('abort');
+    }
+
+    return paramsMiddleware(allowParamList, ctx, next);
+  },
+
   rejectDupes.bind(undefined, {}),
 
   async function codeVerificationCSRF(ctx, next) {
@@ -62,8 +75,13 @@ export const post = [
   },
 
   async function loadDeviceCodeByUserInput(ctx, next) {
-    const { userCodeConfirmSource, mask } = instance(ctx.oidc.provider).configuration('features.deviceFlow');
-    const { user_code: userCode, confirm, abort } = ctx.oidc.params;
+    const {
+      userCodeConfirmSource, mask, useBooleanConfirmation, confirmParamName,
+    } = instance(ctx.oidc.provider).configuration('features.deviceFlow');
+    const { user_code: userCode } = ctx.oidc.params;
+
+    const confirm = useBooleanConfirmation ? ctx.oidc.params[confirmParamName] === 'true' : ctx.oidc.params[confirmParamName];
+    const abort = useBooleanConfirmation ? ctx.oidc.params[confirmParamName] === 'false' : ctx.oidc.params.abort;
 
     if (!userCode) {
       throw new NoCodeError();
@@ -109,7 +127,8 @@ export const post = [
       const action = ctx.oidc.urlFor('code_verification');
       await userCodeConfirmSource(
         ctx,
-        formHtml.confirm(action, ctx.oidc.session.state.secret, userCode),
+        formHtml.confirm(action, ctx.oidc.session.state.secret, userCode, useBooleanConfirmation,
+          confirmParamName),
         client,
         code.deviceInfo,
         denormalize(normalized, mask),

--- a/lib/helpers/configuration.js
+++ b/lib/helpers/configuration.js
@@ -434,6 +434,10 @@ class Configuration {
       if (!/^[-* ]*$/.test(this.features.deviceFlow.mask)) {
         throw new TypeError('mask can only contain asterisk("*"), hyphen-minus("-") and space(" ") characters');
       }
+
+      if (this.features.deviceFlow.confirmParamName !== undefined && !/^[a-zA-Z0-9_]{1,20}$/.test(this.features.deviceFlow.confirmParamName)) {
+        throw new TypeError('confirmation parameter name needs to be 1 - 20 characters in length and use only a basic set of characters (matching the regex: ^[a-zA-Z0-9_]{1,20}$ )');
+      }
     }
   }
 

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -14,6 +14,7 @@ import nanoid from './nanoid.js';
 import { base as defaultPolicy } from './interaction_policy/index.js';
 import htmlSafe from './html_safe.js';
 import * as errors from './errors.js';
+import instance from './weak_cache.js';
 
 const randomFill = util.promisify(crypto.randomFill);
 
@@ -113,6 +114,9 @@ async function userCodeConfirmSource(ctx, form, client, deviceInfo, userCode) {
   const {
     clientId, clientName, clientUri, logoUri, policyUri, tosUri,
   } = ctx.oidc.client;
+
+  const { useBooleanConfirmation, confirmParamName } = instance(ctx.oidc.provider).configuration('features.deviceFlow');
+
   ctx.body = `<!DOCTYPE html>
     <head>
       <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -122,6 +126,12 @@ async function userCodeConfirmSource(ctx, form, client, deviceInfo, userCode) {
       <style>
         @import url(https://fonts.googleapis.com/css?family=Roboto:400,100);.help,h1,h1+p{text-align:center}h1,h1+p{font-weight:100}body{font-family:Roboto,sans-serif;margin-top:25px;margin-bottom:25px}.container{padding:0 40px 10px;width:274px;background-color:#f7f7f7;margin:0 auto 10px;border-radius:2px;box-shadow:0 2px 2px rgba(0,0,0,.3);overflow:hidden}h1{font-size:2.3em}button[autofocus]{width:100%;display:block;margin-bottom:10px;position:relative;font-size:14px;font-family:Arial,sans-serif;font-weight:700;height:36px;padding:0 8px;border:0;color:#fff;text-shadow:0 1px rgba(0,0,0,.1);background-color:#4d90fe;cursor:pointer}button[autofocus]:hover{border:0;text-shadow:0 1px rgba(0,0,0,.3);background-color:#357ae8}button[name=abort]{background:0 0!important;border:none;padding:0!important;font:inherit;cursor:pointer}a,button[name=abort]{text-decoration:none;color:#666;font-weight:400;display:inline-block;opacity:.6}.help{width:100%;font-size:12px}code{font-size:2em}
       </style>
+      <script type="text/javascript">
+        function onAbort() {
+            document.getElementsByTagName('input')["${confirmParamName}"].value = 'false';
+            document.getElementsByTagName('form')[0].submit();
+        }
+    </script>
     </head>
     <body>
       <div class="container">
@@ -137,7 +147,7 @@ async function userCodeConfirmSource(ctx, form, client, deviceInfo, userCode) {
         ${form}
         <button autofocus type="submit" form="op.deviceConfirmForm">Continue</button>
         <div class="help">
-          <button type="submit" form="op.deviceConfirmForm" value="yes" name="abort">[ Abort ]</button>
+          ${useBooleanConfirmation ? '<button type="button" onclick="onAbort()">[ Abort ]</button>' : '<button type="submit" form="op.deviceConfirmForm" value="yes" name="abort">[ Abort ]</button>'}
         </div>
       </div>
     </body>
@@ -1197,6 +1207,21 @@ function makeDefaults() {
         mask: '****-****',
 
         /*
+         * features.deviceFlow.useBooleanConfirmation
+         *
+         * description: Determines to use a boolean confirmation parameter, this affects the
+         *   lib end-user confirm screen.
+         */
+        useBooleanConfirmation: false,
+
+        /*
+         * features.deviceFlow.confirmParamName
+         *
+         * description: Name of the confirmation parameter.
+         */
+        confirmParamName: 'confirm',
+
+        /*
          * features.deviceFlow.deviceInfo
          *
          * description: Function used to extract details from the device authorization endpoint
@@ -1216,8 +1241,8 @@ function makeDefaults() {
         /*
          * features.deviceFlow.userCodeConfirmSource
          *
-         * description: HTML source rendered when device code feature renders an a confirmation prompt for
-         *   ther User-Agent.
+         * description: HTML source rendered when device code feature renders a confirmation prompt for
+         *   their User-Agent.
          */
         userCodeConfirmSource,
 

--- a/lib/helpers/user_code_form.js
+++ b/lib/helpers/user_code_form.js
@@ -10,10 +10,10 @@ export function input(action, csrfToken, code, charset) {
   </form>`;
 }
 
-export function confirm(action, csrfToken, code) {
+export function confirm(action, csrfToken, code, useBooleanConfirmation, confirmParamName) {
   return `<form id="op.deviceConfirmForm" method="post" action="${action}">
 <input type="hidden" name="xsrf" value="${csrfToken}"/>
 <input type="hidden" name="user_code" value="${htmlSafe(code)}"/>
-<input type="hidden" name="confirm" value="yes"/>
+${useBooleanConfirmation ? `<input type="hidden" name="${confirmParamName}" value="true"/>` : `<input type="hidden" name="${confirmParamName}" value="yes"/>`}
 </form>`;
 }

--- a/test/device_code/code_verification_endpoint.test.js
+++ b/test/device_code/code_verification_endpoint.test.js
@@ -9,454 +9,546 @@ const sinon = createSandbox();
 const { any } = sinon.match;
 const route = '/device';
 
-describe('GET code_verification endpoint', () => {
-  before(bootstrap(import.meta.url));
+[{
+  spec: 'default configuration',
+  options: {
+    confirmationPayload: {
+      confirm: 'yes',
+    },
+    abortionPayload: {
+      abort: 'yes',
+    },
+  },
+  expect: {
+    confirmInput: /<input type="hidden" name="confirm" value="yes"\/>/,
+    abortButton: /<button type="submit" form="op.deviceConfirmForm" value="yes" name="abort">/,
+  },
+}, {
+  spec: 'custom confirmation parameter name',
+  options: {
+    config: 'device_code_custom_confirmation',
+    confirmationPayload: {
+      approved: 'yes',
+    },
+    abortionPayload: {
+      abort: 'yes',
+    },
+  },
+  expect: {
+    confirmInput: /<input type="hidden" name="approved" value="yes"\/>/,
+    abortButton: /<button type="submit" form="op.deviceConfirmForm" value="yes" name="abort">/,
+  },
+}, {
+  spec: 'use boolean confirmation',
+  options: {
+    config: 'device_code_boolean_confirmation',
+    confirmationPayload: {
+      confirm: 'true',
+    },
+    abortionPayload: {
+      confirm: 'false',
+    },
+  },
+  expect: {
+    confirmInput: /<input type="hidden" name="confirm" value="true"\/>/,
+    abortButton: /<button type="button" onclick="onAbort\(\)">/,
+  },
+}].forEach((run) => {
+  describe(`GET code_verification endpoint - ${run.spec}`, () => {
+    before(bootstrap(import.meta.url, { config: run.options.config }));
 
-  describe('when accessed without user_code in query (verification_uri)', () => {
-    it('renders 200 OK end-user form with csrf', function () {
-      return this.agent.get(route)
-        .expect(200)
-        .expect('content-type', 'text/html; charset=utf-8')
-        .expect(() => {
-          const { state: { secret } } = this.getSession();
-          expect(secret).to.be.a('string');
-        })
-        .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`));
+    describe('when accessed without user_code in query (verification_uri)', () => {
+      it('renders 200 OK end-user form with csrf', function () {
+        return this.agent.get(route)
+          .expect(200)
+          .expect('content-type', 'text/html; charset=utf-8')
+          .expect(() => {
+            const { state: { secret } } = this.getSession();
+            expect(secret).to.be.a('string');
+          })
+          .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`));
+      });
+    });
+
+    describe('when accessed with user_code in query (verification_uri_complete)', () => {
+      it('renders 200 OK self-submitting form with csrf and the value from uri', function () {
+        let secret;
+
+        return this.agent.get(route)
+          .query({ user_code: '123-456-789' })
+          .expect(200)
+          .expect('content-type', 'text/html; charset=utf-8')
+          .expect(/document.addEventListener\('DOMContentLoaded', function \(\) { document.forms\[0\].submit\(\) }\);/)
+          .expect(({ text }) => {
+            ({ state: { secret } } = this.getSession());
+            expect(text).to.match(new RegExp(`input type="hidden" name="xsrf" value="${secret}"`));
+          })
+          .expect(new RegExp(`<form method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
+          .expect(/<input type="hidden" name="user_code" value="123-456-789"\/>/);
+      });
+
+      it('escapes the user_code values', function () {
+        return this.agent.get(route)
+          .query({ user_code: '&<>"\'123-456-789' })
+          .expect(200)
+          .expect('content-type', 'text/html; charset=utf-8')
+          .expect(/<input type="hidden" name="user_code" value="&amp;&lt;&gt;&quot;&#39;123-456-789"\/>/);
+      });
     });
   });
 
-  describe('when accessed with user_code in query (verification_uri_complete)', () => {
-    it('renders 200 OK self-submitting form with csrf and the value from uri', function () {
-      let secret;
+  describe(`POST code_verification endpoint w/o verification - ${run.spec}`, () => {
+    before(bootstrap(import.meta.url, { config: run.options.config }));
+    before(function () {
+      return this.login();
+    });
+    afterEach(() => timekeeper.reset());
 
-      return this.agent.get(route)
-        .query({ user_code: '123-456-789' })
-        .expect(200)
-        .expect('content-type', 'text/html; charset=utf-8')
-        .expect(/document.addEventListener\('DOMContentLoaded', function \(\) { document.forms\[0\].submit\(\) }\);/)
-        .expect(({ text }) => {
-          ({ state: { secret } } = this.getSession());
-          expect(text).to.match(new RegExp(`input type="hidden" name="xsrf" value="${secret}"`));
-        })
-        .expect(new RegExp(`<form method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
-        .expect(/<input type="hidden" name="user_code" value="123-456-789"\/>/);
+    const xsrf = 'foo';
+
+    beforeEach(function () {
+      this.getSession().state = { secret: xsrf };
     });
 
-    it('escapes the user_code values', function () {
-      return this.agent.get(route)
-        .query({ user_code: '&<>"\'123-456-789' })
-        .expect(200)
-        .expect('content-type', 'text/html; charset=utf-8')
-        .expect(/<input type="hidden" name="user_code" value="&amp;&lt;&gt;&quot;&#39;123-456-789"\/>/);
+    afterEach(function () {
+      this.provider.removeAllListeners('code_verification.error');
+      sinon.restore();
     });
-  });
-});
 
-describe('POST code_verification endpoint w/o verification', () => {
-  before(bootstrap(import.meta.url));
-  before(function () { return this.login(); });
-  afterEach(() => timekeeper.reset());
+    it('renders a confirmation page', async function () {
+      const spy = sinon.spy(i(this.provider)
+        .configuration('features.deviceFlow'), 'userCodeConfirmSource');
+      const deviceInfo = {
+        ip: '127.0.0.1',
+        ua: 'foo',
+      };
 
-  const xsrf = 'foo';
-
-  beforeEach(function () {
-    this.getSession().state = { secret: xsrf };
-  });
-
-  afterEach(function () {
-    this.provider.removeAllListeners('code_verification.error');
-    sinon.restore();
-  });
-
-  it('renders a confirmation page', async function () {
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeConfirmSource');
-    const deviceInfo = {
-      ip: '127.0.0.1',
-      ua: 'foo',
-    };
-
-    await new this.provider.DeviceCode({
-      clientId: 'client',
-      userCode: 'FOOOCODE',
-      deviceInfo,
-    }).save();
-
-    await this.agent.post(route)
-      .send({
-        xsrf,
-        user_code: 'FOOO-CODE',
-      })
-      .type('form')
-      .expect(200)
-      .expect(new RegExp(`<form id="op.deviceConfirmForm" method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`));
-
-    expect(spy.calledOnce).to.be.true;
-    sinon.assert.calledWithMatch(spy, any, any, sinon.match((client) => {
-      expect(client.clientId).to.equal('client');
-      return true;
-    }), deviceInfo, 'FOOO-CODE');
-  });
-
-  it('re-renders on no submitted code', async function () {
-    const errSpy = sinon.spy();
-    this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
-
-    await this.agent.post(route)
-      .send({ xsrf })
-      .type('form')
-      .expect(200)
-      .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
-      .expect(/<p class="red">The code you entered is incorrect\. Try again<\/p>/);
-
-    expect(spy.calledOnce).to.be.true;
-    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
-      expect(err.name).to.equal('NoCodeError');
-      return true;
-    }));
-
-    expect(errSpy).to.have.property('called', false);
-  });
-
-  it('re-renders on not found code', async function () {
-    const errSpy = sinon.spy();
-    this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
-
-    await this.agent.post(route)
-      .send({
-        xsrf,
-        user_code: 'FOO-NOT-FOUND',
-      })
-      .type('form')
-      .expect(200)
-      .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
-      .expect(/<p class="red">The code you entered is incorrect\. Try again<\/p>/);
-
-    expect(spy.calledOnce).to.be.true;
-    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
-      expect(err.name).to.equal('NotFoundError');
-      return true;
-    }));
-
-    expect(errSpy).to.have.property('called', false);
-  });
-
-  it('re-renders on found but expired code', async function () {
-    const errSpy = sinon.spy();
-    this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
-    await new this.provider.DeviceCode({
-      userCode: 'FOOEXPIRED',
-    }).save();
-
-    timekeeper.travel(Date.now() + (((10 * 60) + 10) * 1000));
-    await this.agent.post(route)
-      .send({
-        xsrf,
-        user_code: 'FOO-EXPIRED',
-      })
-      .type('form')
-      .expect(200)
-      .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
-      .expect(/<p class="red">The code you entered is incorrect\. Try again<\/p>/);
-
-    expect(spy.calledOnce).to.be.true;
-    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
-      expect(err.name).to.equal('ExpiredError');
-      return true;
-    }));
-
-    expect(errSpy).to.have.property('called', false);
-  });
-
-  it('re-renders on found but already user code', async function () {
-    const errSpy = sinon.spy();
-    this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
-    await new this.provider.DeviceCode({
-      userCode: 'FOOCONSUMED',
-      accountId: 'account',
-    }).save();
-
-    await this.agent.post(route)
-      .send({
-        xsrf,
-        user_code: 'FOO-CONSUMED',
-      })
-      .type('form')
-      .expect(200)
-      .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
-      .expect(/<p class="red">The code you entered is incorrect\. Try again<\/p>/);
-
-    expect(spy.calledOnce).to.be.true;
-    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
-      expect(err.name).to.equal('AlreadyUsedError');
-      return true;
-    }));
-
-    expect(errSpy).to.have.property('called', false);
-  });
-
-  it('re-renders on invalid client', async function () {
-    const errSpy = sinon.spy();
-    this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
-    await new this.provider.DeviceCode({
-      userCode: 'FOONOTFOUNDCLIENT',
-      clientId: 'client',
-    }).save();
-
-    sinon.stub(this.provider.Client, 'find').callsFake(async () => { });
-    await this.agent.post(route)
-      .send({
-        xsrf,
-        user_code: 'FOO-NOT-FOUND-CLIENT',
-      })
-      .type('form')
-      .expect(400)
-      .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
-      .expect(/<p class="red">There was an error processing your request<\/p>/);
-
-    expect(spy.calledOnce).to.be.true;
-    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
-      expect(err.name).to.equal('InvalidClient');
-      return true;
-    }));
-
-    expect(errSpy.calledOnce).to.be.true;
-  });
-
-  it('re-renders on !ctx.oidc.session.state', async function () {
-    const errSpy = sinon.spy();
-    this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
-    await new this.provider.DeviceCode({
-      userCode: 'FOOCSRF1',
-    }).save();
-
-    delete this.getSession().state;
-    await this.agent.post(route)
-      .send({
-        xsrf,
-        user_code: 'FOO-CSRF-1',
-      })
-      .type('form')
-      .expect(400)
-      .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
-      .expect(/<p class="red">There was an error processing your request<\/p>/);
-
-    expect(spy.calledOnce).to.be.true;
-    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
-      expect(err.name).to.equal('InvalidRequest');
-      expect(err.error_description).to.equal('could not find device form details');
-      return true;
-    }));
-
-    expect(errSpy.calledOnce).to.be.true;
-  });
-
-  it('re-renders on invalid csrf', async function () {
-    const errSpy = sinon.spy();
-    this.provider.once('code_verification.error', errSpy);
-    const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
-    await new this.provider.DeviceCode({
-      userCode: 'FOOCSRF2',
-    }).save();
-
-    await this.agent.post(route)
-      .send({
-        xsrf: 'invalid-csrf',
-        user_code: 'FOO-CSRF-FOO',
-      })
-      .type('form')
-      .expect(400)
-      .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
-      .expect(/<p class="red">There was an error processing your request<\/p>/);
-
-    expect(spy.calledOnce).to.be.true;
-    sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
-      expect(err.name).to.equal('InvalidRequest');
-      expect(err.error_description).to.equal('xsrf token invalid');
-      return true;
-    }));
-
-    expect(errSpy.calledOnce).to.be.true;
-  });
-});
-
-describe('POST code_verification endpoint w/ verification', () => {
-  before(bootstrap(import.meta.url));
-  before(function () {
-    return this.login({
-      scope: 'openid email',
-      rejectedClaims: ['email_verified'],
-    });
-  });
-  afterEach(timekeeper.reset);
-  afterEach(sinon.restore);
-
-  const xsrf = 'foo';
-
-  beforeEach(function () {
-    this.getSession().state = { secret: xsrf };
-  });
-
-  passInteractionChecks('native_client_prompt', 'op_claims_missing', () => {
-    it('accepts an abort command', async function () {
-      const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
-
-      let code = await new this.provider.DeviceCode({
+      await new this.provider.DeviceCode({
         clientId: 'client',
-        userCode: 'FOO',
-        params: {
-          scope: 'openid email',
-          client_id: 'client',
-          claims: JSON.stringify({ userinfo: { email: null } }),
-        },
+        userCode: 'FOOOCODE',
+        deviceInfo,
       }).save();
 
       await this.agent.post(route)
         .send({
           xsrf,
-          abort: 'yes',
-          user_code: 'FOO',
+          user_code: 'FOOO-CODE',
         })
         .type('form')
         .expect(200)
-        .expect(/The Sign-in request was interrupted/);
-
-      code = await this.provider.DeviceCode.find(code);
-
-      expect(code).not.to.have.property('accountId');
-      expect(code).to.have.property('error', 'access_denied');
-      expect(code).to.have.property('errorDescription', 'End-User aborted interaction');
+        .expect(new RegExp(`<form id="op.deviceConfirmForm" method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
+        .expect(run.expect.confirmInput)
+        .expect(run.expect.abortButton);
 
       expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, sinon.match((client) => {
+        expect(client.clientId)
+          .to
+          .equal('client');
+        return true;
+      }), deviceInfo, 'FOOO-CODE');
     });
 
-    it('renders a confirmation and assigns', async function () {
-      const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+    it('re-renders on no submitted code', async function () {
+      const errSpy = sinon.spy();
+      this.provider.once('code_verification.error', errSpy);
+      const spy = sinon.spy(i(this.provider)
+        .configuration('features.deviceFlow'), 'userCodeInputSource');
 
-      let code = await new this.provider.DeviceCode({
+      await this.agent.post(route)
+        .send({ xsrf })
+        .type('form')
+        .expect(200)
+        .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
+        .expect(/<p class="red">The code you entered is incorrect\. Try again<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name)
+          .to
+          .equal('NoCodeError');
+        return true;
+      }));
+
+      expect(errSpy)
+        .to
+        .have
+        .property('called', false);
+    });
+
+    it('re-renders on not found code', async function () {
+      const errSpy = sinon.spy();
+      this.provider.once('code_verification.error', errSpy);
+      const spy = sinon.spy(i(this.provider)
+        .configuration('features.deviceFlow'), 'userCodeInputSource');
+
+      await this.agent.post(route)
+        .send({
+          xsrf,
+          user_code: 'FOO-NOT-FOUND',
+        })
+        .type('form')
+        .expect(200)
+        .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
+        .expect(/<p class="red">The code you entered is incorrect\. Try again<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name)
+          .to
+          .equal('NotFoundError');
+        return true;
+      }));
+
+      expect(errSpy)
+        .to
+        .have
+        .property('called', false);
+    });
+
+    it('re-renders on found but expired code', async function () {
+      const errSpy = sinon.spy();
+      this.provider.once('code_verification.error', errSpy);
+      const spy = sinon.spy(i(this.provider)
+        .configuration('features.deviceFlow'), 'userCodeInputSource');
+      await new this.provider.DeviceCode({
+        userCode: 'FOOEXPIRED',
+      }).save();
+
+      timekeeper.travel(Date.now() + (((10 * 60) + 10) * 1000));
+      await this.agent.post(route)
+        .send({
+          xsrf,
+          user_code: 'FOO-EXPIRED',
+        })
+        .type('form')
+        .expect(200)
+        .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
+        .expect(/<p class="red">The code you entered is incorrect\. Try again<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name)
+          .to
+          .equal('ExpiredError');
+        return true;
+      }));
+
+      expect(errSpy)
+        .to
+        .have
+        .property('called', false);
+    });
+
+    it('re-renders on found but already user code', async function () {
+      const errSpy = sinon.spy();
+      this.provider.once('code_verification.error', errSpy);
+      const spy = sinon.spy(i(this.provider)
+        .configuration('features.deviceFlow'), 'userCodeInputSource');
+      await new this.provider.DeviceCode({
+        userCode: 'FOOCONSUMED',
+        accountId: 'account',
+      }).save();
+
+      await this.agent.post(route)
+        .send({
+          xsrf,
+          user_code: 'FOO-CONSUMED',
+        })
+        .type('form')
+        .expect(200)
+        .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
+        .expect(/<p class="red">The code you entered is incorrect\. Try again<\/p>/);
+
+      expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name)
+          .to
+          .equal('AlreadyUsedError');
+        return true;
+      }));
+
+      expect(errSpy)
+        .to
+        .have
+        .property('called', false);
+    });
+
+    it('re-renders on invalid client', async function () {
+      const errSpy = sinon.spy();
+      this.provider.once('code_verification.error', errSpy);
+      const spy = sinon.spy(i(this.provider)
+        .configuration('features.deviceFlow'), 'userCodeInputSource');
+      await new this.provider.DeviceCode({
+        userCode: 'FOONOTFOUNDCLIENT',
         clientId: 'client',
-        userCode: 'FOO',
-        params: {
-          scope: 'openid email',
-          client_id: 'client',
-          claims: JSON.stringify({ userinfo: { email: null } }),
-        },
       }).save();
 
+      sinon.stub(this.provider.Client, 'find')
+        .callsFake(async () => {
+        });
       await this.agent.post(route)
         .send({
           xsrf,
-          confirm: 'yes',
-          user_code: 'FOO',
+          user_code: 'FOO-NOT-FOUND-CLIENT',
         })
         .type('form')
-        .expect(200);
-
-      code = await this.provider.DeviceCode.find(code);
-
-      const session = this.getSession();
-
-      expect(code).not.to.have.property('sid');
-      expect(code).to.have.property('accountId', session.accountId);
-      expect(code).to.have.property('authTime', session.loginTs);
-      expect(code).to.have.property('scope', 'openid email');
-      expect(code).to.have.property('claims').that.eqls({ userinfo: { email: null } });
+        .expect(400)
+        .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
+        .expect(/<p class="red">There was an error processing your request<\/p>/);
 
       expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name)
+          .to
+          .equal('InvalidClient');
+        return true;
+      }));
+
+      expect(errSpy.calledOnce).to.be.true;
     });
 
-    it('renders a confirmation and assigns (incl. sid because of client configuration)', async function () {
-      const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
-
-      let code = await new this.provider.DeviceCode({
-        clientId: 'client-backchannel',
-        userCode: 'FOO',
-        params: {
-          scope: 'openid',
-          client_id: 'client-backchannel',
-        },
+    it('re-renders on !ctx.oidc.session.state', async function () {
+      const errSpy = sinon.spy();
+      this.provider.once('code_verification.error', errSpy);
+      const spy = sinon.spy(i(this.provider)
+        .configuration('features.deviceFlow'), 'userCodeInputSource');
+      await new this.provider.DeviceCode({
+        userCode: 'FOOCSRF1',
       }).save();
 
+      delete this.getSession().state;
       await this.agent.post(route)
         .send({
           xsrf,
-          confirm: 'yes',
-          user_code: 'FOO',
+          user_code: 'FOO-CSRF-1',
         })
         .type('form')
-        .expect(200);
+        .expect(400)
+        .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
+        .expect(/<p class="red">There was an error processing your request<\/p>/);
 
-      code = await this.provider.DeviceCode.find(code);
-
-      expect(code).to.have.property('sid');
       expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name)
+          .to
+          .equal('InvalidRequest');
+        expect(err.error_description)
+          .to
+          .equal('could not find device form details');
+        return true;
+      }));
+
+      expect(errSpy.calledOnce).to.be.true;
     });
 
-    it('renders a confirmation and assigns (incl. sid because of claims)', async function () {
-      const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
-
-      let code = await new this.provider.DeviceCode({
-        clientId: 'client',
-        userCode: 'FOO',
-        params: {
-          scope: 'openid',
-          client_id: 'client',
-          claims: JSON.stringify({ id_token: { sid: null } }),
-        },
+    it('re-renders on invalid csrf', async function () {
+      const errSpy = sinon.spy();
+      this.provider.once('code_verification.error', errSpy);
+      const spy = sinon.spy(i(this.provider)
+        .configuration('features.deviceFlow'), 'userCodeInputSource');
+      await new this.provider.DeviceCode({
+        userCode: 'FOOCSRF2',
       }).save();
 
       await this.agent.post(route)
         .send({
-          xsrf,
-          confirm: 'yes',
-          user_code: 'FOO',
+          xsrf: 'invalid-csrf',
+          user_code: 'FOO-CSRF-FOO',
         })
         .type('form')
-        .expect(200);
+        .expect(400)
+        .expect(new RegExp(`<form id="op.deviceInputForm" novalidate method="post" action="http://127.0.0.1:\\d+${this.suitePath('/device')}">`))
+        .expect(/<p class="red">There was an error processing your request<\/p>/);
 
-      code = await this.provider.DeviceCode.find(code);
-
-      expect(code).to.have.property('sid');
       expect(spy.calledOnce).to.be.true;
+      sinon.assert.calledWithMatch(spy, any, any, any, sinon.match((err) => {
+        expect(err.name)
+          .to
+          .equal('InvalidRequest');
+        expect(err.error_description)
+          .to
+          .equal('xsrf token invalid');
+        return true;
+      }));
+
+      expect(errSpy.calledOnce).to.be.true;
+    });
+  });
+
+  describe(`POST code_verification endpoint w/ verification - ${run.spec}`, () => {
+    before(bootstrap(import.meta.url, { config: run.options.config }));
+    before(function () {
+      return this.login({
+        scope: 'openid email',
+        rejectedClaims: ['email_verified'],
+      });
+    });
+    afterEach(timekeeper.reset);
+    afterEach(sinon.restore);
+
+    const xsrf = 'foo';
+
+    beforeEach(function () {
+      this.getSession().state = { secret: xsrf };
     });
 
-    it('allows for punctuation to be included and characters to be downcased', async function () {
-      const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+    passInteractionChecks('native_client_prompt', 'op_claims_missing', () => {
+      it('accepts an abort command', async function () {
+        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'userCodeInputSource');
 
-      let code = await new this.provider.DeviceCode({
-        clientId: 'client',
-        userCode: 'FOOBAR',
-        params: {
-          scope: 'openid email',
-          client_id: 'client',
-          claims: JSON.stringify({ userinfo: { email: null } }),
-        },
-      }).save();
+        let code = await new this.provider.DeviceCode({
+          clientId: 'client',
+          userCode: 'FOO',
+          params: {
+            scope: 'openid email',
+            client_id: 'client',
+            claims: JSON.stringify({ userinfo: { email: null } }),
+          },
+        }).save();
 
-      await this.agent.post(route)
-        .send({
-          xsrf,
-          confirm: 'yes',
-          user_code: 'f o o b a r',
-        })
-        .type('form')
-        .expect(200);
+        await this.agent.post(route)
+          .send({
+            xsrf,
+            user_code: 'FOO',
+            ...run.options.abortionPayload,
+          })
+          .type('form')
+          .expect(200)
+          .expect(/The Sign-in request was interrupted/);
 
-      code = await this.provider.DeviceCode.find(code);
+        code = await this.provider.DeviceCode.find(code);
 
-      const session = this.getSession();
+        expect(code).not.to.have.property('accountId');
+        expect(code).to.have.property('error', 'access_denied');
+        expect(code).to.have.property('errorDescription', 'End-User aborted interaction');
 
-      expect(code).to.have.property('accountId', session.accountId);
-      expect(code).to.have.property('authTime', session.loginTs);
-      expect(code).to.have.property('scope', 'openid email');
-      expect(code).to.have.property('claims').that.eqls({ userinfo: { email: null } });
+        expect(spy.calledOnce).to.be.true;
+      });
 
-      expect(spy.calledOnce).to.be.true;
+      it('renders a confirmation and assigns', async function () {
+        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+
+        let code = await new this.provider.DeviceCode({
+          clientId: 'client',
+          userCode: 'FOO',
+          params: {
+            scope: 'openid email',
+            client_id: 'client',
+            claims: JSON.stringify({ userinfo: { email: null } }),
+          },
+        }).save();
+
+        await this.agent.post(route)
+          .send({
+            xsrf,
+            user_code: 'FOO',
+            ...run.options.confirmationPayload,
+          })
+          .type('form')
+          .expect(200);
+
+        code = await this.provider.DeviceCode.find(code);
+
+        const session = this.getSession();
+
+        expect(code).not.to.have.property('sid');
+        expect(code).to.have.property('accountId', session.accountId);
+        expect(code).to.have.property('authTime', session.loginTs);
+        expect(code).to.have.property('scope', 'openid email');
+        expect(code).to.have.property('claims').that.eqls({ userinfo: { email: null } });
+
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('renders a confirmation and assigns (incl. sid because of client configuration)', async function () {
+        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+
+        let code = await new this.provider.DeviceCode({
+          clientId: 'client-backchannel',
+          userCode: 'FOO',
+          params: {
+            scope: 'openid',
+            client_id: 'client-backchannel',
+          },
+        }).save();
+
+        await this.agent.post(route)
+          .send({
+            xsrf,
+            user_code: 'FOO',
+            ...run.options.confirmationPayload,
+          })
+          .type('form')
+          .expect(200);
+
+        code = await this.provider.DeviceCode.find(code);
+
+        expect(code).to.have.property('sid');
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('renders a confirmation and assigns (incl. sid because of claims)', async function () {
+        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+
+        let code = await new this.provider.DeviceCode({
+          clientId: 'client',
+          userCode: 'FOO',
+          params: {
+            scope: 'openid',
+            client_id: 'client',
+            claims: JSON.stringify({ id_token: { sid: null } }),
+          },
+        }).save();
+
+        await this.agent.post(route)
+          .send({
+            xsrf,
+            user_code: 'FOO',
+            ...run.options.confirmationPayload,
+          })
+          .type('form')
+          .expect(200);
+
+        code = await this.provider.DeviceCode.find(code);
+
+        expect(code).to.have.property('sid');
+        expect(spy.calledOnce).to.be.true;
+      });
+
+      it('allows for punctuation to be included and characters to be downcased', async function () {
+        const spy = sinon.spy(i(this.provider).configuration('features.deviceFlow'), 'successSource');
+
+        let code = await new this.provider.DeviceCode({
+          clientId: 'client',
+          userCode: 'FOOBAR',
+          params: {
+            scope: 'openid email',
+            client_id: 'client',
+            claims: JSON.stringify({ userinfo: { email: null } }),
+          },
+        }).save();
+
+        await this.agent.post(route)
+          .send({
+            xsrf,
+            user_code: 'f o o b a r',
+            ...run.options.confirmationPayload,
+          })
+          .type('form')
+          .expect(200);
+
+        code = await this.provider.DeviceCode.find(code);
+
+        const session = this.getSession();
+
+        expect(code).to.have.property('accountId', session.accountId);
+        expect(code).to.have.property('authTime', session.loginTs);
+        expect(code).to.have.property('scope', 'openid email');
+        expect(code).to.have.property('claims').that.eqls({ userinfo: { email: null } });
+
+        expect(spy.calledOnce).to.be.true;
+      });
     });
   });
 });

--- a/test/device_code/code_verification_endpoint.test.js
+++ b/test/device_code/code_verification_endpoint.test.js
@@ -77,14 +77,14 @@ describe('POST code_verification endpoint w/o verification', () => {
 
     await new this.provider.DeviceCode({
       clientId: 'client',
-      userCode: 'FOOCODE',
+      userCode: 'FOOOCODE',
       deviceInfo,
     }).save();
 
     await this.agent.post(route)
       .send({
         xsrf,
-        user_code: 'FOO-CODE',
+        user_code: 'FOOO-CODE',
       })
       .type('form')
       .expect(200)
@@ -94,7 +94,7 @@ describe('POST code_verification endpoint w/o verification', () => {
     sinon.assert.calledWithMatch(spy, any, any, sinon.match((client) => {
       expect(client.clientId).to.equal('client');
       return true;
-    }), deviceInfo);
+    }), deviceInfo, 'FOOO-CODE');
   });
 
   it('re-renders on no submitted code', async function () {

--- a/test/device_code/device_code.test.js
+++ b/test/device_code/device_code.test.js
@@ -72,6 +72,39 @@ describe('configuration features.deviceFlow', () => {
     }).to.throw('mask can only contain asterisk("*"), hyphen-minus("-") and space(" ") characters');
   });
 
+  it('can be configured with a confirmParamName', () => {
+    expect(() => {
+      new Provider('http://localhost', {
+        features: {
+          deviceFlow: {
+            enabled: true,
+            confirmParamName: 'approved',
+          },
+        },
+      });
+    }).not.to.throw;
+    expect(() => {
+      new Provider('http://localhost', {
+        features: {
+          deviceFlow: {
+            enabled: true,
+            confirmParamName: 'accept_request',
+          },
+        },
+      });
+    }).not.to.throw;
+    expect(() => {
+      new Provider('http://localhost', {
+        features: {
+          deviceFlow: {
+            enabled: true,
+            confirmParamName: 'abc+12',
+          },
+        },
+      });
+    }).to.throw('confirmation parameter name needs to be 1 - 20 characters in length and use only a basic set of characters (matching the regex: ^[a-zA-Z0-9_]{1,20}$ )');
+  });
+
   it('extends discovery', function () {
     return this.agent.get('/.well-known/openid-configuration')
       .expect(200)

--- a/test/device_code/device_code_boolean_confirmation.config.js
+++ b/test/device_code/device_code_boolean_confirmation.config.js
@@ -1,0 +1,12 @@
+import cloneDeep from 'lodash/cloneDeep.js';
+
+import config from './device_code.config.js';
+
+const setup = cloneDeep(config);
+
+setup.config.features.deviceFlow = {
+  enabled: true,
+  useBooleanConfirmation: true,
+};
+
+export default setup;

--- a/test/device_code/device_code_custom_confirmation.config.js
+++ b/test/device_code/device_code_custom_confirmation.config.js
@@ -1,0 +1,12 @@
+import cloneDeep from 'lodash/cloneDeep.js';
+
+import config from './device_code.config.js';
+
+const setup = cloneDeep(config);
+
+setup.config.features.deviceFlow = {
+  enabled: true,
+  confirmParamName: 'approved',
+};
+
+export default setup;


### PR DESCRIPTION
**The issue:**
In the feature of device flow - when we use 2 parameters "confirm" and "abort" then no matter what is sent in the value of "confirm" it will confirm.
Example-> if when using "confirm" the value is false/no, it will still confirm.

The reason this is an issue for me is that I'm trying to use the library as an API solution without the "hosted" pages.

**The suggestion:**
In order to be backwards compatible I suggest adding a configuration for "useBooleanConfirmation" that will let the developer decide to use only one approval field which accepts only boolean values.

**Implementation details:**
I added configurations called `useBooleanConfirmation, confirmParamName` that lets the developer decide to use one boolean param name and the param name itself. (perhaps you will decide the second one is not needed).