### PR TITLE
test(client_metadata): add empty string and null checks to client_name test

### DIFF
--- a/test/configuration/client_metadata.test.js
+++ b/test/configuration/client_metadata.test.js
@@ -254,6 +254,8 @@ describe('Client metadata validation', () => {
   context('client_name', function () {
     mustBeString(this.title);
     allows(this.title, 'whatever client name');
+    rejects(this.title, '');
+    rejects(this.title, null);
   });
 
   context('client_secret', function () {


### PR DESCRIPTION
Add assertions to test the empty string and null value checks for the "client_name" metadata. For example:
```
Error: InvalidClientMetadata received invalid_client_metadata client_name must be a non-empty string if provided
```
