### PR TITLE
docs: fix `hapi` mounting

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -348,7 +348,7 @@ hapiApp.route({
     callback(req, res)
     await once(res, 'finish')
 
-    req.url = req.url.replace('/', '/oidc')
+    req.url = req.url.replace('/', '/oidc/')
     delete req.originalUrl
 
     return res.finished ? h.abandon : h.continue


### PR DESCRIPTION
Current behavior: `[/].well-known/openid-configuration` -> `[/oidc].well-known/openid-configuration`
