### PR TITLE
fix: reject client JSON Web Key Set `null` value

### DIFF
--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -37,7 +37,7 @@ const fingerprint = (properties) => hash(properties, {
 });
 
 const validateJWKS = (jwks) => {
-  if (jwks !== undefined) {
+  if (jwks !== undefined && jwks !== null) {
     if (!Array.isArray(jwks.keys) || !jwks.keys.every(isPlainObject)) {
       throw new InvalidClientMetadata('client JSON Web Key Set is invalid');
     }

--- a/lib/models/client.js
+++ b/lib/models/client.js
@@ -37,8 +37,8 @@ const fingerprint = (properties) => hash(properties, {
 });
 
 const validateJWKS = (jwks) => {
-  if (jwks !== undefined && jwks !== null) {
-    if (!Array.isArray(jwks.keys) || !jwks.keys.every(isPlainObject)) {
+  if (jwks !== undefined) {
+    if (!Array.isArray(jwks?.keys) || !jwks.keys.every(isPlainObject)) {
       throw new InvalidClientMetadata('client JSON Web Key Set is invalid');
     }
   }

--- a/test/configuration/client_metadata.test.js
+++ b/test/configuration/client_metadata.test.js
@@ -1749,6 +1749,7 @@ describe('Client metadata validation', () => {
       rejects(this.title, { keys: [value] }, 'client JSON Web Key Set is invalid');
     });
     rejects('jwks', 'string', 'client JSON Web Key Set is invalid');
+    rejects('jwks', null, 'client JSON Web Key Set is invalid');
     rejects(this.title, {}, 'client JSON Web Key Set is invalid');
     rejects(this.title, 1, 'client JSON Web Key Set is invalid');
     rejects(this.title, 0, 'client JSON Web Key Set is invalid');


### PR DESCRIPTION
Prevents "jwks" set to null in the [client metadata](https://github.com/panva/node-oidc-provider/tree/main/docs#clients) instead of a TypeError such as:
```
TypeError: Cannot read properties of null (reading 'keys')\n    at validateJWKS
(node_modules/.pnpm/oidc-provider@8.4.1/node_modules/oidc-provider/lib/models/client.js:41:29
```