### PR TITLE
fix: ignore post_logout_redirect_uris when logout is disabled

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -439,6 +439,7 @@ location / {
   - [requestObjects](#featuresrequestobjects)
   - [resourceIndicators ❗](#featuresresourceindicators)
   - [revocation](#featuresrevocation)
+  - [rpInitiatedLogout](#featuresrpinitiatedlogout)
   - [userinfo](#featuresuserinfo)
 - [acrValues](#acrvalues)
 - [allowOmittingSingleRegisteredRedirectUri](#allowomittingsingleregisteredredirecturi)

--- a/lib/consts/client_attributes.js
+++ b/lib/consts/client_attributes.js
@@ -16,7 +16,6 @@ const RECOGNIZED_METADATA = [
   'jwks',
   'logo_uri',
   'policy_uri',
-  'post_logout_redirect_uris',
   'redirect_uris',
   'require_auth_time',
   'response_types',

--- a/test/configuration/client_metadata.test.js
+++ b/test/configuration/client_metadata.test.js
@@ -497,8 +497,10 @@ describe('Client metadata validation', () => {
   });
 
   context('post_logout_redirect_uris', function () {
-    defaultsTo(this.title, [], undefined);
-    defaultsTo(this.title, [], { post_logout_redirect_uris: undefined });
+    defaultsTo(this.title, []);
+    defaultsTo(this.title, undefined, undefined, {
+      features: { rpInitiatedLogout: { enabled: false } },
+    });
     mustBeArray(this.title, [{}, 'string', 123, true]);
     rejects(this.title, [123], /must only contain strings$/);
 


### PR DESCRIPTION
Hello, I think there is a slight problem wtih `rpInitiatedLogout` configuration.

inside the `client_schema.js` there is this check at line 79

```
  if (features.rpInitiatedLogout.enabled) {
    RECOGNIZED_METADATA.push('post_logout_redirect_uris');
  }
```
However, it looks like it does nothing, because `post_logout_redirect_uris` is already included in the default `RECOGNIZED_METADATA` array.  In order for flag `features.rpInitiatedLogout.enabled` to properly work, default recognized metadata properties should be changed.

I can't run tests locally due to `structuredClone` error, so haven't verified yet if tests don't break.