### PR TITLE
docs: point to a specific part of Discovery 1.0 RFC

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -365,7 +365,7 @@ koaApp.use(mount('/oidc', oidc.app));
 Note: when the issuer identifier does not include the path prefix you should take care of rewriting
 your `${root}/.well-known/openid-configuration` to `${root}${prefix}/.well-known/openid-configuration`
 so that your deployment remains conform to the
-[Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html) specification.
+[Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest) specification. See section 4.1 *OpenID Provider Configuration Request*
 
 ## Trusting TLS offloading proxies
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -365,8 +365,8 @@ koaApp.use(mount('/oidc', oidc.app));
 Note: when the issuer identifier does not include the path prefix you should take care of rewriting
 your `${root}/.well-known/openid-configuration` to `${root}${prefix}/.well-known/openid-configuration`
 so that your deployment remains conform to the
-[Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest) specification. See section 4.1 *OpenID Provider Configuration Request*
-
+[Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest)
+specification. See section 4.1 *OpenID Provider Configuration Request*
 ## Trusting TLS offloading proxies
 
 Having a TLS offloading proxy in front of Node.js running oidc-provider is

--- a/docs/README.md
+++ b/docs/README.md
@@ -366,7 +366,8 @@ Note: when the issuer identifier does not include the path prefix you should tak
 your `${root}/.well-known/openid-configuration` to `${root}${prefix}/.well-known/openid-configuration`
 so that your deployment remains conform to the
 [Discovery 1.0](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfigurationRequest)
-specification. See section 4.1 *OpenID Provider Configuration Request*
+specification.
+
 ## Trusting TLS offloading proxies
 
 Having a TLS offloading proxy in front of Node.js running oidc-provider is


### PR DESCRIPTION
Just uses anchor link to point to specific part of discovery spec