### PR TITLE
Router prefix

### DIFF
--- a/lib/helpers/initialize_app.js
+++ b/lib/helpers/initialize_app.js
@@ -20,7 +20,7 @@ import * as attention from './attention.js';
 
 const discoveryRoute = '/.well-known/openid-configuration';
 
-export default function initializeApp() {
+export default function initializeApp({ mountPath } = { mountPath: '/'}) {
   const configuration = instance(this).configuration();
 
   const CORS_AUTHORIZATION = { exposeHeaders: ['WWW-Authenticate'], maxAge: 3600 };
@@ -33,7 +33,7 @@ export default function initializeApp() {
     client: cors({ allowMethods: 'POST', clientBased: true, ...CORS_AUTHORIZATION }),
   };
 
-  const router = new Router();
+  const router = new Router({ prefix: mountPath });
   instance(this).router = router;
 
   const ensureOIDC = contextEnsureOidc(this);

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -211,7 +211,7 @@ class Provider extends events.EventEmitter {
     }
   }
 
-  pathFor(name, { mountPath = this.#mountPath, ...opts } = {}) {
+  pathFor(name, opts = {}) {
     const { router } = instance(this);
 
     const routerUrl = router.url(name, opts);
@@ -220,7 +220,7 @@ class Provider extends events.EventEmitter {
       throw routerUrl;
     }
 
-    return [mountPath, routerUrl].join('');
+    return routerUrl;
   }
 
   /**

--- a/lib/provider.js
+++ b/lib/provider.js
@@ -165,7 +165,7 @@ class Provider extends events.EventEmitter {
     initializeAdapter.call(this, configuration.adapter);
     initializeKeystore.call(this, configuration.jwks);
     delete configuration.jwks;
-    initializeApp.call(this);
+    initializeApp.call(this, { mountPath: this.#mountPath });
     initializeClients.call(this, configuration.clients);
     delete configuration.clients;
   }

--- a/test/provider/provider_instance.test.js
+++ b/test/provider/provider_instance.test.js
@@ -75,13 +75,8 @@ describe('provider instance', () => {
       expect(provider.urlFor('authorization')).to.equal('http://localhost/auth');
     });
 
-    it('returns the route for prefixed issuers (1/2)', () => {
+    it('returns the route for prefixed issuers', () => {
       const provider = new Provider('http://localhost/op/2.0');
-      expect(provider.urlFor('authorization')).to.equal('http://localhost/op/2.0/auth');
-    });
-
-    it('returns the route for prefixed issuers (2/2)', () => {
-      const provider = new Provider('http://localhost/op/2.0/');
       expect(provider.urlFor('authorization')).to.equal('http://localhost/op/2.0/auth');
     });
 


### PR DESCRIPTION
> fix: set core koa router prefix to correct routes when mounted

I'm mounting a provider in a nextjs app under the path `/api/oidc`. I noticed the discovery paths were wrong, but also some generated paths like ones used by `interactionFinished` would be incorrect. Making this change put everything in line.

Is this something that would be accepted with tests?

prefix option docs: https://github.com/ZijianHe/koa-router#new-routeropts