### PR TITLE
fix: ensure each individual resource indicator is a valid URI

### DIFF
--- a/lib/shared/check_resource.js
+++ b/lib/shared/check_resource.js
@@ -55,7 +55,7 @@ export default async function checkResource(ctx, next) {
   for (const identifier of resource) {
     let href;
     try {
-      ({ href } = new URL(resource));
+      ({ href } = new URL(identifier));
     } catch (err) {
       throw new InvalidTarget('resource indicator must be an absolute URI');
     }

--- a/test/resource_indicators/client_credentials.test.js
+++ b/test/resource_indicators/client_credentials.test.js
@@ -98,6 +98,16 @@ describe('grant_type=client_credentials w/ resourceIndicators', () => {
       .expect(/only a single resource indicator value is supported/);
   });
 
+  it('validates each resource to be a valid URI individually', function () {
+    return this.agent.post(route)
+      .auth('client', 'secret')
+      .send('grant_type=client_credentials&scope=api:read&resource=urn:wl:opaque:default&resource=invalid')
+      .type('form')
+      .expect(400)
+      .expect(/invalid_target/)
+      .expect(/resource indicator must be an absolute URI/);
+  });
+
   it('checks the policy and adds the resource', async function () {
     const spy = sinon.spy();
     this.provider.once('client_credentials.saved', spy);


### PR DESCRIPTION
Fix a bug in `checkResource` util function.

When checking if the resource identifier is a valid URL, we should iterate the resource array with a for-loop, and check if each identifier in the `resource` array is valid, by utilizing the `new URL()` constructor.

However, the origin code seems to mistakenly pass the entire `resource` array into the URL constructor, resulting unexpected behavior.

Fixes: https://github.com/logto-io/logto/issues/5779