### PR TITLE
Update err_out.js

### DIFF
--- a/lib/helpers/err_out.js
+++ b/lib/helpers/err_out.js
@@ -1,10 +1,11 @@
 export default ({
-  expose, message, error_description: description, scope,
+  expose, message, error_description: description, error_detail: detail, scope,
 }, state) => {
   if (expose) {
     return {
       error: message,
       ...(description !== undefined ? { error_description: description } : undefined),
+      ...(detail !== undefined ? { error_detail: detail } : undefined),
       ...(scope !== undefined ? { scope } : undefined),
       ...(state !== undefined ? { state } : undefined),
     };


### PR DESCRIPTION
Added error_detail property in error response, if the response type is json.

This property was not getting propagated to client in response.