### PR TITLE
Error forward

### DIFF
--- a/lib/helpers/initialize_app.js
+++ b/lib/helpers/initialize_app.js
@@ -218,11 +218,5 @@ export default function initializeApp() {
 
   this.app.use(proxyWarning);
   this.app.use(error(this));
-  this.app.use(async (ctx, next) => {
-    await next();
-    if (ctx.status === 404 && ctx.message === 'Not Found') {
-      throw new InvalidRequest(`unrecognized route or not allowed method (${ctx.method} on ${ctx.path})`, 404);
-    }
-  });
   this.app.use(router.routes());
 }

--- a/lib/shared/error_handler.js
+++ b/lib/shared/error_handler.js
@@ -27,6 +27,7 @@ export default function getErrorHandler(provider, eventName) {
     } catch (err) {
       const out = errOut(err);
       ctx.status = err.statusCode || 500;
+      let doThrow = false
 
       if (err.expose && !(err instanceof ReRenderError)) {
         debug('path=%s method=%s error=%o detail=%s', ctx.path, ctx.method, out, err.error_detail);
@@ -51,13 +52,16 @@ export default function getErrorHandler(provider, eventName) {
         const renderError = instance(provider).configuration('renderError');
         await renderError(ctx, out, err);
       } else {
-        ctx.body = out;
+        doThrow = true
       }
 
       if (out.error === 'server_error') {
         provider.emit('server_error', ctx, err);
       } else if (eventName) {
         provider.emit(eventName, ctx, err);
+      }
+      if(doThrow){
+        throw err;
       }
     }
   };


### PR DESCRIPTION
Hello, please review my pull request.

What do you identify as a problem:
When the request is not made via HTML, it is impossible to capture the error event in order to use a Koa Error Handling, as the error is converted to a message in the body.

The ideal would be to send the error forward and thus be recaptured.