### PR TITLE
[7.x] Fix cve-2022-25883 for non ESM-only projects

### DIFF
--- a/lib/shared/cors.js
+++ b/lib/shared/cors.js
@@ -20,7 +20,13 @@ function checkClientCORS(ctx, client) {
 }
 
 module.exports = ({ clientBased = false, ...options }) => {
-  const builtin = cors({ keepHeadersOnError: false, ...options });
+  const builtin = cors({
+    keepHeadersOnError: false,
+    origin(ctx) {
+      return ctx.get('Origin') || '*';
+    },
+    ...options,
+  });
 
   return async (ctx, next) => {
     const headers = Object.keys(ctx.response.headers);

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test": "node ./test/run"
   },
   "dependencies": {
-    "@koa/cors": "^3.3.0",
+    "@koa/cors": "^5.0.0",
     "cacheable-lookup": "^6.0.4",
     "debug": "^4.3.4",
     "ejs": "^3.1.8",

--- a/test/cors/cors.test.js
+++ b/test/cors/cors.test.js
@@ -29,6 +29,15 @@ const ACAOrigin = 'access-control-allow-origin';
 const ACEHeaders = 'access-control-expose-headers';
 const Vary = 'vary';
 
+function accessControlHeaders(headers) {
+  return Object.fromEntries(Object.entries(headers).filter(([header]) => header.startsWith('access-control-')));
+}
+
+function assertCorsHeaders(headers, expected) {
+  expect(headers[Vary]).to.eql('Origin');
+  expect(accessControlHeaders(headers)).to.eql(expected);
+}
+
 describe('CORS setup', () => {
   before(bootstrap(__dirname));
   before(function () { return this.login(); });
@@ -63,44 +72,49 @@ describe('CORS setup', () => {
         ['set', 'authorization', `Bearer ${this.token}`],
       );
       expect(status).to.eql(500);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
+      assertCorsHeaders(headers, {
+        [ACEHeaders]: 'WWW-Authenticate',
+        [ACAOrigin]: 'https://example.com',
+      });
     });
   });
 
   it('discovery has cors open', async function () {
     const { status, headers } = await req.call(this, 'get', '/.well-known/openid-configuration', 'https://example.com');
     expect(status).to.eql(200);
-    expect(headers[Vary]).to.eql('Origin');
-    expect(headers[ACAOrigin]).to.eql('https://example.com');
+    assertCorsHeaders(headers, {
+      [ACAOrigin]: 'https://example.com',
+    });
   });
 
   it('discovery preflights have cors open', async function () {
     const { status, headers } = await preflight.call(this, 'GET', '/.well-known/openid-configuration', 'https://example.com');
     expect(status).to.eql(204);
-    expect(headers[Vary]).to.eql('Origin');
-    expect(headers[ACAOrigin]).to.eql('https://example.com');
-    expect(headers[ACAMaxAge]).to.eql('3600');
-    expect(headers[ACAMethods]).to.eql('GET');
-    expect(headers[ACAHeaders]).to.eql('foo');
+    assertCorsHeaders(headers, {
+      [ACAOrigin]: 'https://example.com',
+      [ACAMaxAge]: '3600',
+      [ACAMethods]: 'GET',
+      [ACAHeaders]: 'foo',
+    });
   });
 
   it('jwks_uri has cors open', async function () {
     const { status, headers } = await req.call(this, 'get', '/jwks', 'https://example.com');
     expect(status).to.eql(200);
-    expect(headers[Vary]).to.eql('Origin');
-    expect(headers[ACAOrigin]).to.eql('https://example.com');
+    assertCorsHeaders(headers, {
+      [ACAOrigin]: 'https://example.com',
+    });
   });
 
   it('jwks_uri preflights have cors open', async function () {
     const { status, headers } = await preflight.call(this, 'GET', '/jwks', 'https://example.com');
     expect(status).to.eql(204);
-    expect(headers[Vary]).to.eql('Origin');
-    expect(headers[ACAOrigin]).to.eql('https://example.com');
-    expect(headers[ACAMaxAge]).to.eql('3600');
-    expect(headers[ACAMethods]).to.eql('GET');
-    expect(headers[ACAHeaders]).to.eql('foo');
+    assertCorsHeaders(headers, {
+      [ACAOrigin]: 'https://example.com',
+      [ACAMaxAge]: '3600',
+      [ACAMethods]: 'GET',
+      [ACAHeaders]: 'foo',
+    });
   });
 
   describe('with clientBasedCORS resolving to true', () => {
@@ -124,19 +138,21 @@ describe('CORS setup', () => {
         ['set', 'authorization', `Bearer ${this.token}`],
       );
       expect(status).to.eql(200);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
+      assertCorsHeaders(headers, {
+        [ACEHeaders]: 'WWW-Authenticate',
+        [ACAOrigin]: 'https://example.com',
+      });
     });
 
     it('userinfo preflights have cors open', async function () {
       const { status, headers } = await preflight.call(this, 'GET', '/me', 'https://example.com');
       expect(status).to.eql(204);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
-      expect(headers[ACAMaxAge]).to.eql('3600');
-      expect(headers[ACAMethods]).to.eql('GET,POST');
-      expect(headers[ACAHeaders]).to.eql('foo');
+      assertCorsHeaders(headers, {
+        [ACAOrigin]: 'https://example.com',
+        [ACAMaxAge]: '3600',
+        [ACAMethods]: 'GET,POST',
+        [ACAHeaders]: 'foo',
+      });
     });
 
     it('token has cors open', async function () {
@@ -150,9 +166,10 @@ describe('CORS setup', () => {
         ['send', { client_id: 'client', grant_type: 'client_credentials' }],
       );
       expect(status).to.eql(200);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
+      assertCorsHeaders(headers, {
+        [ACEHeaders]: 'WWW-Authenticate',
+        [ACAOrigin]: 'https://example.com',
+      });
     });
 
     it('token (error) has cors open', async function () {
@@ -166,19 +183,21 @@ describe('CORS setup', () => {
         ['send', { client_id: 'client' }],
       );
       expect(status).to.eql(400);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
+      assertCorsHeaders(headers, {
+        [ACEHeaders]: 'WWW-Authenticate',
+        [ACAOrigin]: 'https://example.com',
+      });
     });
 
     it('token preflights have cors open', async function () {
       const { status, headers } = await preflight.call(this, 'POST', '/token', 'https://example.com');
       expect(status).to.eql(204);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
-      expect(headers[ACAMaxAge]).to.eql('3600');
-      expect(headers[ACAMethods]).to.eql('POST');
-      expect(headers[ACAHeaders]).to.eql('foo');
+      assertCorsHeaders(headers, {
+        [ACAOrigin]: 'https://example.com',
+        [ACAMaxAge]: '3600',
+        [ACAMethods]: 'POST',
+        [ACAHeaders]: 'foo',
+      });
     });
 
     it('revocation has cors open', async function () {
@@ -192,19 +211,21 @@ describe('CORS setup', () => {
         ['send', { client_id: 'client', token: 'foo' }],
       );
       expect(status).to.eql(200);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
+      assertCorsHeaders(headers, {
+        [ACEHeaders]: 'WWW-Authenticate',
+        [ACAOrigin]: 'https://example.com',
+      });
     });
 
     it('revocation preflights have cors open', async function () {
       const { status, headers } = await preflight.call(this, 'POST', '/token/revocation', 'https://example.com');
       expect(status).to.eql(204);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
-      expect(headers[ACAMaxAge]).to.eql('3600');
-      expect(headers[ACAMethods]).to.eql('POST');
-      expect(headers[ACAHeaders]).to.eql('foo');
+      assertCorsHeaders(headers, {
+        [ACAOrigin]: 'https://example.com',
+        [ACAMaxAge]: '3600',
+        [ACAMethods]: 'POST',
+        [ACAHeaders]: 'foo',
+      });
     });
 
     it('introspection has cors open', async function () {
@@ -218,9 +239,10 @@ describe('CORS setup', () => {
         ['send', { client_id: 'client', token: this.token }],
       );
       expect(status).to.eql(200);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
+      assertCorsHeaders(headers, {
+        [ACEHeaders]: 'WWW-Authenticate',
+        [ACAOrigin]: 'https://example.com',
+      });
     });
 
     it('introspection (error) has cors open', async function () {
@@ -234,19 +256,21 @@ describe('CORS setup', () => {
         ['send', { client_id: 'client' }],
       );
       expect(status).to.eql(400);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
+      assertCorsHeaders(headers, {
+        [ACEHeaders]: 'WWW-Authenticate',
+        [ACAOrigin]: 'https://example.com',
+      });
     });
 
     it('introspection preflights have cors open', async function () {
       const { status, headers } = await preflight.call(this, 'POST', '/token/introspection', 'https://example.com');
       expect(status).to.eql(204);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
-      expect(headers[ACAMaxAge]).to.eql('3600');
-      expect(headers[ACAMethods]).to.eql('POST');
-      expect(headers[ACAHeaders]).to.eql('foo');
+      assertCorsHeaders(headers, {
+        [ACAOrigin]: 'https://example.com',
+        [ACAMaxAge]: '3600',
+        [ACAMethods]: 'POST',
+        [ACAHeaders]: 'foo',
+      });
     });
 
     it('device_authorization has cors open', async function () {
@@ -260,9 +284,10 @@ describe('CORS setup', () => {
         ['send', { client_id: 'client' }],
       );
       expect(status).to.eql(200);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
+      assertCorsHeaders(headers, {
+        [ACEHeaders]: 'WWW-Authenticate',
+        [ACAOrigin]: 'https://example.com',
+      });
     });
 
     it('device_authorization (error) has cors open', async function () {
@@ -276,19 +301,21 @@ describe('CORS setup', () => {
         ['send', { client_id: 'client', max_age: '-1' }],
       );
       expect(status).to.eql(400);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
+      assertCorsHeaders(headers, {
+        [ACEHeaders]: 'WWW-Authenticate',
+        [ACAOrigin]: 'https://example.com',
+      });
     });
 
     it('device_authorization preflights have cors open', async function () {
       const { status, headers } = await preflight.call(this, 'POST', '/device/auth', 'https://example.com');
       expect(status).to.eql(204);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
-      expect(headers[ACAMaxAge]).to.eql('3600');
-      expect(headers[ACAMethods]).to.eql('POST');
-      expect(headers[ACAHeaders]).to.eql('foo');
+      assertCorsHeaders(headers, {
+        [ACAOrigin]: 'https://example.com',
+        [ACAMaxAge]: '3600',
+        [ACAMethods]: 'POST',
+        [ACAHeaders]: 'foo',
+      });
     });
   });
 
@@ -302,19 +329,21 @@ describe('CORS setup', () => {
         ['set', 'authorization', `Bearer ${this.token}`],
       );
       expect(status).to.eql(400);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers).not.to.have.property(ACAOrigin);
+      assertCorsHeaders(headers, {
+        // no Access-Control-Allow-Origin
+        [ACEHeaders]: 'WWW-Authenticate',
+      });
     });
 
     it('userinfo preflights have cors open', async function () {
       const { status, headers } = await preflight.call(this, 'GET', '/me', 'https://example.com');
       expect(status).to.eql(204);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
-      expect(headers[ACAMaxAge]).to.eql('3600');
-      expect(headers[ACAMethods]).to.eql('GET,POST');
-      expect(headers[ACAHeaders]).to.eql('foo');
+      assertCorsHeaders(headers, {
+        [ACAOrigin]: 'https://example.com',
+        [ACAMaxAge]: '3600',
+        [ACAMethods]: 'GET,POST',
+        [ACAHeaders]: 'foo',
+      });
     });
 
     it('token has cors closed', async function () {
@@ -328,9 +357,10 @@ describe('CORS setup', () => {
         ['send', { client_id: 'client', grant_type: 'client_credentials' }],
       );
       expect(status).to.eql(400);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers).not.to.have.property(ACAOrigin);
+      assertCorsHeaders(headers, {
+        // no Access-Control-Allow-Origin
+        [ACEHeaders]: 'WWW-Authenticate',
+      });
     });
 
     it('token (error) has cors open', async function () {
@@ -343,19 +373,21 @@ describe('CORS setup', () => {
         ['type', 'form'],
       );
       expect(status).to.eql(400);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
+      assertCorsHeaders(headers, {
+        [ACEHeaders]: 'WWW-Authenticate',
+        [ACAOrigin]: 'https://example.com',
+      });
     });
 
     it('token preflights have cors open', async function () {
       const { status, headers } = await preflight.call(this, 'POST', '/token', 'https://example.com');
       expect(status).to.eql(204);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
-      expect(headers[ACAMaxAge]).to.eql('3600');
-      expect(headers[ACAMethods]).to.eql('POST');
-      expect(headers[ACAHeaders]).to.eql('foo');
+      assertCorsHeaders(headers, {
+        [ACAOrigin]: 'https://example.com',
+        [ACAMaxAge]: '3600',
+        [ACAMethods]: 'POST',
+        [ACAHeaders]: 'foo',
+      });
     });
 
     it('revocation has cors closed', async function () {
@@ -369,19 +401,21 @@ describe('CORS setup', () => {
         ['send', { client_id: 'client', token: 'foo' }],
       );
       expect(status).to.eql(400);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers).not.to.have.property(ACAOrigin);
+      assertCorsHeaders(headers, {
+        // no Access-Control-Allow-Origin
+        [ACEHeaders]: 'WWW-Authenticate',
+      });
     });
 
     it('revocation preflights have cors open', async function () {
       const { status, headers } = await preflight.call(this, 'POST', '/token/revocation', 'https://example.com');
       expect(status).to.eql(204);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
-      expect(headers[ACAMaxAge]).to.eql('3600');
-      expect(headers[ACAMethods]).to.eql('POST');
-      expect(headers[ACAHeaders]).to.eql('foo');
+      assertCorsHeaders(headers, {
+        [ACAOrigin]: 'https://example.com',
+        [ACAMaxAge]: '3600',
+        [ACAMethods]: 'POST',
+        [ACAHeaders]: 'foo',
+      });
     });
 
     it('introspection has cors closed', async function () {
@@ -395,9 +429,10 @@ describe('CORS setup', () => {
         ['send', { client_id: 'client', token: this.token }],
       );
       expect(status).to.eql(400);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers).not.to.have.property(ACAOrigin);
+      assertCorsHeaders(headers, {
+        // no Access-Control-Allow-Origin
+        [ACEHeaders]: 'WWW-Authenticate',
+      });
     });
 
     it('introspection (error) has cors open', async function () {
@@ -410,19 +445,21 @@ describe('CORS setup', () => {
         ['type', 'form'],
       );
       expect(status).to.eql(400);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
+      assertCorsHeaders(headers, {
+        [ACEHeaders]: 'WWW-Authenticate',
+        [ACAOrigin]: 'https://example.com',
+      });
     });
 
     it('introspection preflights have cors open', async function () {
       const { status, headers } = await preflight.call(this, 'POST', '/token/introspection', 'https://example.com');
       expect(status).to.eql(204);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
-      expect(headers[ACAMaxAge]).to.eql('3600');
-      expect(headers[ACAMethods]).to.eql('POST');
-      expect(headers[ACAHeaders]).to.eql('foo');
+      assertCorsHeaders(headers, {
+        [ACAOrigin]: 'https://example.com',
+        [ACAMaxAge]: '3600',
+        [ACAMethods]: 'POST',
+        [ACAHeaders]: 'foo',
+      });
     });
 
     it('device_authorization has cors closed', async function () {
@@ -436,9 +473,10 @@ describe('CORS setup', () => {
         ['send', { client_id: 'client' }],
       );
       expect(status).to.eql(400);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers).not.to.have.property(ACAOrigin);
+      assertCorsHeaders(headers, {
+        // no Access-Control-Allow-Origin
+        [ACEHeaders]: 'WWW-Authenticate',
+      });
     });
 
     it('device_authorization (error) has cors open', async function () {
@@ -451,19 +489,21 @@ describe('CORS setup', () => {
         ['type', 'form'],
       );
       expect(status).to.eql(400);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACEHeaders]).to.eql('WWW-Authenticate');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
+      assertCorsHeaders(headers, {
+        [ACEHeaders]: 'WWW-Authenticate',
+        [ACAOrigin]: 'https://example.com',
+      });
     });
 
     it('device_authorization preflights have cors open', async function () {
       const { status, headers } = await preflight.call(this, 'POST', '/device/auth', 'https://example.com');
       expect(status).to.eql(204);
-      expect(headers[Vary]).to.eql('Origin');
-      expect(headers[ACAOrigin]).to.eql('https://example.com');
-      expect(headers[ACAMaxAge]).to.eql('3600');
-      expect(headers[ACAMethods]).to.eql('POST');
-      expect(headers[ACAHeaders]).to.eql('foo');
+      assertCorsHeaders(headers, {
+        [ACAOrigin]: 'https://example.com',
+        [ACAMaxAge]: '3600',
+        [ACAMethods]: 'POST',
+        [ACAHeaders]: 'foo',
+      });
     });
   });
 });


### PR DESCRIPTION
Hello,

I would like to fix this CVE for 7.x versions : https://avd.aquasec.com/nvd/2022/cve-2022-25883/

I use this package on a Nest project and there is still no plan for Nest to add ESM-only packages support (https://github.com/nestjs/nest/pull/8736), so it's impossible for Nest project to migrate to v8.4.3 that fix this CVE

I check on this commit https://github.com/panva/node-oidc-provider/commit/9023e23c0c567ab712655595a7e4fb06c3907def to replicate changes

It's my first contribution on this package, so sorry if i did not respect standard, process or whatever.

Thanks a lot 🙏 