### PR TITLE
fix: ignore non-existent resource scopes during refresh

### DIFF
--- a/lib/actions/grants/refresh_token.js
+++ b/lib/actions/grants/refresh_token.js
@@ -193,10 +193,10 @@ export const handler = async function refreshTokenHandler(ctx, next) {
       .getResourceServerInfo(ctx, resource, ctx.oidc.client);
     at.resourceServer = new ctx.oidc.provider.ResourceServer(resource, resourceServerInfo);
 
-    const resourceScopes = new Set(resourceServerInfo.scope.split(' '));
-    const filter = new Set([...scope].filter(Set.prototype.has.bind(resourceScopes)));
-
-    at.scope = grant.getResourceScopeFiltered(resource, filter);
+    at.scope = grant.getResourceScopeFiltered(
+      resource,
+      [...scope].filter(Set.prototype.has.bind(at.resourceServer.scopes)),
+    );
   } else {
     at.claims = refreshToken.claims;
     at.scope = grant.getOIDCScopeFiltered(scope);

--- a/lib/actions/grants/refresh_token.js
+++ b/lib/actions/grants/refresh_token.js
@@ -192,7 +192,6 @@ export const handler = async function refreshTokenHandler(ctx, next) {
     const resourceServerInfo = await resourceIndicators
       .getResourceServerInfo(ctx, resource, ctx.oidc.client);
     at.resourceServer = new ctx.oidc.provider.ResourceServer(resource, resourceServerInfo);
-
     at.scope = grant.getResourceScopeFiltered(
       resource,
       [...scope].filter(Set.prototype.has.bind(at.resourceServer.scopes)),

--- a/lib/actions/grants/refresh_token.js
+++ b/lib/actions/grants/refresh_token.js
@@ -192,7 +192,11 @@ export const handler = async function refreshTokenHandler(ctx, next) {
     const resourceServerInfo = await resourceIndicators
       .getResourceServerInfo(ctx, resource, ctx.oidc.client);
     at.resourceServer = new ctx.oidc.provider.ResourceServer(resource, resourceServerInfo);
-    at.scope = grant.getResourceScopeFiltered(resource, scope);
+    
+    const resourceScopes = new Set(resourceServerInfo.scope.split(" "));
+    const filter = new Set([...scope].filter(Set.prototype.has.bind(resourceScopes)));
+
+    at.scope = grant.getResourceScopeFiltered(resource, filter);
   } else {
     at.claims = refreshToken.claims;
     at.scope = grant.getOIDCScopeFiltered(scope);

--- a/lib/actions/grants/refresh_token.js
+++ b/lib/actions/grants/refresh_token.js
@@ -192,8 +192,8 @@ export const handler = async function refreshTokenHandler(ctx, next) {
     const resourceServerInfo = await resourceIndicators
       .getResourceServerInfo(ctx, resource, ctx.oidc.client);
     at.resourceServer = new ctx.oidc.provider.ResourceServer(resource, resourceServerInfo);
-    
-    const resourceScopes = new Set(resourceServerInfo.scope.split(" "));
+
+    const resourceScopes = new Set(resourceServerInfo.scope.split(' '));
     const filter = new Set([...scope].filter(Set.prototype.has.bind(resourceScopes)));
 
     at.scope = grant.getResourceScopeFiltered(resource, filter);


### PR DESCRIPTION
## Context
We have implemented the RBAC feature in our system based on the oidc-provider. Leveraging `resourceIndicators.getResourceServerInfo`  method to guard and filter the resource scopes being issued. 

### What problem I have met
After a user is initially sign-in and authenticated, we manually revoke a role(resource scopes) from that user. Or delete the scopes directly from that resource indicator. 

### Expected behavior
The revoked resource scopes should be filtered from the newly exchanged access tokens. 
As mentioned in the doc:
<img width="926" alt="image" src="https://github.com/panva/node-oidc-provider/assets/36393111/37e940d1-e21a-4e2b-8ef0-493b19da6f60">

### Actually behavior
Instead of reading the latest scopes returned from the resource server, the Provider uses the initially granted resource scopes pool to issue new access tokens.  The scope can only be revoked till the user re-authenticates. 

## Summary
Any 'down-scope' action should take effect immediately to the end user.  Attempt to filter out revoked or invalid resource scopes using the latest resource server info data in the refresh_token grant action. 

Please let me know if there are any other recommended approaches. Thx.
