### PR TITLE
Allow engines greater or equal to 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,6 @@
     "timekeeper": "^2.2.0"
   },
   "engines": {
-    "node": "18"
+    "node": "^18"
   }
 }


### PR DESCRIPTION
This pull request updates the `engine` property in package.json to `^18`, to allow versions equal to or greater than 18. Which fixes the following:

<img width="1160" alt="image" src="https://user-images.githubusercontent.com/383994/209015833-41b83582-671b-4f5b-bd0b-4f4f7a5fc351.png">

FWIW, this error message is displayed more than any other message in my terminal. It's quite frustrating debugging with this message taking up most of the terminal. 