### PR TITLE
skip checking constructor for ttl functions

### DIFF
--- a/lib/helpers/configuration.js
+++ b/lib/helpers/configuration.js
@@ -351,9 +351,7 @@ class Configuration {
       let valid = false;
       switch (typeof value) {
         case 'function':
-          if (value.constructor.toString() === 'function Function() { [native code] }') {
-            valid = true;
-          }
+          valid = true;
           break;
         case 'number':
           if (Number.isSafeInteger(value) && value > 0) {


### PR DESCRIPTION
tried running w/bun instead of node and everything worked fine apart from this check.

bun returns an indented/formatted function which doesn't match the expected string. i.e
```javascript 
function Function() {
    [native code]
}
```
this makes this check fail. i'm not sure how much value there is in checking the stringified constructor anyway. would be better if we could actually check what the function returns,  but i'm not sure that is viable at startup, would prob need to happen when the function is actually invoked.

this pr just removes that check