### PR TITLE
Remove toString() function type check

### DIFF
--- a/lib/helpers/configuration.js
+++ b/lib/helpers/configuration.js
@@ -370,9 +370,7 @@ class Configuration {
       let valid = false;
       switch (typeof value) {
         case 'function':
-          if (value.constructor.toString() === 'function Function() { [native code] }') {
-            valid = true;
-          }
+          valid = true;
           break;
         case 'number':
           if (Number.isSafeInteger(value) && value > 0) {


### PR DESCRIPTION
In alternative runtimes Function#toString() doesn't equal `function Function() { [native code] }` exactly, which causes checkTTL() to fail

This can be seen using Bun 1.2.10 and oidc-provider@9.0.1