### PR TITLE
allow to override discovery urls, to redirect auth endpoint to a fron…

### DIFF
--- a/lib/actions/discovery.js
+++ b/lib/actions/discovery.js
@@ -5,11 +5,11 @@ import instance from '../helpers/weak_cache.js';
 
 export default function discovery(ctx, next) {
   const config = instance(ctx.oidc.provider).configuration();
-  const { features } = config;
+  const { features, discovery: { urls: discoveryUrls } } = config;
 
   ctx.body = {
     acr_values_supported: config.acrValues.size ? [...config.acrValues] : undefined,
-    authorization_endpoint: ctx.oidc.urlFor('authorization'),
+    authorization_endpoint: discoveryUrls.auth || ctx.oidc.urlFor('authorization'),
     device_authorization_endpoint: features.deviceFlow.enabled
       ? ctx.oidc.urlFor('device_authorization')
       : undefined,

--- a/lib/helpers/defaults.js
+++ b/lib/helpers/defaults.js
@@ -796,6 +796,7 @@ function makeDefaults() {
       op_tos_uri: undefined,
       service_documentation: undefined,
       ui_locales_supported: undefined,
+      urls: {},
     },
 
     /*

--- a/lib/response_modes/fragment.js
+++ b/lib/response_modes/fragment.js
@@ -1,7 +1,15 @@
 import formatUri from '../helpers/redirect_uri.js';
 
 export default (ctx, redirectUri, payload) => {
+  const isXHR = ctx.get('x-requested-with') === 'XMLHttpRequest';
   const uri = formatUri(redirectUri, payload, 'fragment');
-  ctx.status = 303;
-  ctx.redirect(uri);
+
+  if(isXHR) {
+    ctx.status = 200;
+    ctx.body = { code: 303, uri };
+  }
+  else {
+    ctx.status = 303;
+    ctx.redirect(uri);
+  }
 };

--- a/lib/response_modes/query.js
+++ b/lib/response_modes/query.js
@@ -1,7 +1,15 @@
 import formatUri from '../helpers/redirect_uri.js';
 
 export default (ctx, redirectUri, payload) => {
+  const isXHR = ctx.get('x-requested-with') === 'XMLHttpRequest';
   const uri = formatUri(redirectUri, payload, 'query');
-  ctx.status = 303;
-  ctx.redirect(uri);
+
+  if(isXHR) {
+    ctx.status = 200;
+    ctx.body = { code: 303, uri };
+  }
+  else {
+    ctx.status = 303;
+    ctx.redirect(uri);
+  }
 };


### PR DESCRIPTION
This allows to override discovery urls, to redirect auth endpoint to a frontend. The reason for this is that we're laying an independent frontend on top, from there we're passing through the necessary params to the backend. For this to work, the well-known config must return a different path for the auth endpoint in specific.