### PR TITLE
Fix test config file import on Windows

### DIFF
--- a/test/test_helper.js
+++ b/test/test_helper.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 
-import { parse } from 'node:url';
+import { parse, pathToFileURL } from 'node:url';
 import * as path from 'node:path';
 import * as querystring from 'node:querystring';
 import { createServer } from 'node:http';
@@ -82,7 +82,7 @@ export default function testHelper(importMetaUrl, {
   });
 
   return async function () {
-    const conf = path.format({ dir, base: `${base}.config.js` });
+    const conf = pathToFileURL(path.format({ dir, base: `${base}.config.js` })).toString();
     const { default: mod } = await import(conf);
     const { config, client } = mod;
     let { clients } = mod;


### PR DESCRIPTION
On Windows the `path.format` return the path of file starting with `C:`, which is a probleam on the ESM import as you can see in the log I get after running the tests

```
87) configuration features.webMessageResponseMode
       "before all" hook in "configuration features.webMessageResponseMode":
     Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data are supported by the default ESM loader. On Windows, absolute paths must be valid 
file:// URLs. Received protocol 'c:'
      at new NodeError (node:internal/errors:400:5)
      at throwIfUnsupportedURLScheme (node:internal/modules/esm/resolve:1055:11)
      at defaultResolve (node:internal/modules/esm/resolve:1135:3)
      at nextResolve (node:internal/modules/esm/loader:163:28)
      at ESMLoader.resolve (node:internal/modules/esm/loader:842:30)
      at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
      at ESMLoader.import (node:internal/modules/esm/loader:525:22)
      at importModuleDynamically (node:internal/modules/esm/translators:110:35)
      at importModuleDynamicallyCallback (node:internal/process/esm_loader:35:14)
      at Context.<anonymous> (file:///C:/Users/matheus.almeida/Documents/trabalho/node-oidc-provider/test/test_helper.js:85:30)
```
This problem can be solved by using the `pathToFileURL` method from `node:url`

```
  configuration features.webMessageResponseMode
    discovery
      ✔ extends the well known config
    /auth
      logged in
        ✔ responds by rendering a an HTML with the client side code and response data [1/4]
        ✔ responds by rendering a an HTML with the client side code and response data [2/4]
        ✔ responds by rendering a an HTML with the client side code and response data [3/4]
        ✔ responds by rendering a an HTML with the client side code and response data [4/4]
      error handling
        ✔ verifies web_message_uri is allowed
        ✔ validates web_message_uri ad acta [regular error]
        ✔ validates web_message_uri ad acta [server error]
        ✔ responds by rendering a self-submitting form with the error
```