### PR TITLE
fix: allow specifying the user-agent header for outgoing requests

### DIFF
--- a/lib/helpers/request.js
+++ b/lib/helpers/request.js
@@ -19,6 +19,7 @@ export default async function request(options) {
     signal = AbortSignal.timeout(2500),
     agent = options.url.protocol === 'http:' ? http.globalAgent : https.globalAgent,
     dnsLookup = dns.lookup,
+    'user-agent': userAgent = undefined,
   } = instance(this).configuration('httpOptions')(new URL(options.url));
   const helperOptions = pickBy({ signal, agent, dnsLookup }, Boolean);
 
@@ -34,12 +35,12 @@ export default async function request(options) {
     throw new TypeError('"dnsLookup" http request option must be a function');
   }
 
-  if (helperOptions['user-agent'] !== undefined && typeof helperOptions['user-agent'] !== 'string') {
+  if (userAgent !== undefined && typeof userAgent !== 'string') {
     throw new TypeError('"user-agent" http request option must be a string');
   }
 
   // eslint-disable-next-line no-param-reassign
-  options.headers['user-agent'] = helperOptions['user-agent'];
+  options.headers['user-agent'] = userAgent;
 
   return got({
     ...options,

--- a/test/helpers/request/request.config.js
+++ b/test/helpers/request/request.config.js
@@ -4,9 +4,13 @@ import getConfig from '../../default.config.js';
 
 const config = getConfig();
 merge(config, {
-  httpOptions: (url) => {
-    return url.pathname === '/with-custom-user-agent' ? { 'user-agent': 'some user agent' } : {};
-  }
+  httpOptions(url) {
+    if (url.pathname === '/with-custom-user-agent') {
+      return { 'user-agent': 'some user agent' };
+    }
+
+    return {};
+  },
 });
 
 export default {

--- a/test/helpers/request/request.config.js
+++ b/test/helpers/request/request.config.js
@@ -1,0 +1,14 @@
+import merge from 'lodash/merge.js';
+
+import getConfig from '../../default.config.js';
+
+const config = getConfig();
+merge(config, {
+  httpOptions: (url) => {
+    return url.pathname === '/with-custom-user-agent' ? { 'user-agent': 'some user agent' } : {};
+  }
+});
+
+export default {
+  config,
+};

--- a/test/helpers/request/request.test.js
+++ b/test/helpers/request/request.test.js
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import nock from 'nock';
+
+import bootstrap from '../../test_helper.js';
+import request from '../../../lib/helpers/request.js';
+
+describe('request helper', () => {
+  before(bootstrap(import.meta.url));
+
+  afterEach(nock.cleanAll);
+
+  afterEach(() => {
+    expect(nock.isDone()).to.be.true;
+  });
+
+  describe('when using custom httpOptions', () => {
+    it('defaults to not sending the user-agent HTTP header', async function () {
+      nock('https://www.example.com/', {
+        badheaders: ['user-agent'],
+      })
+        .get('/')
+        .reply(200);
+
+      await request.call(this.provider, { url: 'https://www.example.com' });
+    });
+
+    it("uses a custom 'user-agent' HTTP header", async function () {
+      nock('https://www.example.com/', {
+        reqheaders: {
+          'user-agent': "some user agent",
+        },
+      })
+        .get('/with-custom-user-agent')
+        .reply(200);
+
+      await request.call(this.provider, { url: 'https://www.example.com/with-custom-user-agent' });
+    });
+  });
+});

--- a/test/helpers/request/request.test.js
+++ b/test/helpers/request/request.test.js
@@ -27,7 +27,7 @@ describe('request helper', () => {
     it("uses a custom 'user-agent' HTTP header", async function () {
       nock('https://www.example.com/', {
         reqheaders: {
-          'user-agent': "some user agent",
+          'user-agent': 'some user agent',
         },
       })
         .get('/with-custom-user-agent')


### PR DESCRIPTION
Specifying the `user-agent` header for outgoing requests was introduced in https://github.com/panva/node-oidc-provider/commit/95f24ef6365ae54375f7459cec19fb1c6b8ba291.

This PR is fixing an issue with that commit: the `user-agent` header value set in the `httpOptions` config is not really being used, and the http agent defaults to not sending the `user-agent` HTTP header.

```javascript
  const helperOptions = pickBy({ signal, agent, dnsLookup }, Boolean);
  // ...
  options.headers['user-agent'] = helperOptions['user-agent']; // at this point, helperOptions['user-agent'] is always undefined
```

In practice, due to the missing `user-agent`, WAFs could block requests to the `jwks_uri` endpoint during a client authentication.